### PR TITLE
ci: upload PR test-build artifacts individually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,15 +104,32 @@ jobs:
         working-directory: android
 
       # ── PR test-build artifacts ────────────────────────────────────────────
-      - name: Upload test-build artifacts
+      # One upload-artifact step per file so each is listed and downloadable
+      # individually in the run's Artifacts section.
+      - name: Upload Chrome extension artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: test-build-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: |
-            chrome-extension.zip
-            firefox-extension.zip
-            android/app/build/outputs/apk/debug/app-debug.apk
+          name: chrome-extension-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: chrome-extension.zip
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Upload Firefox extension artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-extension-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: firefox-extension.zip
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Upload Android APK artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 30
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,9 @@ jobs:
 
       - name: Build Android debug APK
         if: github.event_name == 'pull_request'
-        run: ./gradlew assembleDebug
+        run: |
+          ./gradlew assembleDebug
+          cp app/build/outputs/apk/debug/app-debug.apk ../app-debug.apk
         working-directory: android
 
       # ── PR test-build artifacts ────────────────────────────────────────────
@@ -129,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: android-apk-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: android/app/build/outputs/apk/debug/app-debug.apk
+          path: app-debug.apk
           retention-days: 30
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary

Splits the single "Upload test-build artifacts" step in `release.yml` into three separate `upload-artifact` steps so each build output is listed and downloadable on its own in a run's Artifacts section.

`actions/upload-artifact@v4` produces one artifact per step — the previous single step listing three `path:` entries bundled them all into one `test-build-pr-<N>-<sha>` archive.

### Before
- `test-build-pr-<N>-<sha>` (one zip containing all three)

### After
- `chrome-extension-pr-<N>-<sha>`
- `firefox-extension-pr-<N>-<sha>`
- `android-apk-pr-<N>-<sha>`

Retention (30 days), the `pull_request` gate, and `if-no-files-found: error` are unchanged. The Chrome/Firefox `.zip` files are uploaded as-is (GitHub still wraps each artifact in its own zip on download).

## Test plan

- [ ] This PR's `Release` run shows three separate artifacts instead of one
- [ ] Each artifact downloads and contains the expected build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)