### PR TITLE
feat: beta version for PR test builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Check version consistency
         run: node tools/test-version-consistency.mjs
 
+      - name: Version tooling — unit tests
+        run: node --test tools/bump-version.test.mjs
+
       - name: Build extension (Chrome)
         run: npm run build -w extension
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,13 @@ jobs:
         id: bump
         if: github.event_name == 'workflow_dispatch'
         run: |
-          node tools/bump-version.mjs ${{ inputs.bump }}
+          node tools/bump-version.mjs bump ${{ inputs.bump }}
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Apply beta version (PR builds)
+        if: github.event_name == 'pull_request'
+        run: node tools/bump-version.mjs beta ${{ github.event.pull_request.number }}
 
       - name: Commit and tag version bump
         if: github.event_name == 'workflow_dispatch'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "tools/*"
   ],
   "scripts": {
-    "test": "node tools/validate-config.mjs && node tools/test-version-consistency.mjs && npm run test --workspaces --if-present",
+    "test": "node tools/validate-config.mjs && node tools/test-version-consistency.mjs && node --test tools/bump-version.test.mjs && npm run test --workspaces --if-present",
     "validate-config": "node tools/validate-config.mjs",
     "lint": "npm run lint --workspaces --if-present",
     "build": "npm run build --workspaces --if-present"

--- a/tools/bump-version.mjs
+++ b/tools/bump-version.mjs
@@ -1,14 +1,24 @@
 #!/usr/bin/env node
 // Called by the GitHub Actions release workflow.
-// Usage: node tools/bump-version.mjs <patch|minor|major|X.Y.Z>
+// Usage:
+//   node tools/bump-version.mjs bump <patch|minor|major|X.Y.Z>   (real release)
+//   node tools/bump-version.mjs beta <pr-number>                 (PR test build)
 
 import { readFileSync, writeFileSync, appendFileSync } from "fs";
 import { resolve, dirname } from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
 
+// ── Paths ───────────────────────────────────────────────────────────────────
+const ROOT_PKG = resolve(root, "package.json");
+const EXT_PKG = resolve(root, "extension/package.json");
+const MANIFEST = resolve(root, "extension/manifest.json");
+const ABOUT = resolve(root, "extension/src/options/screens/about.ts");
+const GRADLE = resolve(root, "android/app/build.gradle.kts");
+
+// ── JSON helpers ────────────────────────────────────────────────────────────
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
 }
@@ -17,63 +27,154 @@ function writeJson(path, obj) {
   writeFileSync(path, JSON.stringify(obj, null, 2) + "\n");
 }
 
-function bumpSemver(current, type) {
+// ── Pure version computation (exported for tests) ───────────────────────────
+export function bumpSemver(current, type) {
   const [major, minor, patch] = current.split(".").map(Number);
   if (type === "major") return `${major + 1}.0.0`;
   if (type === "minor") return `${major}.${minor + 1}.0`;
   if (type === "patch") return `${major}.${minor}.${patch + 1}`;
   if (/^\d+\.\d+\.\d+$/.test(type)) return type;
-  throw new Error(`Invalid bump type: ${type}. Use patch, minor, major, or X.Y.Z`);
+  throw new Error(
+    `Invalid bump type: ${type}. Use patch, minor, major, or X.Y.Z`,
+  );
 }
 
-const bumpType = process.argv[2];
-if (!bumpType) {
-  console.error("Usage: node tools/bump-version.mjs <patch|minor|major|X.Y.Z>");
-  process.exit(1);
+// The manifest version must stay numeric (Chrome MV3 only allows 1-4 dotted
+// integers), so the PR number rides in a 4th segment; the human-readable
+// display string keeps the literal "-beta-<pr>".
+export function betaVersions(base, pr) {
+  return {
+    displayVersion: `${base}-beta-${pr}`,
+    manifestVersion: `${base}.${pr}`,
+  };
 }
 
-const rootPkg = readJson(resolve(root, "package.json"));
-const currentVersion = rootPkg.version;
-const newVersion = bumpSemver(currentVersion, bumpType);
+// ── Argument parsing (exported for tests) ───────────────────────────────────
+const USAGE =
+  "Usage:\n" +
+  "  node tools/bump-version.mjs bump <patch|minor|major|X.Y.Z>\n" +
+  "  node tools/bump-version.mjs beta <pr-number>";
 
-console.log(`Bumping ${currentVersion} → ${newVersion}`);
+export function parseArgs(args) {
+  const [mode, value] = args;
+  if (mode === "bump") {
+    if (!value) throw new Error(USAGE);
+    return { mode: "bump", bumpType: value };
+  }
+  if (mode === "beta") {
+    if (!value || !/^\d+$/.test(value) || Number(value) < 1) {
+      throw new Error(USAGE);
+    }
+    return { mode: "beta", pr: Number(value) };
+  }
+  throw new Error(USAGE);
+}
 
-// 1. Root package.json
-rootPkg.version = newVersion;
-writeJson(resolve(root, "package.json"), rootPkg);
+// ── File writers ────────────────────────────────────────────────────────────
+function writeRootPackageJson(version) {
+  const pkg = readJson(ROOT_PKG);
+  pkg.version = version;
+  writeJson(ROOT_PKG, pkg);
+}
 
-// 2. extension/package.json
-const extPkg = readJson(resolve(root, "extension/package.json"));
-extPkg.version = newVersion;
-writeJson(resolve(root, "extension/package.json"), extPkg);
+function writeExtPackageJson(version) {
+  const pkg = readJson(EXT_PKG);
+  pkg.version = version;
+  writeJson(EXT_PKG, pkg);
+}
 
-// 3. extension/manifest.json
-const manifest = readJson(resolve(root, "extension/manifest.json"));
-manifest.version = newVersion;
-writeJson(resolve(root, "extension/manifest.json"), manifest);
+function writeManifest(version) {
+  const manifest = readJson(MANIFEST);
+  manifest.version = version;
+  writeJson(MANIFEST, manifest);
+}
 
-// 4. extension/src/options/screens/about.ts — replace the hardcoded version badge
-const aboutPath = resolve(root, "extension/src/options/screens/about.ts");
-const aboutContent = readFileSync(aboutPath, "utf-8");
-const updatedAbout = aboutContent.replace(/"v\d+\.\d+\.\d+"/, `"v${newVersion}"`);
-if (updatedAbout === aboutContent) throw new Error("Could not find version string in about.ts");
-writeFileSync(aboutPath, updatedAbout);
+function writeAbout(displayVersion) {
+  const content = readFileSync(ABOUT, "utf-8");
+  // Matches both the clean badge ("v2.0.0") and an already-beta'd badge
+  // ("v2.0.0-beta-19") so the rewrite is idempotent.
+  const updated = content.replace(
+    /"v\d+\.\d+\.\d+(?:-beta-\d+)?"/,
+    `"v${displayVersion}"`,
+  );
+  if (updated === content) {
+    throw new Error("Could not find version string in about.ts");
+  }
+  writeFileSync(ABOUT, updated);
+}
 
-// 5. android/app/build.gradle.kts — bump versionName and increment versionCode
-const gradlePath = resolve(root, "android/app/build.gradle.kts");
-let gradleContent = readFileSync(gradlePath, "utf-8");
+// versionCode is only rewritten when a value is passed (real releases);
+// PR builds omit it and leave versionCode untouched.
+function writeGradle(versionName, versionCode) {
+  let content = readFileSync(GRADLE, "utf-8");
+  content = content.replace(
+    /versionName\s*=\s*"[^"]*"/,
+    `versionName = "${versionName}"`,
+  );
+  if (versionCode !== undefined) {
+    content = content.replace(
+      /versionCode\s*=\s*\d+/,
+      `versionCode = ${versionCode}`,
+    );
+  }
+  writeFileSync(GRADLE, content);
+}
 
-const versionCodeMatch = gradleContent.match(/versionCode\s*=\s*(\d+)/);
-if (!versionCodeMatch) throw new Error("Could not find versionCode in build.gradle.kts");
-const newVersionCode = parseInt(versionCodeMatch[1], 10) + 1;
+// ── Modes ───────────────────────────────────────────────────────────────────
+function runBump(bumpType) {
+  const currentVersion = readJson(ROOT_PKG).version;
+  const newVersion = bumpSemver(currentVersion, bumpType);
+  console.log(`Bumping ${currentVersion} → ${newVersion}`);
 
-gradleContent = gradleContent
-  .replace(/versionCode\s*=\s*\d+/, `versionCode = ${newVersionCode}`)
-  .replace(/versionName\s*=\s*"[^"]*"/, `versionName = "${newVersion}"`);
-writeFileSync(gradlePath, gradleContent);
+  const gradleContent = readFileSync(GRADLE, "utf-8");
+  const versionCodeMatch = gradleContent.match(/versionCode\s*=\s*(\d+)/);
+  if (!versionCodeMatch) {
+    throw new Error("Could not find versionCode in build.gradle.kts");
+  }
+  const newVersionCode = parseInt(versionCodeMatch[1], 10) + 1;
 
-console.log(`Done. New version: ${newVersion}, Android versionCode: ${newVersionCode}`);
-const githubOutput = process.env.GITHUB_OUTPUT;
-if (githubOutput) {
-  appendFileSync(githubOutput, `version=${newVersion}\n`);
+  writeRootPackageJson(newVersion);
+  writeExtPackageJson(newVersion);
+  writeManifest(newVersion);
+  writeAbout(newVersion);
+  writeGradle(newVersion, newVersionCode);
+
+  console.log(
+    `Done. New version: ${newVersion}, Android versionCode: ${newVersionCode}`,
+  );
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (githubOutput) {
+    appendFileSync(githubOutput, `version=${newVersion}\n`);
+  }
+}
+
+function runBeta(pr) {
+  const base = readJson(ROOT_PKG).version;
+  const { displayVersion, manifestVersion } = betaVersions(base, pr);
+  console.log(
+    `Applying beta version: ${displayVersion} (manifest ${manifestVersion})`,
+  );
+
+  writeManifest(manifestVersion);
+  writeAbout(displayVersion);
+  writeGradle(displayVersion);
+
+  console.log("Done.");
+}
+
+function main() {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+  if (parsed.mode === "bump") runBump(parsed.bumpType);
+  else runBeta(parsed.pr);
+}
+
+// Only run the CLI when executed directly, not when imported by tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }

--- a/tools/bump-version.test.mjs
+++ b/tools/bump-version.test.mjs
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { bumpSemver, betaVersions, parseArgs } from "./bump-version.mjs";
+
+test("bumpSemver handles patch/minor/major", () => {
+  assert.equal(bumpSemver("2.0.0", "patch"), "2.0.1");
+  assert.equal(bumpSemver("2.0.0", "minor"), "2.1.0");
+  assert.equal(bumpSemver("2.0.0", "major"), "3.0.0");
+});
+
+test("bumpSemver accepts an explicit X.Y.Z", () => {
+  assert.equal(bumpSemver("2.0.0", "5.6.7"), "5.6.7");
+});
+
+test("bumpSemver rejects an invalid type", () => {
+  assert.throws(() => bumpSemver("2.0.0", "nonsense"), /Invalid bump type/);
+});
+
+test("betaVersions builds the display and manifest strings", () => {
+  assert.deepEqual(betaVersions("2.0.0", 19), {
+    displayVersion: "2.0.0-beta-19",
+    manifestVersion: "2.0.0.19",
+  });
+});
+
+test("parseArgs handles bump mode", () => {
+  assert.deepEqual(parseArgs(["bump", "patch"]), {
+    mode: "bump",
+    bumpType: "patch",
+  });
+});
+
+test("parseArgs handles beta mode", () => {
+  assert.deepEqual(parseArgs(["beta", "19"]), { mode: "beta", pr: 19 });
+});
+
+test("parseArgs rejects bump with no type", () => {
+  assert.throws(() => parseArgs(["bump"]), /Usage/);
+});
+
+test("parseArgs rejects beta with no pr number", () => {
+  assert.throws(() => parseArgs(["beta"]), /Usage/);
+});
+
+test("parseArgs rejects beta with a non-integer pr number", () => {
+  assert.throws(() => parseArgs(["beta", "abc"]), /Usage/);
+  assert.throws(() => parseArgs(["beta", "1.5"]), /Usage/);
+  assert.throws(() => parseArgs(["beta", "0"]), /Usage/);
+});
+
+test("parseArgs rejects an unknown or missing mode", () => {
+  assert.throws(() => parseArgs(["frobnicate"]), /Usage/);
+  assert.throws(() => parseArgs([]), /Usage/);
+});


### PR DESCRIPTION
## Summary

PR test builds now carry an in-app version of `<base>-beta-<pr-number>` (e.g. `2.0.0-beta-22`) instead of the same `2.0.0` as `main`, so an installed PR build is identifiable.

`tools/bump-version.mjs` becomes a subcommand CLI:
- `bump <patch|minor|major|X.Y.Z>` — real releases, **behavior unchanged**
- `beta <pr-number>` — new; rewrites the three in-app display files only

The `Release` workflow runs `beta` on the `pull_request` path before building.

### What `beta` writes

| File | PR-build value |
|---|---|
| `extension/manifest.json` `version` | `2.0.0.<pr>` (numeric — Chrome MV3 requires dotted integers) |
| `extension/src/options/screens/about.ts` badge | `v2.0.0-beta-<pr>` |
| `android/app/build.gradle.kts` `versionName` | `2.0.0-beta-<pr>` |

`package.json`, `extension/package.json`, and Android `versionCode` are untouched by `beta`. The rewrite happens only inside the ephemeral `Release` job — never committed — so `main` and the version-consistency check are unaffected.

## Changes

- `tools/bump-version.mjs` — refactored into an importable module: exported pure functions (`bumpSemver`, `betaVersions`, `parseArgs`), shared file-writing helpers, `bump`/`beta` dispatch, CLI execution guard
- `tools/bump-version.test.mjs` — new unit tests (10), wired into CI and the root `test` script
- `.github/workflows/release.yml` — `bump` subcommand on the existing call + new `beta` step
- `.github/workflows/ci.yml`, `package.json` — run the new test

Spec: `docs/superpowers/specs/2026-05-14-pr-beta-versioning-design.md`
Plan: `docs/superpowers/plans/2026-05-14-pr-beta-versioning.md`

## Test plan

- [ ] CI green (includes the new `bump-version` unit tests + unchanged version-consistency check)
- [ ] This PR's `Release` run: Chrome artifact `manifest.json` shows `2.0.0.<this-pr>`, options page badge shows `v2.0.0-beta-<this-pr>`, APK `versionName` is `2.0.0-beta-<this-pr>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)