### PR TITLE
fix(android): widget 4x1 sizing, preview chevrons, color picker padding

### DIFF
--- a/android/app/src/main/assets/default-config.json
+++ b/android/app/src/main/assets/default-config.json
@@ -181,6 +181,73 @@
               "searchUrl": "https://scholar.google.com/scholar?q={query}"
             }
           ]
+        },
+        {
+          "id": "annas-archive",
+          "triggers": [
+            "aa",
+            "annas"
+          ],
+          "name": "Anna's Archive",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=annas-archive.org&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://annas-archive.org",
+              "searchUrl": "https://annas-archive.org/search?q={query}"
+            }
+          ]
+        },
+        {
+          "id": "libgen",
+          "triggers": [
+            "libgen",
+            "lg"
+          ],
+          "name": "Library Genesis",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=libgen.li&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://libgen.li",
+              "searchUrl": "https://libgen.li/index.php?req={query}"
+            }
+          ]
+        },
+        {
+          "id": "scihub",
+          "triggers": [
+            "scihub",
+            "sci"
+          ],
+          "name": "Sci-Hub",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=sci-hub.ru&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://sci-hub.ru",
+              "searchUrl": "https://sci-hub.ru/{query}"
+            }
+          ]
+        },
+        {
+          "id": "arxiv",
+          "triggers": [
+            "arxiv"
+          ],
+          "name": "arXiv",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=arxiv.org&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://arxiv.org",
+              "searchUrl": "https://arxiv.org/search/?query={query}&searchtype=all"
+            }
+          ]
         }
       ]
     },
@@ -414,6 +481,71 @@
               "devices": "*",
               "defaultUrl": "https://archive.today",
               "searchUrl": "https://archive.today/submit/?url={query}"
+            }
+          ]
+        },
+        {
+          "id": "wayback",
+          "triggers": [
+            "wb",
+            "wayback"
+          ],
+          "name": "Wayback Machine",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=web.archive.org&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://web.archive.org",
+              "searchUrl": "https://web.archive.org/web/*/{query}"
+            }
+          ]
+        },
+        {
+          "id": "fmhy",
+          "triggers": [
+            "fmhy"
+          ],
+          "name": "FMHY",
+          "type": "redirect",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=fmhy.net&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://fmhy.net"
+            }
+          ]
+        },
+        {
+          "id": "1337x",
+          "triggers": [
+            "1337x",
+            "torrent"
+          ],
+          "name": "1337x",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=1337x.to&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://1337x.to",
+              "searchUrl": "https://1337x.to/search/{query}/1/"
+            }
+          ]
+        },
+        {
+          "id": "btdig",
+          "triggers": [
+            "btdig"
+          ],
+          "name": "BTDigg",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=btdig.com&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://btdig.com",
+              "searchUrl": "https://btdig.com/search?q={query}"
             }
           ]
         },
@@ -671,6 +803,56 @@
               "devices": "*",
               "defaultUrl": "https://genius.com",
               "searchUrl": "https://genius.com/search?q={query}"
+            }
+          ]
+        },
+        {
+          "id": "mangadex",
+          "triggers": [
+            "mdex",
+            "manga"
+          ],
+          "name": "MangaDex",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=mangadex.org&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://mangadex.org",
+              "searchUrl": "https://mangadex.org/titles?q={query}"
+            }
+          ]
+        },
+        {
+          "id": "nyaa",
+          "triggers": [
+            "nyaa"
+          ],
+          "name": "Nyaa",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=nyaa.si&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://nyaa.si",
+              "searchUrl": "https://nyaa.si/?q={query}"
+            }
+          ]
+        },
+        {
+          "id": "miruro",
+          "triggers": [
+            "miruro",
+            "anime"
+          ],
+          "name": "Miruro",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=miruro.com&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://www.miruro.com",
+              "searchUrl": "https://www.miruro.com/search?query={query}"
             }
           ]
         }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -2290,10 +2290,22 @@ fun GroupEditScreen(
                         GROUP_COLOR_PRESETS.forEach { hex ->
                             val parsed = parseGroupColor(hex) ?: return@forEach
                             val selected = colorField.equals(hex, ignoreCase = true)
+                            // Fixed 40dp slot with a constant 32dp swatch
+                            // centered in it. Selection draws a 2dp ring on the
+                            // slot edge — inside the 4dp gap around the swatch —
+                            // so the swatch footprint never changes between
+                            // states and rows don't shift on selection.
                             Box(
                                 modifier = Modifier
                                     .size(40.dp)
                                     .clip(RoundedCornerShape(20.dp))
+                                    .then(
+                                        if (selected) Modifier.border(
+                                            width = 2.dp,
+                                            color = MaterialTheme.colorScheme.onSurface,
+                                            shape = RoundedCornerShape(20.dp),
+                                        ) else Modifier
+                                    )
                                     .clickable {
                                         colorField = hex
                                         colorError = null
@@ -2302,16 +2314,9 @@ fun GroupEditScreen(
                             ) {
                                 Box(
                                     modifier = Modifier
-                                        .size(if (selected) 32.dp else 40.dp)
+                                        .size(32.dp)
                                         .clip(RoundedCornerShape(20.dp))
-                                        .background(parsed)
-                                        .then(
-                                            if (selected) Modifier.border(
-                                                width = 2.dp,
-                                                color = MaterialTheme.colorScheme.onSurface,
-                                                shape = RoundedCornerShape(20.dp),
-                                            ) else Modifier
-                                        ),
+                                        .background(parsed),
                                 )
                             }
                         }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/WidgetPreview.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/WidgetPreview.kt
@@ -61,9 +61,14 @@ fun WidgetPreview(
                 .padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            // Mirror the live widget's two-color chevron: back uses the
+            // surface-paired fg (widgetIconColor), front uses the variant's
+            // accent (widgetAccentColor). Passing searchBarContentColor for
+            // both flattened it to one color, so the preview disagreed with
+            // the real widget and the main-screen search bar.
             WidgetChevron(
-                backColor = appearance.searchBarContentColor,
-                accentColor = appearance.searchBarContentColor,
+                backColor = androidx.compose.ui.graphics.Color(appearance.widgetIconColor),
+                accentColor = androidx.compose.ui.graphics.Color(appearance.widgetAccentColor),
                 modifier = Modifier.size(28.dp),
             )
             Spacer(Modifier.width(8.dp))

--- a/android/app/src/main/res/drawable/ic_chevron_widget.xml
+++ b/android/app/src/main/res/drawable/ic_chevron_widget.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Fast Travel chevron mark for widget + brand surfaces.
-     Tinted at runtime via RemoteViews.setColorFilter so the accent picks up
-     the widget's resolved textColor. -->
+<!-- Fast Travel two-color chevron — brand colors (Night back + Denim accent).
+     Used only as the static widget-picker preview (previewLayout). The live
+     widget replaces this with a theme-tinted two-color bitmap rendered by
+     SearchWidgetProvider.renderChevronBitmap, so the picker preview must carry
+     the two colors itself to match. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#000000"
+        android:fillColor="#0E1020"
         android:pathData="M4.4,6.8 L4.4,9.2 L8.4,12 L4.4,14.8 L4.4,17.2 L11.6,12 Z" />
     <path
-        android:fillColor="#000000"
+        android:fillColor="#3E6098"
         android:pathData="M12.4,6.8 L12.4,9.2 L16.4,12 L12.4,14.8 L12.4,17.2 L19.6,12 Z" />
 </vector>

--- a/android/app/src/main/res/xml/search_widget_info.xml
+++ b/android/app/src/main/res/xml/search_widget_info.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialLayout="@layout/widget_search"
-    android:minWidth="250dp"
-    android:minHeight="48dp"
+    android:minWidth="360dp"
+    android:minHeight="40dp"
     android:minResizeWidth="180dp"
-    android:minResizeHeight="40dp"
+    android:minResizeHeight="20dp"
     android:maxResizeWidth="600dp"
     android:maxResizeHeight="72dp"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
## Summary

Three Android UI bug fixes (+ one bundled-config sync). All verified — widget on a physical Samsung device running Lawnchair, the other two on an emulator.

### 1 — Home-screen widget defaulted to 3×2 instead of 4×1
`search_widget_info.xml` declared `targetCellWidth/Height = 4/1`, but Launcher3-based launchers (Lawnchair, Pixel) only apply that override when `targetCellHeight >= minSpanY`, and `minSpanY` is derived from `minResizeHeight`. At `minResizeHeight=40dp` the launcher computed `minSpanY=2`, so the override never fired and the widget fell back to a 2-row `minHeight`-derived size. Samsung One UI ignores `targetCell*` entirely and sizes purely from `minWidth`/`minHeight`.

Fix: `minWidth` 250→360dp and `minResizeHeight` 40→20dp so the `targetCell` override applies. Result: reliable **4×1** on Lawnchair, Pixel, and Samsung One UI.

### 2 — Appearance preview & widget-picker preview showed a flat chevron
- `WidgetPreview.kt` passed `searchBarContentColor` for **both** halves of the two-color chevron → flat one-color preview. Now uses `widgetIconColor` + `widgetAccentColor`, matching the live widget.
- `ic_chevron_widget.xml` (the launcher's widget-picker preview) had both vector paths `#000000`. Now two-color brand (Night back, Denim accent).

### 3 — Group color picker swatches shifted on selection
The swatch `Box` changed size with selection state (40dp unselected, 32dp selected), shrinking the selected swatch and shifting spacing. Now a constant 32dp swatch in a 40dp slot with the selection ring drawn on the slot edge.

### chore — bundled Android config sync
Separate commit: the Gradle `syncSharedConfig` task copies `shared/config/default-config.json` into Android assets; the committed copy had drifted stale.

## Test plan

- [ ] CI green
- [ ] Widget adds at 4×1 on a fresh placement
- [ ] Appearance preview + widget-picker preview chevrons are two-color
- [ ] Group color swatches don't resize/shift on selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)