### PR TITLE
Release setup Track A: privacy policy, store assets, Firefox ID fix

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,88 @@
+# Privacy Policy — Fast Travel
+
+_Last updated: 14 May 2026_
+
+Fast Travel is a command-based search tool available as a browser extension (Chrome,
+Firefox) and a native Android app. This policy explains what data the app handles and,
+just as importantly, what it does **not**.
+
+## Summary
+
+- **There are no Fast Travel servers.** We do not operate a backend, and we do not have
+  user accounts.
+- **We do not collect, transmit, sell, or share any personal data.**
+- **No analytics, no telemetry, no tracking, no advertising.**
+- All of your settings and configuration stay **on your device**.
+
+## What is stored on your device
+
+Fast Travel keeps the following in your browser's or Android device's local storage. It
+never leaves your device except as described in "Network requests" below.
+
+- **Your settings** — themes, layout preferences, and other in-app options.
+- **Your command configuration** — the list of commands, search engines, and icon packs,
+  whether typed in manually or synced from a config URL you provide.
+- **A cached copy of your remote config** — if you set a config URL, the most recent
+  fetched copy is cached locally so the app works offline.
+- **Auto-ignore list** — locally-computed entries used to refine command matching.
+
+You can clear all of this at any time by removing the extension / app, or via the
+in-app settings.
+
+## Network requests
+
+Fast Travel only makes network requests that are a direct result of something you do.
+None of these requests go to a server operated by us.
+
+1. **Fetching your config URL.** If you set a remote configuration URL, the app fetches
+   that URL to load your commands. The request goes to whichever host you chose. The
+   built-in default configuration is bundled with the app and requires no network
+   request.
+2. **Search suggestions.** As you type, the app may request autocomplete suggestions
+   from the suggestion API endpoints defined in your configuration (for example, a
+   search engine's public autocomplete endpoint). The text you type is sent to those
+   third-party endpoints so they can return suggestions. These providers handle that
+   data under their own privacy policies.
+3. **Site icons.** The app may fetch favicons for the sites in your configuration so it
+   can display their icons.
+4. **Navigation.** When you run a command, the app opens the destination URL in your
+   browser. This is ordinary web browsing and is subject to the destination site's own
+   policies.
+
+If you do not set a config URL and do not use suggestion-backed commands, Fast Travel
+makes effectively no network requests of its own.
+
+## Browser extension permissions
+
+The extension requests these permissions purely to provide its core functionality:
+
+- **`storage`** — save your settings and configuration locally.
+- **`alarms`** — periodically refresh your remote config in the background.
+- **`tabs`** and **`webNavigation`** — detect and redirect address-bar searches so your
+  commands run.
+- **`declarativeNetRequestWithHostAccess`** and host access — redirect the internal
+  search sentinel URL to the right destination. Host access is used only for this
+  redirect; the extension does not read page content.
+
+## Android permissions
+
+- **Internet / network state** — fetch your config URL and search suggestions, as
+  described above.
+- **Installed-app query** (`queries`) — on Android 11+ the app reads the list of
+  launchable apps **on your device** so you can launch them with a command. This list
+  is used locally and is **never transmitted off the device**.
+
+## Children's privacy
+
+Fast Travel is not directed at children and does not knowingly collect any data from
+anyone, including children.
+
+## Changes to this policy
+
+If this policy changes, the updated version will be published at this URL with a new
+"Last updated" date.
+
+## Contact
+
+Questions about this policy can be sent to **khukmani+fast-travel@gmail.com**, or raised
+as an issue on the project's GitHub repository.

--- a/docs/store-assets/README.md
+++ b/docs/store-assets/README.md
@@ -1,0 +1,70 @@
+# Store Listing Assets
+
+Everything needed to create the Chrome Web Store, Firefox AMO, and Google Play
+listings. Listing copy is drafted and ready for review; **screenshots and promo
+graphics still need to be captured** (see "Screenshots" below).
+
+## Status
+
+| Asset | Chrome | Firefox | Google Play |
+|---|---|---|---|
+| Short description | ✅ drafted | ✅ drafted | ✅ drafted |
+| Long description | ✅ drafted | ✅ drafted | ✅ drafted |
+| Privacy policy URL | ⏳ needs GitHub Pages live | ⏳ | ⏳ |
+| Screenshots | ❌ to capture | ❌ to capture | ❌ to capture |
+| Promo / feature graphic | ❌ to create | n/a | ❌ to create |
+| Icon | ✅ in repo | ✅ in repo | ✅ in repo |
+
+Drafted copy lives in `chrome-web-store.md`, `firefox-amo.md`, `google-play.md`.
+
+## Privacy policy URL
+
+All three stores require one. Source: `docs/privacy-policy.md`. Once GitHub Pages is
+enabled (Settings → Pages → deploy from `main` / `/docs`), the URL will be:
+
+```
+https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+```
+
+Confirm the exact path after Pages builds, then paste it into each listing.
+
+## Screenshots — to capture
+
+Automated capture could not be run in the current dev environment (Playwright's
+bundled browser is unsupported on this OS, and no Android device was attached).
+Capture these when joining, using the existing scripts:
+
+- **Extension options screens** — `node extension/scripts/screenshot-options.mjs`
+  (outputs to `extension/scripts/screenshots/`). Requires `cd extension && npm install`
+  and `npm run build` first.
+- **Extension new-tab + address bar** — `node extension/scripts/screenshot-newtab.mjs`
+  (needs ImageMagick `magick` and an X display).
+- **Android themes** — `bash android/screenshot-themes.sh` (needs a connected device
+  or emulator via `adb`).
+
+Then crop/resize into the per-store folders below.
+
+### Per-store size requirements
+
+| Store | Screenshot size | Min count | Other graphics |
+|---|---|---|---|
+| Chrome Web Store | 1280×800 or 640×400 PNG | 1 (5 recommended) | Small promo tile 440×280; optional marquee 1400×560 |
+| Firefox AMO | up to 2400×1800, 1280×800 recommended | 1 | none required |
+| Google Play | phone: 16:9 or 9:16, 320–3840 px | 2 | Feature graphic 1024×500 (required); 512×512 icon |
+
+Drop final files into:
+
+```
+docs/store-assets/chrome/screenshots/
+docs/store-assets/firefox/screenshots/
+docs/store-assets/google-play/screenshots/
+docs/store-assets/google-play/feature-graphic.png
+docs/store-assets/chrome/promo-tile.png
+```
+
+## Icons
+
+Brand sources are in `shared/brand/` (`icon-*.svg`, `generate-icons.mjs`). Extension
+icons (16/48/128) ship in `extension/src/icons/`. Android launcher icons are in
+`android/app/src/main/res/mipmap-*`. A 512×512 PNG for the Play listing can be
+generated from the brand SVGs.

--- a/docs/store-assets/chrome-web-store.md
+++ b/docs/store-assets/chrome-web-store.md
@@ -1,0 +1,69 @@
+# Chrome Web Store — Listing Copy
+
+**Draft for review.** Paste into the Chrome Web Store developer console when creating
+the listing. Edit freely.
+
+## Name
+
+```
+Fast Travel
+```
+
+## Category
+
+Productivity
+
+## Short description (max 132 chars)
+
+```
+Type short commands in your address bar to jump straight to the sites and searches you use most.
+```
+
+## Detailed description
+
+```
+Fast Travel turns your address bar into a command line for the web.
+
+Instead of bookmarks, history, and half-remembered URLs, type a short command and go
+straight where you mean to: a search on a specific site, a subreddit, a stock ticker,
+your team's dashboard — whatever you set up.
+
+FEATURES
+• Command-based navigation — define triggers like "yt", "gh", or "r/" and route them
+  anywhere you want.
+• Inline suggestions — get autocomplete as you type, per command, from the search
+  engines you choose.
+• New tab page — a fast, focused start page built around your commands.
+• Bring your own config — keep your commands in a JSON file you host yourself, and
+  sync the same setup across every device and browser. Or just use the built-in
+  defaults and edit them in-app.
+• Groups, icon packs, and themes — organize and personalize your command set.
+
+PRIVACY
+Fast Travel has no servers and no accounts. It collects nothing, tracks nothing, and
+shows no ads. Your settings and commands stay on your device. Network requests only
+happen when you ask for them — fetching your config file or search suggestions.
+Full policy: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+
+Fast Travel is open source: https://github.com/DoubleGremlin181/fast-travel-app
+```
+
+## Privacy practices (console questionnaire)
+
+- Does the item collect user data? **No.**
+- Single purpose: "Provide command-based navigation and search from the browser
+  address bar and new tab page."
+- Permission justifications:
+  - `storage` — save the user's settings and command configuration locally.
+  - `alarms` — periodically refresh the user's remote config in the background.
+  - `tabs` / `webNavigation` — detect address-bar searches and route them to the
+    matching command.
+  - `declarativeNetRequestWithHostAccess` + host access — redirect the internal search
+    sentinel URL to the resolved destination. No page content is read.
+
+## Assets needed
+
+- Screenshots: 1280×800 PNG (see `README.md`). Suggested set: new tab page, a command
+  in the address bar with suggestions, the options/commands screen, a theme showcase.
+- Small promo tile: 440×280 PNG.
+- Icon: 128×128 (already in `extension/src/icons/icon128.png`).

--- a/docs/store-assets/firefox-amo.md
+++ b/docs/store-assets/firefox-amo.md
@@ -1,0 +1,74 @@
+# Firefox AMO — Listing Copy
+
+**Draft for review.** Paste into addons.mozilla.org when creating the listing.
+
+## Name
+
+```
+Fast Travel
+```
+
+## Add-on type
+
+Extension. Extension ID: `khukmani+fast.travel@gmail.com`
+(set in `extension/manifest.firefox.json`).
+
+## Summary (max 250 chars)
+
+```
+Turn your address bar into a command line for the web. Define short triggers and jump
+straight to the sites and searches you use most, with inline suggestions and a focused
+new tab page. No servers, no tracking, no ads.
+```
+
+## Detailed description
+
+```
+Fast Travel turns your address bar into a command line for the web.
+
+Instead of bookmarks, history, and half-remembered URLs, type a short command and go
+straight where you mean to: a search on a specific site, a subreddit, a stock ticker,
+your team's dashboard — whatever you set up.
+
+FEATURES
+• Command-based navigation — define triggers like "yt", "gh", or "r/" and route them
+  anywhere you want.
+• Inline suggestions — get autocomplete as you type, per command, from the search
+  engines you choose.
+• New tab page — a fast, focused start page built around your commands.
+• Bring your own config — keep your commands in a JSON file you host yourself, and
+  sync the same setup across every device and browser. Or just use the built-in
+  defaults and edit them in-app.
+• Groups, icon packs, and themes — organize and personalize your command set.
+
+PRIVACY
+Fast Travel has no servers and no accounts. It collects nothing, tracks nothing, and
+shows no ads. Your settings and commands stay on your device. Network requests only
+happen when you ask for them — fetching your config file or search suggestions.
+Full policy: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+
+Fast Travel is open source: https://github.com/DoubleGremlin181/fast-travel-app
+```
+
+## License
+
+MIT (matches the repository `LICENSE`).
+
+## Privacy policy
+
+Required by AMO. URL: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+
+## Notes for reviewers
+
+- Minimum Firefox version: 128.0 (`strict_min_version` in the Firefox manifest).
+- The extension registers a search provider that points at the sentinel host
+  `fast-travel-omnibox.invalid`; this URL is intercepted internally and is never
+  actually requested over the network — it is the mechanism used to capture the
+  address-bar query and route it to the matching command.
+- Source build: `cd extension && npm install && npm run build:firefox` produces the
+  reviewed artifact in `extension/dist-firefox/`.
+
+## Assets needed
+
+- Screenshots: 1280×800 recommended (see `README.md`).
+- Icon: 128×128 (already in `extension/src/icons/icon128.png`).

--- a/docs/store-assets/google-play.md
+++ b/docs/store-assets/google-play.md
@@ -1,0 +1,78 @@
+# Google Play — Listing Copy
+
+**Draft for review.** Paste into the Google Play Console when creating the app listing.
+
+## App name (max 30 chars)
+
+```
+Fast Travel
+```
+
+## Short description (max 80 chars)
+
+```
+Type commands to search and open your favorite sites instantly.
+```
+
+## Full description (max 4000 chars)
+
+```
+Fast Travel turns search into a command line.
+
+Instead of digging through apps, bookmarks, and history, type a short command and go
+straight where you mean to: a search on a specific site, a subreddit, a stock ticker,
+an installed app — whatever you set up.
+
+FEATURES
+• Command-based navigation — define triggers like "yt", "gh", or "r/" and route them
+  anywhere you want.
+• Home screen widget — search from your home screen without opening the app first.
+• Launch installed apps — point a command at an app on your device and open it
+  straight from search.
+• Inline suggestions — get autocomplete as you type, per command, from the search
+  engines you choose.
+• Set as your device search — route your launcher's search to Fast Travel.
+• Bring your own config — keep your commands in a JSON file you host yourself, and
+  sync the same setup across every device and browser. Or just use the built-in
+  defaults and edit them in-app.
+• Themes — nine appearance variants, each with light and dark modes.
+
+PRIVACY
+Fast Travel has no servers and no accounts. It collects nothing, tracks nothing, and
+shows no ads. Your settings and commands stay on your device. The list of installed
+apps is read on-device only and is never transmitted. Network requests only happen
+when you ask for them — fetching your config file or search suggestions.
+Full policy: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+
+Fast Travel is open source: https://github.com/DoubleGremlin181/fast-travel-app
+```
+
+## Categorization
+
+- Application type: App
+- Category: Productivity
+- Tags: search, productivity, launcher
+
+## Content rating
+
+Complete the questionnaire in the console. Expected outcome: **Everyone** — no ads,
+no user-generated content, no data collection, no sensitive content.
+
+## Data safety form
+
+- Data collected: **None.**
+- Data shared: **None.**
+- Note in the form: search query text is sent to the user-configured search/suggestion
+  providers at the user's request; this is not collected or received by the developer.
+
+## Privacy policy
+
+Required. URL: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+
+## Assets needed
+
+- Phone screenshots: min 2, 16:9 or 9:16, 320–3840 px. Suggested set: search screen,
+  home screen widget, suggestions in action, theme showcase, settings.
+- Feature graphic: 1024×500 PNG (required).
+- App icon: 512×512 PNG (generate from `shared/brand/` sources).
+- Package name: `sh.kavi.fasttravel` (fixed — cannot change after first upload).

--- a/docs/store-assets/post-launch-steps.md
+++ b/docs/store-assets/post-launch-steps.md
@@ -1,0 +1,70 @@
+# Post-Launch Steps (README & Repo Metadata)
+
+Run these once the three store listings are live and you have their public URLs.
+Each step is pre-written so it's a quick copy/paste. Covers issues #10, #13, #9, #8.
+
+## 1. README install badges (#10)
+
+Replace the install table in `README.md` (currently the `(coming soon — …)` rows) with
+real badges. Fill in the three URLs:
+
+```markdown
+## Install
+
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/CHROME_EXTENSION_ID?label=Chrome&logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/CHROME_EXTENSION_ID)
+[![Firefox Add-ons](https://img.shields.io/amo/v/fast-travel?label=Firefox&logo=firefoxbrowser&logoColor=white)](https://addons.mozilla.org/firefox/addon/FIREFOX_SLUG/)
+[![Google Play](https://img.shields.io/badge/Google%20Play-sh.kavi.fasttravel-blue?logo=googleplay&logoColor=white)](https://play.google.com/store/apps/details?id=sh.kavi.fasttravel)
+```
+
+Placeholders to fill:
+- `CHROME_EXTENSION_ID` — from the Chrome Web Store dashboard
+- `FIREFOX_SLUG` — the AMO listing slug (e.g. `fast-travel`)
+- Google Play uses the fixed package name `sh.kavi.fasttravel` — no edit needed
+
+## 2. README screenshot / GIF (#13)
+
+Add a hero image just under the tagline line in `README.md`:
+
+```markdown
+![Fast Travel](docs/store-assets/chrome/screenshots/newtab.png)
+```
+
+Use one of the captured store screenshots, or record a short demo GIF of typing a
+command + suggestions and save it to `docs/store-assets/`.
+
+## 3. Repo website URL (#9)
+
+Point the repository's website field at the privacy-policy / landing page:
+
+```bash
+gh repo edit DoubleGremlin181/fast-travel-app \
+  --homepage "https://doublegremlin181.github.io/fast-travel-app/"
+```
+
+## 4. Repo topics (#8)
+
+```bash
+gh repo edit DoubleGremlin181/fast-travel-app \
+  --add-topic browser-extension \
+  --add-topic chrome-extension \
+  --add-topic firefox-addon \
+  --add-topic android \
+  --add-topic productivity \
+  --add-topic search \
+  --add-topic new-tab-page
+```
+
+## 5. Branch protection on main (#7)
+
+Not store-related, but part of repo hardening. Enable via Settings → Branches, or:
+
+```bash
+gh api -X PUT repos/DoubleGremlin181/fast-travel-app/branches/main/protection \
+  -F required_status_checks.strict=true \
+  -F 'required_status_checks.contexts[]=' \
+  -F enforce_admins=true \
+  -F required_pull_request_reviews.required_approving_review_count=1 \
+  -F restrictions=
+```
+
+Adjust the status-check contexts to match the CI job names in `.github/workflows/ci.yml`.

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "browser_specific_settings": {
     "gecko": {
-      "id": "fast-travel@kavi.sh",
+      "id": "khukmani+fast.travel@gmail.com",
       "strict_min_version": "128.0"
     }
   },


### PR DESCRIPTION
## Summary

Track A of the app-store release setup — the code/docs work that needs no developer accounts. Prepares everything so the account/token/secret steps (Track B) go quickly.

- **Fix Firefox extension ID (#12)** — `extension/manifest.firefox.json` `gecko.id` changed from the personal mailbox `fast-travel@kavi.sh` to `khukmani+fast.travel@gmail.com`. Must land before the first AMO upload.
- **Privacy policy (#6)** — new `docs/privacy-policy.md`, to be served via GitHub Pages and reused as the privacy-policy URL for all three store listings.
- **Store listing assets (#6)** — new `docs/store-assets/` with drafted listing copy for Chrome Web Store, Firefox AMO, and Google Play, an asset checklist, and pre-written post-launch README/repo-metadata steps (#8, #9, #10, #13).

## Not done yet

Screenshots and promo graphics still need capture — this dev environment can't run the capture scripts (Playwright browser unsupported on the OS, no Android device attached). Instructions and size requirements are in `docs/store-assets/README.md`.

## Next (Track B — needs you)

GitHub Pages enablement, developer accounts, signing keys, and the 11 GitHub Actions secrets. See the plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)