### PR TITLE
docs: use canonical kavi.sh privacy-policy URL

### DIFF
--- a/docs/store-assets/README.md
+++ b/docs/store-assets/README.md
@@ -39,7 +39,7 @@ Android screenshots are captured from the `fast_travel_dev` AVD and cropped to 2
 ## Privacy policy
 
 All three stores require a privacy-policy URL. Source: `docs/privacy-policy.md`,
-served at `https://doublegremlin181.github.io/fast-travel-app/privacy-policy`.
+served at `https://kavi.sh/fast-travel-app/privacy-policy/`.
 
 ## Icons
 

--- a/docs/store-assets/chrome-web-store.md
+++ b/docs/store-assets/chrome-web-store.md
@@ -56,7 +56,7 @@ PRIVATE BY DESIGN
 Fast Travel has no servers and no accounts. It collects nothing, tracks nothing, and
 shows no ads. Your settings and commands stay on your device. Network requests only
 happen when you ask for them — fetching your config file or search suggestions.
-Full policy: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+Full policy: https://kavi.sh/fast-travel-app/privacy-policy/
 
 Open source: https://github.com/DoubleGremlin181/fast-travel-app
 ```

--- a/docs/store-assets/firefox-amo.md
+++ b/docs/store-assets/firefox-amo.md
@@ -57,7 +57,7 @@ PRIVATE BY DESIGN
 Fast Travel has no servers and no accounts. It collects nothing, tracks nothing, and
 shows no ads. Your settings and commands stay on your device. Network requests only
 happen when you ask for them — fetching your config file or search suggestions.
-Full policy: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+Full policy: https://kavi.sh/fast-travel-app/privacy-policy/
 
 Open source: https://github.com/DoubleGremlin181/fast-travel-app
 ```
@@ -68,7 +68,7 @@ MIT (matches the repository `LICENSE`).
 
 ## Privacy policy
 
-URL: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+URL: https://kavi.sh/fast-travel-app/privacy-policy/
 
 ## Notes for reviewers
 

--- a/docs/store-assets/google-play.md
+++ b/docs/store-assets/google-play.md
@@ -55,7 +55,7 @@ Fast Travel has no servers and no accounts. It collects nothing, tracks nothing,
 shows no ads. Your settings and commands stay on your device. The list of installed
 apps is read on-device only and is never transmitted. Network requests only happen
 when you ask for them — fetching your config file or search suggestions.
-Full policy: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+Full policy: https://kavi.sh/fast-travel-app/privacy-policy/
 
 Open source: https://github.com/DoubleGremlin181/fast-travel-app
 ```
@@ -80,7 +80,7 @@ no user-generated content, no data collection, no sensitive content.
 
 ## Privacy policy
 
-URL: https://doublegremlin181.github.io/fast-travel-app/privacy-policy
+URL: https://kavi.sh/fast-travel-app/privacy-policy/
 
 ## Assets
 


### PR DESCRIPTION
Pages serves via the kavi.sh custom domain (the github.io URL 301-redirects there). Updates the store listing copy to the canonical `https://kavi.sh/fast-travel-app/privacy-policy/` (direct 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)