### PR TITLE
fix(extension): align manifest description with store short summary

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Fast Travel",
   "version": "2.0.0",
   "default_locale": "en",
-  "description": "Command-based search engine replacement. Type commands to navigate the web faster.",
+  "description": "Turn your search bar into a command line for the web. Define short triggers and jump straight to the sites and searches you use.",
   "permissions": [
     "storage",
     "alarms",


### PR DESCRIPTION
Chrome Web Store auto-populates the extension summary from `manifest.description`, which was out of sync with the listing copy. Updates it to the canonical short summary (128 chars, within the 132 limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)