### PR TITLE
test(e2e): fix nav-test flakiness (race-free waitForRequest)

### DIFF
--- a/extension/tests/e2e/config-editing.spec.ts
+++ b/extension/tests/e2e/config-editing.spec.ts
@@ -45,6 +45,8 @@ test("config: editing default command sets dirty flag", async ({ context, extens
   await page.goto(`chrome-extension://${extensionId}/options/options.html#/configuration`);
 
   const select = page.locator('select#default-cmd');
+  // Wait for the async config load to populate the dropdown before asserting.
+  await expect.poll(() => select.locator("option").count()).toBeGreaterThan(1);
   const options = await select.locator("option").allTextContents();
   expect(options.length).toBeGreaterThan(1);
 

--- a/extension/tests/e2e/newtab.spec.ts
+++ b/extension/tests/e2e/newtab.spec.ts
@@ -9,23 +9,19 @@ test("newtab loads with search input focused", async ({ context, extensionId }) 
   await expect(input).toBeFocused();
 });
 
-// Capture the resolved navigation URL by intercepting the main-frame navigation
-// request and aborting it — so the test asserts on the destination without
-// actually loading the external site (no network dependence, deterministic).
-async function captureFirstNav(page: import("@playwright/test").Page, pattern: RegExp) {
-  return new Promise<string>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("no matching nav")), 10000);
-    void page.route("**/*", async (route) => {
-      const req = route.request();
-      if (req.isNavigationRequest() && req.frame() === page.mainFrame() && pattern.test(req.url())) {
-        clearTimeout(timer);
-        resolve(req.url());
-        await route.abort();
-        return;
-      }
-      await route.continue();
-    });
-  });
+// Press Enter and return the resolved main-frame navigation URL.
+// waitForRequest attaches its listener synchronously and resolves the moment the
+// navigation request is issued — so this is race-free (no async route-registration
+// gap) and doesn't depend on the external site actually loading.
+async function pressEnterAndGetNavUrl(page: import("@playwright/test").Page, pattern: RegExp) {
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (r) => r.isNavigationRequest() && r.frame() === page.mainFrame() && pattern.test(r.url()),
+      { timeout: 10000 },
+    ),
+    page.keyboard.press("Enter"),
+  ]);
+  return request.url();
 }
 
 test("typing a command with query navigates to the command's search URL", async ({
@@ -36,9 +32,7 @@ test("typing a command with query navigates to the command's search URL", async 
   await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
   await page.locator("#search-input").fill("g playwright extension testing");
 
-  const nav = captureFirstNav(page, /google\.com\/search\?q=/);
-  await page.keyboard.press("Enter");
-  const matchedUrl = await nav;
+  const matchedUrl = await pressEnterAndGetNavUrl(page, /google\.com\/search\?q=/);
   const q = new URL(matchedUrl).searchParams.get("q");
   expect(q).toBe("playwright extension testing");
 });
@@ -47,9 +41,7 @@ test("bare query uses the default command (google)", async ({ context, extension
   const page = await context.newPage();
   await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
   await page.locator("#search-input").fill("hello world");
-  const nav = captureFirstNav(page, /google\.com\/search\?q=/);
-  await page.keyboard.press("Enter");
-  const matchedUrl = await nav;
+  const matchedUrl = await pressEnterAndGetNavUrl(page, /google\.com\/search\?q=/);
   expect(new URL(matchedUrl).searchParams.get("q")).toBe("hello world");
 });
 
@@ -57,9 +49,7 @@ test("gh command routes to GitHub search", async ({ context, extensionId }) => {
   const page = await context.newPage();
   await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
   await page.locator("#search-input").fill("gh facebook/react");
-  const nav = captureFirstNav(page, /github\.com/);
-  await page.keyboard.press("Enter");
-  const matchedUrl = await nav;
+  const matchedUrl = await pressEnterAndGetNavUrl(page, /github\.com/);
   expect(matchedUrl).toMatch(/github\.com/);
 });
 

--- a/extension/tests/e2e/xss-javascript-url.spec.ts
+++ b/extension/tests/e2e/xss-javascript-url.spec.ts
@@ -189,18 +189,16 @@ test("newtab handleSearch: https: URLs still navigate (guards do not over-block)
   const input = page.locator("#search-input");
   await input.fill("g playwright testing");
 
-  const navPromise = new Promise<string>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("no navigation")), 8000);
-    page.on("framenavigated", (f) => {
-      if (f === page.mainFrame() && /google\.com/.test(f.url())) {
-        clearTimeout(timer);
-        resolve(f.url());
-      }
-    });
-  });
-
-  await page.keyboard.press("Enter");
-  const url = await navPromise;
+  // Race-free + network-independent: waitForRequest resolves when the navigation
+  // request is issued, without waiting for the external site to load.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (r) => r.isNavigationRequest() && r.frame() === page.mainFrame() && /google\.com/.test(r.url()),
+      { timeout: 10000 },
+    ),
+    page.keyboard.press("Enter"),
+  ]);
+  const url = request.url();
   // The URL may use + or %20 for spaces depending on encodeURIComponent vs URLSearchParams
   expect(url).toMatch(/google\.com\/search\?q=playwright/);
 });


### PR DESCRIPTION
Fixes the recurring e2e flakiness (the failing merge-run on main).

## Root cause
The previous route-interception hardening had a real bug: `page.route()` is async and wasn't awaited, so on a slow runner the Enter keypress could trigger navigation **before** the intercept registered → `no matching nav`. A slow runner this time also exposed two more timing-sensitive tests.

## Fix
- **newtab.spec.ts** (3 nav tests) + **xss-javascript-url.spec.ts:181**: capture the nav with `Promise.all([page.waitForRequest(...), page.keyboard.press('Enter')])`. `waitForRequest` attaches its listener synchronously and resolves the moment the navigation request is issued — **race-free and network-independent** (no waiting for the external site to load).
- **config-editing.spec.ts:43**: `await expect.poll(() => select.locator('option').count()).toBeGreaterThan(1)` so the async config load populates the dropdown before asserting.

## Verification
- Affected specs: pass 3× locally.
- Full e2e suite: **38/38**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)