### PR TITLE
test(e2e): fix nav-test flake via [data-ft-ready] config-load gate

### DIFF
--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -188,6 +188,7 @@ async function init(): Promise<void> {
         updateLeadingIcon(trimmed);
         if (config) renderQuickChips();
         showTypoSuggestion(result);
+        markReady();
         return;
       }
     }
@@ -196,6 +197,14 @@ async function init(): Promise<void> {
 
   if (config) renderQuickChips();
   void setupOnboardingHint();
+  markReady();
+}
+
+// Signal that init() has finished loading config and the page is interactive.
+// Pressing Enter before this resolves makes handleSearch() a no-op (config is
+// null), so e2e tests must wait for [data-ft-ready] before submitting a query.
+function markReady(): void {
+  document.documentElement.dataset.ftReady = "1";
 }
 
 function focusSearchInput(): void {

--- a/extension/tests/e2e/newtab.spec.ts
+++ b/extension/tests/e2e/newtab.spec.ts
@@ -13,7 +13,12 @@ test("newtab loads with search input focused", async ({ context, extensionId }) 
 // waitForRequest attaches its listener synchronously and resolves the moment the
 // navigation request is issued — so this is race-free (no async route-registration
 // gap) and doesn't depend on the external site actually loading.
+//
+// Gating on [data-ft-ready] first is essential: handleSearch() silently no-ops
+// until init() has loaded config (an async getConfig round-trip to the service
+// worker), so pressing Enter too early issues no navigation and times out.
 async function pressEnterAndGetNavUrl(page: import("@playwright/test").Page, pattern: RegExp) {
+  await page.locator("html[data-ft-ready]").waitFor();
   const [request] = await Promise.all([
     page.waitForRequest(
       (r) => r.isNavigationRequest() && r.frame() === page.mainFrame() && pattern.test(r.url()),

--- a/extension/tests/e2e/xss-javascript-url.spec.ts
+++ b/extension/tests/e2e/xss-javascript-url.spec.ts
@@ -114,6 +114,10 @@ test("newtab handleSearch: scheme guard blocks javascript: URL navigation", asyn
   // Reload the newtab so it picks up the malicious config from storage.
   await page.reload();
 
+  // Wait for init() to load the (malicious) config — otherwise handleSearch()
+  // no-ops and this guard test would pass vacuously without exercising the guard.
+  await page.locator("html[data-ft-ready]").waitFor();
+
   // Type the trigger for the malicious command and submit.
   const input = page.locator("#search-input");
   await input.fill("xss");
@@ -188,6 +192,9 @@ test("newtab handleSearch: https: URLs still navigate (guards do not over-block)
   // Use the bundled default config (Google search), no storage injection needed.
   const input = page.locator("#search-input");
   await input.fill("g playwright testing");
+
+  // Wait for init() to finish loading config — handleSearch() no-ops until then.
+  await page.locator("html[data-ft-ready]").waitFor();
 
   // Race-free + network-independent: waitForRequest resolves when the navigation
   // request is issued, without waiting for the external site to load.


### PR DESCRIPTION
## Problem

The newtab navigation e2e tests keep flaking on CI, failing a **different test each run** with `page.waitForRequest: Timeout 10000ms exceeded`. PR #39's "race-free waitForRequest" hardened the *capture* mechanism but the flake persisted — most tellingly, the docs-only PR #40 merge to `main` failed on `newtab.spec.ts › bare query uses the default command`.

## Root cause

The race is upstream of the capture mechanism. `handleSearch()` silently no-ops while `config` is `null` (`newtab.ts:279`), and `config` is only populated via an async `getConfig` round-trip to the MV3 service worker inside `init()` (`newtab.ts:158`). The tests `fill()` the static input and press Enter immediately — gated only on the input being editable, not on config being loaded. When a cold/slow service worker on a loaded CI runner lost that race, **pressing Enter issued no navigation at all**, so the (now reliable) `waitForRequest` waited the full 10s and timed out.

This is the same "acted before async config load" family that PR #39 fixed for `config-editing.spec.ts` — just never applied to the nav tests.

## Fix

- **`newtab.ts`**: set `document.documentElement.dataset.ftReady` once `init()` has loaded config (and on the typo early-return) — a readiness signal for tests.
- **`newtab.spec.ts`**: gate the shared `pressEnterAndGetNavUrl` helper on `html[data-ft-ready]` before pressing Enter.
- **`xss-javascript-url.spec.ts`**: gate the "https still navigates" nav test, and the negative `handleSearch` guard test (which previously could pass *vacuously* if config hadn't loaded — now it genuinely exercises the guard).

Deterministic — no timeouts, no dependence on service-worker warmth.

## Verification

- Affected specs: **33/33** over 3 repeats (`--repeat-each=3`); nav tests now resolve in ~620ms instead of timing out
- Full e2e suite: **38/38**
- Unit tests: **197/197**

🤖 Generated with [Claude Code](https://claude.com/claude-code)