### PR TITLE
ci(release): use a maintainer PAT so the version bump can push to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,14 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A real release pushes the version-bump commit to the protected `main`
+          # branch. The default GITHUB_TOKEN runs as github-actions[bot] — a
+          # non-admin that cannot bypass branch protection, so that push is
+          # rejected ("protected branch hook declined"). Use a maintainer PAT
+          # (RELEASE_PAT) instead; since `enforce_admins` is off, an owner PAT
+          # bypasses the required status checks. Falls back to GITHUB_TOKEN for
+          # PR builds, which never push.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
## Why

The first real release run (`workflow_dispatch`) failed at **Commit and tag version bump**:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 4 of 4 required status checks are expected.
! [remote rejected] main -> main (protected branch hook declined)
```

The workflow bumps the version and pushes the commit + tag to `main`, but the default `GITHUB_TOKEN` runs as `github-actions[bot]` — a non-admin that can't bypass branch protection. So the auto-release has never completed.

## Fix

Check out (and therefore push) with a maintainer **`RELEASE_PAT`** secret instead. `main`'s protection has `enforce_admins: false`, so an owner-owned PAT bypasses the required status checks. Falls back to `GITHUB_TOKEN` for PR builds, which never push:

```yaml
token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
```

## Required before the next release

Create the `RELEASE_PAT` secret (steps in the PR thread). Until it's set, the fallback keeps PR builds working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019sZCK4Qo58tk3jvW9c9dHh