### PR TITLE
ci(release): fix Chrome publish (env vars), tag push, and Play track→internal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,9 @@ jobs:
           git add package.json extension/package.json extension/manifest.json \
             extension/src/options/screens/about.ts android/app/build.gradle.kts
           git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
-          git tag "v${{ steps.bump.outputs.version }}"
+          # Annotated tag so `git push --follow-tags` actually pushes it
+          # (--follow-tags ignores lightweight tags).
+          git tag -a "v${{ steps.bump.outputs.version }}" -m "v${{ steps.bump.outputs.version }}"
           git push --follow-tags
 
       # ── Extension build ────────────────────────────────────────────────────
@@ -149,14 +151,14 @@ jobs:
       # ── Publish (workflow_dispatch only) ───────────────────────────────────
       - name: Publish to Chrome Web Store
         if: github.event_name == 'workflow_dispatch'
-        run: |
-          npx chrome-webstore-upload-cli upload \
-            --source chrome-extension.zip \
-            --extension-id ${{ secrets.CHROME_EXTENSION_ID }} \
-            --client-id ${{ secrets.CHROME_CLIENT_ID }} \
-            --client-secret ${{ secrets.CHROME_CLIENT_SECRET }} \
-            --refresh-token ${{ secrets.CHROME_REFRESH_TOKEN }} \
-            --auto-publish
+        # chrome-webstore-upload-cli v4 dropped the --client-id/--client-secret/
+        # --refresh-token/--extension-id flags in favour of env vars.
+        env:
+          EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: npx chrome-webstore-upload-cli@4 upload --source chrome-extension.zip --auto-publish
 
       - name: Publish to Firefox AMO
         if: github.event_name == 'workflow_dispatch'

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -124,7 +124,9 @@ play {
     serviceAccountCredentials.set(
         file(System.getenv("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON") ?: "play-credentials.json")
     )
-    track.set("production")
+    // New Play accounts must complete closed testing (>=12 testers, 14 days)
+    // before they can publish to `production`; use `internal` until eligible.
+    track.set("internal")
     defaultToAppBundles.set(true)
 }
 


### PR DESCRIPTION
Follow-up to #46. The release now gets past the protected-branch push (PAT) but the publish steps were stale/misconfigured and had never run. Fixes:

- **Chrome Web Store** — `chrome-webstore-upload-cli` v4 dropped the credential flags; use `EXTENSION_ID/CLIENT_ID/CLIENT_SECRET/REFRESH_TOKEN` env vars and pin to `@4`.
- **Tag push** — `git tag` made a *lightweight* tag, which `git push --follow-tags` skips, so `v<version>` was never pushed. Use an annotated tag.
- **Google Play** — flip the track `production → internal` (new account can't publish to production until closed testing completes).

After merge, a re-run should complete: Chrome + Firefox publish, Play → internal testing, tag pushed, GitHub Release created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019sZCK4Qo58tk3jvW9c9dHh