### PR TITLE
ci(release): pin chrome-webstore-upload-cli to v3 (v4 requires publisherId)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,14 +151,16 @@ jobs:
       # ── Publish (workflow_dispatch only) ───────────────────────────────────
       - name: Publish to Chrome Web Store
         if: github.event_name == 'workflow_dispatch'
-        # chrome-webstore-upload-cli v4 dropped the --client-id/--client-secret/
-        # --refresh-token/--extension-id flags in favour of env vars.
+        # Pin to chrome-webstore-upload-cli v3: v4's underlying lib also requires
+        # a `publisherId` we don't have. v3 needs only extension id + OAuth creds,
+        # read from these env vars (EXTENSION_ID/CLIENT_ID/CLIENT_SECRET/
+        # REFRESH_TOKEN).
         env:
           EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
-        run: npx chrome-webstore-upload-cli@4 upload --source chrome-extension.zip --auto-publish
+        run: npx chrome-webstore-upload-cli@3 upload --source chrome-extension.zip --auto-publish
 
       - name: Publish to Firefox AMO
         if: github.event_name == 'workflow_dispatch'

--- a/extension/tests/e2e/issue43-startup-window-close.spec.ts
+++ b/extension/tests/e2e/issue43-startup-window-close.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from "./fixtures";
 test("a new window whose only tab is the New Tab Page is NOT torn down", async ({
   context,
 }) => {
-  const sw = context.serviceWorkers()[0];
+  const sw = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
 
   const winId: number = await sw.evaluate(async () => {
     const win = await chrome.windows.create({ url: "chrome://newtab/" });
@@ -42,7 +42,7 @@ test("a new window whose only tab is the New Tab Page is NOT torn down", async (
 test("Ctrl+T (new tab in a window that already has tabs) still routes through the extension New Tab page", async ({
   context,
 }) => {
-  const sw = context.serviceWorkers()[0];
+  const sw = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
 
   const result = await sw.evaluate(async () => {
     const [win] = await chrome.windows.getAll({ populate: true });

--- a/extension/tests/e2e/issue44-omnibox-redirect.spec.ts
+++ b/extension/tests/e2e/issue44-omnibox-redirect.spec.ts
@@ -21,7 +21,7 @@ test("Chrome removes any stale declarativeNetRequest redirect rule (it would blo
 }) => {
   const sw = context.serviceWorkers()[0];
 
-  const result = await sw.evaluate(async () => {
+  const installed = await sw.evaluate(async () => {
     // Simulate the rule an older build left in the profile.
     await chrome.declarativeNetRequest.updateDynamicRules({
       removeRuleIds: [1],
@@ -40,7 +40,7 @@ test("Chrome removes any stale declarativeNetRequest redirect rule (it would blo
         },
       ],
     });
-    const installed = (await chrome.declarativeNetRequest.getDynamicRules()).length;
+    const n = (await chrome.declarativeNetRequest.getDynamicRules()).length;
 
     // Re-run the worker's startup/update paths; on Chrome they remove the rule.
     (chrome.runtime.onStartup as chrome.events.Event<() => void>).dispatch();
@@ -49,13 +49,18 @@ test("Chrome removes any stale declarativeNetRequest redirect rule (it would blo
         (d: chrome.runtime.InstalledDetails) => void
       >
     ).dispatch({ reason: "update" } as chrome.runtime.InstalledDetails);
-
-    await new Promise((r) => setTimeout(r, 1500));
-    return { installed, remaining: (await chrome.declarativeNetRequest.getDynamicRules()).length };
+    return n;
   });
 
-  expect(result.installed).toBe(1);
-  expect(result.remaining).toBe(0);
+  expect(installed).toBe(1);
+  // The removal is async; poll from the test side so a slow CI worker can't flake
+  // on a fixed wait.
+  await expect
+    .poll(
+      async () => (await sw.evaluate(() => chrome.declarativeNetRequest.getDynamicRules())).length,
+      { timeout: 10000 },
+    )
+    .toBe(0);
 });
 
 test("Chrome routes the sentinel via a webNavigation handler (not a blocked DNR redirect)", async ({

--- a/extension/tests/e2e/issue44-omnibox-redirect.spec.ts
+++ b/extension/tests/e2e/issue44-omnibox-redirect.spec.ts
@@ -19,7 +19,7 @@ import { test, expect } from "./fixtures";
 test("Chrome removes any stale declarativeNetRequest redirect rule (it would block the search)", async ({
   context,
 }) => {
-  const sw = context.serviceWorkers()[0];
+  const sw = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
 
   const installed = await sw.evaluate(async () => {
     // Simulate the rule an older build left in the profile.
@@ -66,7 +66,7 @@ test("Chrome removes any stale declarativeNetRequest redirect rule (it would blo
 test("Chrome routes the sentinel via a webNavigation handler (not a blocked DNR redirect)", async ({
   context,
 }) => {
-  const sw = context.serviceWorkers()[0];
+  const sw = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
   // The fix replaces the Chrome-blocked DNR redirect with a webNavigation +
   // tabs.update interception of the sentinel host. Assert the listener is wired
   // up. (Driving the full .invalid → tabs.update → result chain end-to-end is a


### PR DESCRIPTION
Follow-up to #47. The Chrome publish step now authenticates, but `chrome-webstore-upload-cli@4`'s underlying lib requires a `publisherId` we don't have → `Error: Option "publisherId" is required`. Verified locally: **v3.5.0** needs only the extension id + OAuth creds (via `EXTENSION_ID/CLIENT_ID/CLIENT_SECRET/REFRESH_TOKEN`), so pin to `@3`.

(Firefox AMO's `web-ext sign --api-key/--api-secret/--channel` flags were verified still-valid in current web-ext, so no change there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019sZCK4Qo58tk3jvW9c9dHh