### PR TITLE
fix(auto-update-domains): open a PR instead of pushing to protected main; harden sources

### DIFF
--- a/.github/workflows/auto-update-domains.yml
+++ b/.github/workflows/auto-update-domains.yml
@@ -3,11 +3,19 @@ name: Auto-update domains
 # Weekly health check on the default-config domains. For each unreachable
 # domain whose command-id is listed in tools/auto-update-domains/auto-update.json,
 # the script picks a replacement via the configured source (Wikipedia or FMHY),
-# verifies the candidate is itself reachable, and commits the patched config
-# straight to main. Three safety gates run before push:
+# verifies the candidate is itself reachable, and opens a pull request with the
+# patched config (auto-merged once CI passes). `main` has branch protection with
+# required status checks, so the bot cannot push to it directly — it must go
+# through a PR. Three safety gates run before the PR is opened:
 #   1. Resolver unit tests must pass.
 #   2. The orchestrator only writes candidates that pass a HEAD check.
 #   3. The patched config and auto-update mapping must validate.
+#
+# NOTE: For the required CI checks to actually run on the bot's PR (and thus for
+# auto-merge to complete), set an `AUTOMATION_PAT` repo secret — a fine-grained
+# PAT with contents+pull-requests write. PRs opened with the default GITHUB_TOKEN
+# do NOT trigger other workflows, so without the PAT the PR is opened but its
+# required checks never run and it must be merged by hand.
 
 on:
   schedule:
@@ -16,6 +24,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   check-domains:
@@ -24,6 +33,10 @@ jobs:
       - name: Checkout repository
         # actions/checkout@v4
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Use the PAT (if set) so the branch push is attributed to it and the
+          # PR triggers CI; falls back to the default token otherwise.
+          token: ${{ secrets.AUTOMATION_PAT || github.token }}
 
       - name: Setup Node.js
         # actions/setup-node@v4.4.0
@@ -43,21 +56,29 @@ jobs:
       - name: Validate patched config
         run: node tools/validate-config.mjs
 
-      - name: Commit and push if config changed
+      - name: Open PR with domain updates (if any)
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT || github.token }}
         run: |
           if git diff --quiet shared/config/default-config.json; then
             echo "No config changes — nothing to commit."
             exit 0
           fi
+          branch="auto-update-domains/$(date -u +%Y-%m-%d)"
           git config user.name  'fast-travel-bot'
           git config user.email 'fast-travel-bot@users.noreply.github.com'
+          git switch -c "$branch"
           git add shared/config/default-config.json
           git commit -m "chore(config): auto-update mirror domains"
-          for attempt in 1 2 3 4; do
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            sleep $((2 ** attempt))
-          done
-          echo "git push failed after retries" >&2
-          exit 1
+          git push --force-with-lease origin "$branch"
+          # Open the PR if one doesn't already exist for this branch.
+          if ! gh pr view "$branch" >/dev/null 2>&1; then
+            gh pr create --base main --head "$branch" \
+              --title "chore(config): auto-update mirror domains" \
+              --body "Automated weekly domain health check found one or more unreachable mirror domains in \`shared/config/default-config.json\` and replaced them with reachable alternatives (verified via a HEAD check). Review the diff; CI must pass before this merges."
+          fi
+          # Best-effort: queue auto-merge once required checks pass. Requires
+          # auto-merge to be enabled on the repo and a PAT for CI to run (see
+          # the note at the top of this file).
+          gh pr merge "$branch" --auto --squash \
+            || echo "::warning::Could not enable auto-merge; merge the PR manually once CI is green."

--- a/tools/auto-update-domains/auto-update.json
+++ b/tools/auto-update-domains/auto-update.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./auto-update.schema.json",
   "commands": {
-    "annas-archive": { "source": "wikipedia", "wikipediaTitle": "Anna's Archive" },
+    "annas-archive": { "source": "fmhy", "fmhyPath": "reading",     "matchName": "Anna's Archive" },
     "libgen":        { "source": "fmhy", "fmhyPath": "reading",     "matchName": "Library Genesis" },
     "scihub":        { "source": "wikipedia", "wikipediaTitle": "Sci-Hub" },
     "mangadex":      { "source": "wikipedia", "wikipediaTitle": "MangaDex" },

--- a/tools/auto-update-domains/check-domains.test.mjs
+++ b/tools/auto-update-domains/check-domains.test.mjs
@@ -40,10 +40,10 @@ test("resolveCandidate returns the candidate when source resolves and HEAD check
   const fakeCheckDomain = async (host) => ({ ok: true, status: 200, error: null });
 
   const result = await resolveCandidate({
-    downDomain: "down.example",
+    downDomain: "reachable.org",
     commandId: "some-cmd",
-    commandName: "Some Cmd",
-    autoUpdateEntry: { source: "wikipedia", wikipediaTitle: "Some Cmd" },
+    commandName: "Reachable",
+    autoUpdateEntry: { source: "wikipedia", wikipediaTitle: "Reachable" },
     fetchImpl: fakeFetch,
     checkDomainImpl: fakeCheckDomain,
   });
@@ -83,14 +83,15 @@ test("resolveCandidate returns null when the candidate itself fails its HEAD che
       },
     }),
   });
-  // Resolver suggests "dead.example", but the second HEAD check says it's down.
+  // Resolver suggests "dead.example" (brand match), but the second HEAD check
+  // says it's down, so resolveCandidate must reject it.
   const fakeCheckDomain = async () => ({ ok: false, status: null, error: "dns-error" });
 
   const result = await resolveCandidate({
-    downDomain: "down.example",
+    downDomain: "dead.org",
     commandId: "some-cmd",
-    commandName: "Some Cmd",
-    autoUpdateEntry: { source: "wikipedia", wikipediaTitle: "Some Cmd" },
+    commandName: "Dead",
+    autoUpdateEntry: { source: "wikipedia", wikipediaTitle: "Dead" },
     fetchImpl: fakeFetch,
     checkDomainImpl: fakeCheckDomain,
   });

--- a/tools/auto-update-domains/sources/wikipedia.mjs
+++ b/tools/auto-update-domains/sources/wikipedia.mjs
@@ -63,7 +63,41 @@ const SKIP_HOSTS = new Set([
   "www.worldcat.org",
 ]);
 
-function pickAlternativeHost(links, downDomain) {
+// Reduce a string to its alphanumeric core for brand comparison, e.g.
+// "Anna's Archive" -> "annasarchive", "sci-hub.st" -> "scihubst".
+function normalizeToken(s) {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+// Public suffixes with two labels that we care about; enough for the
+// brand-stable services this tool tracks. Everything else uses the label
+// immediately before the final dot.
+const TWO_PART_TLDS = new Set([
+  "co.uk", "org.uk", "com.au", "co.jp", "co.in", "com.br",
+]);
+
+// The registrable "brand" label of a host, e.g. "annas-archive.gl" ->
+// "annas-archive", "www.sci-hub.st" -> "sci-hub", "foo.co.uk" -> "foo".
+function brandLabel(host) {
+  const parts = host.replace(/^www\./, "").split(".");
+  if (parts.length <= 1) return parts[0] || "";
+  const lastTwo = parts.slice(-2).join(".");
+  const sldIndex = TWO_PART_TLDS.has(lastTwo) ? parts.length - 3 : parts.length - 2;
+  return parts[Math.max(sldIndex, 0)] || "";
+}
+
+// A candidate is accepted only if one of the service brand tokens appears in
+// its hostname — same brand on a different TLD (the common mirror pattern) or
+// a platform-hosted subdomain carrying the brand. Wikipedia article extlinks
+// are mostly references and news coverage, so the first link is frequently an
+// article *about* the service rather than a mirror; matching on the brand and
+// otherwise returning null avoids auto-merging an unrelated domain.
+function hostMatchesService(host, tokens) {
+  const full = normalizeToken(host);
+  return tokens.some((t) => t.length >= 4 && full.includes(t));
+}
+
+function pickAlternativeHost(links, downDomain, tokens) {
   const seen = new Set();
   for (const raw of links) {
     try {
@@ -74,7 +108,7 @@ function pickAlternativeHost(links, downDomain) {
       if (SKIP_HOSTS.has(host)) continue;
       if (seen.has(host)) continue;
       seen.add(host);
-      return host;
+      if (hostMatchesService(host, tokens)) return host;
     } catch {
       // ignore
     }
@@ -87,5 +121,12 @@ export async function resolve({ downDomain, autoUpdate, commandName, fetchImpl =
   if (!title) return null;
   console.error(`  [wikipedia] Looking up "${title}" ...`);
   const links = await fetchExtLinks(title, fetchImpl);
-  return pickAlternativeHost(links, downDomain);
+  const tokens = [
+    ...new Set(
+      [normalizeToken(brandLabel(downDomain)), normalizeToken(title)].filter(
+        (t) => t.length >= 4,
+      ),
+    ),
+  ];
+  return pickAlternativeHost(links, downDomain, tokens);
 }

--- a/tools/auto-update-domains/sources/wikipedia.test.mjs
+++ b/tools/auto-update-domains/sources/wikipedia.test.mjs
@@ -18,20 +18,52 @@ function fakeMediaWikiResponse(extlinks) {
   };
 }
 
-test("resolve returns first plausible external link, skipping the down domain", async () => {
+test("returns a same-brand mirror on a different TLD, skipping the down domain", async () => {
   const fakeFetch = async () =>
     fakeMediaWikiResponse([
-      "https://olddomain.example/",   // down — skipped
-      "https://newdomain.example/",
-      "https://some-other.example/",
+      "https://sci-hub.se/",            // down — skipped
+      "https://www.nature.com/articles/d41586", // unrelated coverage — skipped
+      "https://sci-hub.st/",            // PICKED (same brand)
     ]);
   const host = await resolve({
-    downDomain: "olddomain.example",
-    autoUpdate: { source: "wikipedia", wikipediaTitle: "Some Service" },
-    commandName: "Some Service",
+    downDomain: "sci-hub.se",
+    autoUpdate: { source: "wikipedia", wikipediaTitle: "Sci-Hub" },
+    commandName: "Sci-Hub",
     fetchImpl: fakeFetch,
   });
-  assert.equal(host, "newdomain.example");
+  assert.equal(host, "sci-hub.st");
+});
+
+test("skips a news article that merely mentions the service and picks the real mirror", async () => {
+  // Regression for the real failure: Wikipedia's first extlink for Anna's
+  // Archive was a LA Weekly news article, not a mirror.
+  const fakeFetch = async () =>
+    fakeMediaWikiResponse([
+      "https://www.laweekly.com/free-z-library-e-book-download-search-engine-annas-archive-launches/",
+      "https://annas-archive.gl/", // PICKED (brand match)
+    ]);
+  const host = await resolve({
+    downDomain: "annas-archive.org",
+    autoUpdate: { source: "wikipedia", wikipediaTitle: "Anna's Archive" },
+    commandName: "Anna's Archive",
+    fetchImpl: fakeFetch,
+  });
+  assert.equal(host, "annas-archive.gl");
+});
+
+test("returns null when no external link matches the service brand (won't guess a news domain)", async () => {
+  const fakeFetch = async () =>
+    fakeMediaWikiResponse([
+      "https://www.laweekly.com/some-article/",
+      "https://news.ycombinator.com/item?id=1",
+    ]);
+  const host = await resolve({
+    downDomain: "annas-archive.org",
+    autoUpdate: { source: "wikipedia", wikipediaTitle: "Anna's Archive" },
+    commandName: "Anna's Archive",
+    fetchImpl: fakeFetch,
+  });
+  assert.equal(host, null);
 });
 
 test("resolve skips internet-archive and citation-database hosts", async () => {
@@ -40,15 +72,15 @@ test("resolve skips internet-archive and citation-database hosts", async () => {
       "https://web.archive.org/web/...",
       "https://www.wikidata.org/wiki/Q123",
       "https://viaf.org/viaf/123",
-      "https://realdomain.example/",
+      "https://sci-hub.st/", // brand match
     ]);
   const host = await resolve({
-    downDomain: "olddomain.example",
-    autoUpdate: { source: "wikipedia", wikipediaTitle: "Service" },
-    commandName: "Service",
+    downDomain: "sci-hub.se",
+    autoUpdate: { source: "wikipedia", wikipediaTitle: "Sci-Hub" },
+    commandName: "Sci-Hub",
     fetchImpl: fakeFetch,
   });
-  assert.equal(host, "realdomain.example");
+  assert.equal(host, "sci-hub.st");
 });
 
 test("resolve returns null when Wikipedia returns no external links", async () => {
@@ -66,13 +98,14 @@ test("resolve uses commandName when wikipediaTitle is absent", async () => {
   const captured = [];
   const fakeFetch = async (url) => {
     captured.push(url);
-    return fakeMediaWikiResponse(["https://x.example/"]);
+    return fakeMediaWikiResponse(["https://sci-hub.st/"]);
   };
-  await resolve({
-    downDomain: "olddomain.example",
+  const host = await resolve({
+    downDomain: "sci-hub.se",
     autoUpdate: { source: "wikipedia" },
-    commandName: "Fallback Title",
+    commandName: "Sci-Hub",
     fetchImpl: fakeFetch,
   });
-  assert.ok(captured[0].includes("Fallback%20Title"));
+  assert.ok(captured[0].includes("Sci-Hub"));
+  assert.equal(host, "sci-hub.st");
 });


### PR DESCRIPTION
## Why
The weekly **Auto-update domains** workflow ran every Monday but **failed every single run** at the *Commit and push* step. `main` has branch protection with required status checks, so the bot's direct `git push origin HEAD:main` was always rejected — it has never landed a mirror update (no `fast-travel-bot` commits in history).

Verified via `gh run view`: every run passes the checker + validation steps, then exits 1 at the push.

## What changed
- **Workflow opens a PR + auto-merges** instead of pushing to `main`; adds `pull-requests: write`.
  - ⚠️ **Action needed:** add an `AUTOMATION_PAT` repo secret (fine-grained PAT: contents + pull-requests write). PRs opened by the default `GITHUB_TOKEN` don't trigger other workflows, so the required CI checks won't run on the bot PR and auto-merge can't complete. Without it the PR still opens but must be merged by hand. Documented at the top of the workflow.
- **`annas-archive` → FMHY source** (the Wikipedia source returned a news article, `laweekly.com`). FMHY lists real mirrors first → resolves `annas-archive.gl`.
- **Hardened `wikipedia.mjs`**: only accepts hosts whose brand matches the service, returns `null` otherwise — so unrelated/news domains aren't auto-merged now that there's no human gate. Added a regression test for the `laweekly.com` failure.

## Tests
`cd tools/auto-update-domains && npm test` → 20/20 pass. Mapping + config validators pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)