### PR TITLE
feat(suggestions): unify empty-input top commands on a shared frecency ranking

### DIFF
--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/Frecency.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/Frecency.kt
@@ -1,0 +1,45 @@
+package sh.kavi.fasttravel.core
+
+import kotlin.math.pow
+
+/**
+ * Frecency ranking for the empty-input "top commands" suggestions, shared in
+ * behaviour with the extension (extension/src/core/frecency.ts) via
+ * shared/test-fixtures/frecency.fixtures.json.
+ *
+ * Each past use of a command contributes an exponentially-decaying weight
+ * (1-week half-life), so a command's score rewards both how often and how
+ * recently it was used. Never-used commands score 0 and keep config order,
+ * which also gives a sensible cold-start (no history -> config order).
+ */
+object Frecency {
+
+    private const val HALF_LIFE_DAYS = 7.0
+    private const val DAY_MS = 86_400_000.0
+
+    data class HistoryEntry(val commandId: String?, val timestamp: Long)
+
+    /**
+     * Rank [commandIds] (already in config order) by frecency, most relevant
+     * first. Ties — including the all-zero cold-start case — fall back to
+     * config order.
+     */
+    fun rank(commandIds: List<String>, history: List<HistoryEntry>, now: Long): List<String> {
+        val score = HashMap<String, Double>()
+        for (id in commandIds) score[id] = 0.0
+
+        for (entry in history) {
+            val id = entry.commandId ?: continue
+            if (!score.containsKey(id)) continue
+            val ageDays = maxOf(0.0, (now - entry.timestamp) / DAY_MS)
+            score[id] = score.getValue(id) + 0.5.pow(ageDays / HALF_LIFE_DAYS)
+        }
+
+        return commandIds.withIndex()
+            .sortedWith(
+                compareByDescending<IndexedValue<String>> { score.getValue(it.value) }
+                    .thenBy { it.index },
+            )
+            .map { it.value }
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -9,6 +9,7 @@ import sh.kavi.fasttravel.core.CommandParser
 import sh.kavi.fasttravel.core.CommandType
 import sh.kavi.fasttravel.core.DeviceType
 import sh.kavi.fasttravel.core.FastTravelConfig
+import sh.kavi.fasttravel.core.Frecency
 import sh.kavi.fasttravel.core.Group
 import sh.kavi.fasttravel.core.InstalledApp
 import sh.kavi.fasttravel.core.InstalledAppResolver
@@ -132,26 +133,21 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun updateChipCommands() {
         val cfg = config ?: return
-        val allCommands = flattenCommands(cfg.groups)
-        val standardCommands = allCommands.filter { it.type == CommandType.Standard }
+        val standardCommands = flattenCommands(cfg.groups).filter { it.type == CommandType.Standard }
 
         // ~4 chips per row fits the Figma spec's pill grid.
         val targetCount = (shortcutRows * 4).coerceAtLeast(4)
 
-        val history = searchHistory.getHistory()
-        if (history.isEmpty()) {
-            _chipCommands.value = standardCommands.take(targetCount)
-            return
+        // Rank by frecency (usage frequency + recency); empty history falls back
+        // to config order. Shared with the extension via
+        // shared/test-fixtures/frecency.fixtures.json.
+        val history = searchHistory.getHistory().map {
+            Frecency.HistoryEntry(it.commandId, it.timestamp)
         }
-
-        val frequencyMap = mutableMapOf<String, Int>()
-        for (entry in history) {
-            val id = entry.commandId ?: continue
-            frequencyMap[id] = (frequencyMap[id] ?: 0) + 1
-        }
-
-        _chipCommands.value = standardCommands
-            .sortedByDescending { frequencyMap[it.id] ?: 0 }
+        val byId = standardCommands.associateBy { it.id }
+        _chipCommands.value = Frecency
+            .rank(standardCommands.map { it.id }, history, System.currentTimeMillis())
+            .mapNotNull { byId[it] }
             .take(targetCount)
     }
 

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/core/FrecencyTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/core/FrecencyTest.kt
@@ -1,0 +1,73 @@
+package sh.kavi.fasttravel.core
+
+import org.json.JSONArray
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+import java.util.stream.Stream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FrecencyTest {
+
+    private val dayMs = 86_400_000L
+
+    data class FrecencyFixture(
+        val description: String,
+        val commandIds: List<String>,
+        val nowMs: Long,
+        val history: List<Frecency.HistoryEntry>,
+        val expected: List<String>,
+    )
+
+    private fun resolveSharedFile(relativePath: String): File {
+        val candidates = listOf(
+            File("../shared/$relativePath"),
+            File("../../shared/$relativePath"),
+            File("shared/$relativePath"),
+        )
+        return candidates.firstOrNull { it.exists() }
+            ?: throw IllegalStateException(
+                "Cannot find shared/$relativePath. Tried: ${candidates.map { it.absolutePath }}"
+            )
+    }
+
+    private fun loadFixtures(): Stream<FrecencyFixture> {
+        val json = resolveSharedFile("test-fixtures/frecency.fixtures.json").readText()
+        val arr = JSONArray(json)
+        val fixtures = mutableListOf<FrecencyFixture>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            val nowMs = obj.getLong("nowMs")
+            val idsArr = obj.getJSONArray("commandIds")
+            val ids = (0 until idsArr.length()).map { idsArr.getString(it) }
+            val histArr = obj.getJSONArray("history")
+            val history = (0 until histArr.length()).map {
+                val h = histArr.getJSONObject(it)
+                Frecency.HistoryEntry(
+                    commandId = h.getString("commandId"),
+                    timestamp = nowMs - h.getLong("ageDays") * dayMs,
+                )
+            }
+            val expArr = obj.getJSONArray("expected")
+            val expected = (0 until expArr.length()).map { expArr.getString(it) }
+            fixtures.add(
+                FrecencyFixture(obj.getString("description"), ids, nowMs, history, expected)
+            )
+        }
+        return fixtures.stream()
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("loadFixtures")
+    @DisplayName("rankByFrecency shared fixtures")
+    fun `frecency fixtures`(fixture: FrecencyFixture) {
+        assertEquals(
+            fixture.expected,
+            Frecency.rank(fixture.commandIds, fixture.history, fixture.nowMs),
+            fixture.description,
+        )
+    }
+}

--- a/extension/src/core/frecency.ts
+++ b/extension/src/core/frecency.ts
@@ -1,0 +1,41 @@
+// Frecency ranking for the empty-input "top commands" suggestions, shared in
+// behaviour with the Android side (sh.kavi.fasttravel.core.Frecency) via
+// shared/test-fixtures/frecency.fixtures.json.
+//
+// Each past use of a command contributes an exponentially-decaying weight
+// (1-week half-life), so a command's score rewards both how often and how
+// recently it was used. Never-used commands score 0 and keep config order,
+// which also gives a sensible cold-start (no history -> config order).
+
+export interface FrecencyHistoryEntry {
+  commandId: string | null;
+  timestamp: number;
+}
+
+const HALF_LIFE_DAYS = 7;
+const DAY_MS = 86_400_000;
+
+/**
+ * Rank `commandIds` (already in config order) by frecency, most relevant first.
+ * Ties — including the all-zero cold-start case — fall back to config order.
+ */
+export function rankByFrecency(
+  commandIds: string[],
+  history: FrecencyHistoryEntry[],
+  now: number,
+): string[] {
+  const score = new Map<string, number>();
+  for (const id of commandIds) score.set(id, 0);
+
+  for (const entry of history) {
+    const id = entry.commandId;
+    if (id == null || !score.has(id)) continue;
+    const ageDays = Math.max(0, (now - entry.timestamp) / DAY_MS);
+    score.set(id, (score.get(id) as number) + Math.pow(0.5, ageDays / HALF_LIFE_DAYS));
+  }
+
+  return commandIds
+    .map((id, index) => ({ id, index, s: score.get(id) as number }))
+    .sort((a, b) => b.s - a.s || a.index - b.index)
+    .map((x) => x.id);
+}

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -21,6 +21,7 @@ import {
   type AutoIgnoreStore,
 } from "../core/auto-ignore-store.js";
 import { effectiveIgnoreList } from "../core/effective-ignore-list.js";
+import { rankByFrecency } from "../core/frecency.js";
 
 interface HistoryEntry {
   query: string;
@@ -84,6 +85,9 @@ function findResolvedByTrigger(cfg: FastTravelConfig, trigger: string): Resolved
 
 // State
 let config: FastTravelConfig | null = null;
+// Recent usage history, fetched once at load and used to frecency-rank the
+// empty-input quick chips.
+let topChipHistory: HistoryEntry[] = [];
 let permanentIgnoreList: string[] = [];
 let candidates: AutoIgnoreStore = {};
 let threshold = 3;
@@ -162,6 +166,7 @@ async function init(): Promise<void> {
     subscribeAppearance(applyAppearance);
     config = await chrome.runtime.sendMessage({ type: "getConfig" });
     await refreshIgnoreState();
+    topChipHistory = (await chrome.runtime.sendMessage({ type: "getHistory" })) ?? [];
 
     // Omnibox search-provider path: ?q=<query> → resolve + navigate immediately.
     // The presence of ?q= proves Fast Travel is the active default search engine.
@@ -263,7 +268,18 @@ function renderQuickChips(): void {
   if (!config) return;
   chipsContent.replaceChildren();
   const resolved = flattenWithColors(config).filter(({ cmd }) => cmd.type === "standard");
-  for (const { cmd, groupColor } of resolved.slice(0, 8)) {
+  // Rank the standard commands by frecency (usage frequency + recency), most
+  // relevant first; falls back to config order with no history. Shared with the
+  // Android side via shared/test-fixtures/frecency.fixtures.json.
+  const byId = new Map(resolved.map((rc) => [rc.cmd.id, rc]));
+  const ranked = rankByFrecency(
+    resolved.map((rc) => rc.cmd.id),
+    topChipHistory,
+    Date.now(),
+  )
+    .map((id) => byId.get(id))
+    .filter((rc): rc is ResolvedCommand => rc !== undefined);
+  for (const { cmd, groupColor } of ranked.slice(0, 8)) {
     const tint = resolveGroupTint(groupColor);
     const btn = document.createElement("button");
     btn.type = "button";

--- a/extension/tests/unit/frecency.test.ts
+++ b/extension/tests/unit/frecency.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { rankByFrecency } from "../../src/core/frecency.js";
+
+const DAY_MS = 86_400_000;
+
+interface FrecencyFixture {
+  description: string;
+  commandIds: string[];
+  nowMs: number;
+  history: { commandId: string; ageDays: number }[];
+  expected: string[];
+}
+
+const fixtures: FrecencyFixture[] = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "../../../shared/test-fixtures/frecency.fixtures.json"),
+    "utf-8",
+  ),
+);
+
+describe("rankByFrecency - shared fixtures", () => {
+  for (const fixture of fixtures) {
+    it(fixture.description, () => {
+      const history = fixture.history.map((h) => ({
+        commandId: h.commandId,
+        timestamp: fixture.nowMs - h.ageDays * DAY_MS,
+      }));
+      expect(rankByFrecency(fixture.commandIds, history, fixture.nowMs)).toEqual(
+        fixture.expected,
+      );
+    });
+  }
+});

--- a/shared/test-fixtures/frecency.fixtures.json
+++ b/shared/test-fixtures/frecency.fixtures.json
@@ -1,0 +1,74 @@
+[
+  {
+    "description": "cold start - no history keeps config order",
+    "commandIds": ["g", "ddg", "yt", "gh"],
+    "nowMs": 1700000000000,
+    "history": [],
+    "expected": ["g", "ddg", "yt", "gh"]
+  },
+  {
+    "description": "a single recent use outranks never-used commands",
+    "commandIds": ["g", "ddg", "yt"],
+    "nowMs": 1700000000000,
+    "history": [{ "commandId": "yt", "ageDays": 0 }],
+    "expected": ["yt", "g", "ddg"]
+  },
+  {
+    "description": "recent use outranks older use",
+    "commandIds": ["g", "ddg", "yt"],
+    "nowMs": 1700000000000,
+    "history": [
+      { "commandId": "yt", "ageDays": 0 },
+      { "commandId": "g", "ageDays": 30 }
+    ],
+    "expected": ["yt", "g", "ddg"]
+  },
+  {
+    "description": "frequency accumulates - frequent and recent beats single recent",
+    "commandIds": ["g", "ddg", "yt"],
+    "nowMs": 1700000000000,
+    "history": [
+      { "commandId": "ddg", "ageDays": 1 },
+      { "commandId": "ddg", "ageDays": 2 },
+      { "commandId": "g", "ageDays": 0 }
+    ],
+    "expected": ["ddg", "g", "yt"]
+  },
+  {
+    "description": "unused commands keep config order after used ones",
+    "commandIds": ["a", "b", "c", "d"],
+    "nowMs": 1700000000000,
+    "history": [{ "commandId": "c", "ageDays": 0 }],
+    "expected": ["c", "a", "b", "d"]
+  },
+  {
+    "description": "equal frecency is tie-broken by config order",
+    "commandIds": ["a", "b"],
+    "nowMs": 1700000000000,
+    "history": [
+      { "commandId": "b", "ageDays": 0 },
+      { "commandId": "a", "ageDays": 0 }
+    ],
+    "expected": ["a", "b"]
+  },
+  {
+    "description": "future timestamps are clamped so they cannot over-weight",
+    "commandIds": ["a", "b"],
+    "nowMs": 1700000000000,
+    "history": [
+      { "commandId": "a", "ageDays": 0 },
+      { "commandId": "b", "ageDays": -5 }
+    ],
+    "expected": ["a", "b"]
+  },
+  {
+    "description": "history referencing an unknown command id is ignored",
+    "commandIds": ["a", "b"],
+    "nowMs": 1700000000000,
+    "history": [
+      { "commandId": "zzz", "ageDays": 0 },
+      { "commandId": "b", "ageDays": 0 }
+    ],
+    "expected": ["b", "a"]
+  }
+]


### PR DESCRIPTION
## Why
The empty-input **top commands** behaved differently per platform:
- **Extension** showed the first 8 commands in **static config order** — not personalized at all.
- **Android** ranked chips by **raw usage frequency** — no recency.

Neither decayed stale habits, and there were **no shared parity fixtures** despite the stated parity goal.

## What changed
Both platforms now rank by **frecency**: each past use of a command contributes an exponentially-decaying weight (1-week half-life), so the score rewards how *often* and how *recently* it was used. No history → config order (cold start); ties → config order.

- `extension/src/core/frecency.ts` + `android/.../core/Frecency.kt` — identical algorithm.
- `shared/test-fixtures/frecency.fixtures.json` — drives **parity tests on both platforms** (Vitest + JUnit5), 8 cases: recency beats older use, frequency accumulation, tie→config order, future-timestamp clamping, unknown-id ignored.
- Wired into `renderQuickChips` (extension) and `updateChipCommands` (Android).

## Tests
- Extension: `npm test` → 206/206 (incl. 8 new frecency).
- Android: `./gradlew :app:testDebugUnitTest` → 152/152 (incl. 8 new frecency).
- e2e unaffected (fresh profiles cold-start to config order; no spec asserts chip order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)