### PR TITLE
fix(android): non-dirty editable snapshot no longer freezes config auto-refresh

### DIFF
--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ConfigRepository.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ConfigRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import sh.kavi.fasttravel.core.ConfigParser
+import sh.kavi.fasttravel.core.ConfigWriter
 import sh.kavi.fasttravel.core.FastTravelConfig
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -33,9 +34,15 @@ class ConfigRepository(private val context: Context) {
     private val fetchMutex = Mutex()
 
     suspend fun getConfig(): FastTravelConfig {
-        // Local edits (direct-edit model) win over any remote/bundled base.
-        editableStore.getLocalConfig()
-            ?.let { if (validate(it, "local")) return it }
+        // Local edits (direct-edit model) win over any remote/bundled base — but
+        // ONLY when the user actually has local edits (dirty). A non-dirty
+        // editable snapshot (e.g. one left behind by "Fetch & Import" or
+        // "Reset to remote") must NOT shadow the live remote, otherwise
+        // auto-refresh silently freezes on that stale snapshot.
+        if (themePreferences.configSourceDirty) {
+            editableStore.getLocalConfig()
+                ?.let { if (validate(it, "local")) return it }
+        }
 
         // Cached remote (if fresh enough) — re-validate every load so a corrupt
         // entry doesn't survive forever.
@@ -113,6 +120,18 @@ class ConfigRepository(private val context: Context) {
 
     /** Convenience for callers that want to know if the user has any local edits. */
     fun hasLocalEdits(): Boolean = editableStore.hasLocalConfig()
+
+    /**
+     * Adopt a freshly-fetched remote config as the new baseline: cache it so
+     * [getConfig] serves it immediately and the periodic refresh keeps it
+     * current, and drop any editable snapshot so it can't shadow the remote.
+     * Used by URL import and reset-to-remote (which must NOT leave a non-dirty
+     * editable snapshot — that is the "frozen config" bug).
+     */
+    fun adoptRemoteConfig(config: FastTravelConfig) {
+        editableStore.clearLocalConfig()
+        cacheConfig(ConfigWriter.writeConfig(config))
+    }
 
     private fun getCachedConfig(): FastTravelConfig? {
         val json = prefs.getString(KEY_CACHED_CONFIG, null) ?: return null

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -802,14 +802,17 @@ fun ImportExportScreen(
                                     isLoading = false
                                     return@launch
                                 }
-                                editableStore.saveLocalConfig(fetched)
                                 themePrefs.configUrl = url
                                 themePrefs.configRefreshInterval = selectedInterval
                                 if (selectedInterval != ConfigRefreshInterval.MANUAL) {
+                                    // Adopt as the remote baseline (cache it + drop any
+                                    // editable snapshot) so auto-refresh isn't shadowed.
+                                    configRepository.adoptRemoteConfig(fetched)
                                     themePrefs.configSourceDirty = false
                                     ConfigRefreshScheduler.schedule(context, selectedInterval)
                                     statusText = "Synced"
                                 } else {
+                                    editableStore.saveLocalConfig(fetched)
                                     markDirtyAndCancelRefresh(context, themePrefs)
                                     statusText = "Local config"
                                 }
@@ -886,7 +889,9 @@ fun ImportExportScreen(
                     scope.launch {
                         val fetched = configRepository.fetchFromUrl(themePrefs.configUrl)
                         if (fetched != null) {
-                            editableStore.saveLocalConfig(fetched)
+                            // Adopt as the remote baseline so the reset actually
+                            // clears local edits instead of re-saving them.
+                            configRepository.adoptRemoteConfig(fetched)
                             themePrefs.configSourceDirty = false
                             ConfigRefreshScheduler.schedule(context, themePrefs.configRefreshInterval)
                             onConfigChanged()

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ConfigRepositoryTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ConfigRepositoryTest.kt
@@ -1,0 +1,72 @@
+package sh.kavi.fasttravel.data
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import sh.kavi.fasttravel.core.ConfigParser
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class ConfigRepositoryTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    /** Save a copy of the bundled config with group[0] renamed to [marker] as the local edit. */
+    private fun saveMarkerLocalConfig(marker: String) {
+        val json = context.assets.open("default-config.json").bufferedReader().use { it.readText() }
+        val base = ConfigParser.parseConfig(json)
+        val marked = base.copy(
+            groups = listOf(base.groups[0].copy(name = marker)) + base.groups.drop(1),
+        )
+        EditableConfigStore(context).saveLocalConfig(marked)
+    }
+
+    @Test
+    fun `editable config wins when the user has local edits (dirty)`() = runBlocking {
+        saveMarkerLocalConfig("LOCAL_MARKER")
+        ThemePreferences(context).configSourceDirty = true
+
+        val result = ConfigRepository(context).getConfig()
+
+        assertEquals("LOCAL_MARKER", result.groups[0].name)
+    }
+
+    @Test
+    fun `adoptRemoteConfig caches the config and clears any local snapshot`() = runBlocking {
+        saveMarkerLocalConfig("OLD_LOCAL") // a stale snapshot exists
+        val prefs = ThemePreferences(context)
+        prefs.configSourceDirty = false
+        prefs.configUrl = "no-protocol-url" // ensure getConfig never reaches the network
+        val repo = ConfigRepository(context)
+
+        val json = context.assets.open("default-config.json").bufferedReader().use { it.readText() }
+        val base = ConfigParser.parseConfig(json)
+        val fresh = base.copy(
+            groups = listOf(base.groups[0].copy(name = "FRESH_REMOTE")) + base.groups.drop(1),
+        )
+        repo.adoptRemoteConfig(fresh)
+
+        assertEquals(false, EditableConfigStore(context).hasLocalConfig())
+        assertEquals("FRESH_REMOTE", repo.getConfig().groups[0].name)
+    }
+
+    @Test
+    fun `a non-dirty editable snapshot does not shadow the remote (frozen-config bug)`() = runBlocking {
+        // A snapshot left by "Fetch & Import" / "Reset to remote" has dirty=false.
+        saveMarkerLocalConfig("LOCAL_MARKER")
+        val prefs = ThemePreferences(context)
+        prefs.configSourceDirty = false
+        prefs.configUrl = "no-protocol-url" // remote fetch fails fast -> bundled fallback
+
+        val result = ConfigRepository(context).getConfig()
+
+        assertNotEquals("LOCAL_MARKER", result.groups[0].name)
+    }
+}


### PR DESCRIPTION
## The bug (reproduced on a real device)
A device set to **Daily** auto-refresh silently stopped getting config updates. Root cause:

`ConfigRepository.getConfig()` returned `editableStore.getLocalConfig()` **unconditionally**. But "Fetch & Import" — the *only* UI that sets a config URL or the refresh interval (`SettingsActivity` line ~805) — and "Reset to remote" **save the fetched config into the editable store with `dirty=false`**. So:
- the daily worker keeps fetching the latest config into the **cache** ✅
- but `getConfig()` serves the **frozen editable snapshot**, ignoring the cache ❌
- the UI shows **"Synced from remote"** and hides the Reset button (it only shows when `dirty`), so there's no in-app way out.

Pulled from a real device (`SM-S942U1`) over adb:

| | served (frozen snapshot) | cache (worker fetched today) | live remote |
|---|---|---|---|
| google | `['g','google']` | `['g']` | `['g']` |
| annas-archive | *missing* | `['aa']` | `['aa']` |

`cache == remote` (fetched today), but `local != remote` — classic freeze. The extension doesn't have this (its import writes the same key the refresh overwrites).

## The fix
- **`getConfig()` honors the editable store only when `configSourceDirty == true`.** A non-dirty snapshot (import/reset leftover) can no longer shadow the live remote.
- **New `ConfigRepository.adoptRemoteConfig()`** — caches the fetched config and clears any editable snapshot. Non-manual **URL import** and **Reset to remote** now use it, so they don't leave a frozen snapshot and the config is served immediately (and the real `resetToRemote` semantics are restored — the dialog previously re-saved local).

## Tests
`ConfigRepositoryTest` (Robolectric), TDD:
- editable config wins when `dirty=true`
- a non-dirty editable snapshot does **not** shadow the remote (the bug)
- `adoptRemoteConfig` caches the config + clears the snapshot

`./gradlew :app:testDebugUnitTest` → 147/147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)