### PR TITLE
fix(android): dark-mode settings/launch no longer flash white; show developer as DoubleGremlin181

### DIFF
--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -242,21 +242,29 @@ class SettingsActivity : ComponentActivity() {
             var appearance by remember { mutableStateOf(resolveFromPrefs(applicationContext, themePrefs)) }
 
             FastTravelTheme(appearance = appearance.forSettings()) {
-                SettingsNavHost(
-                    onFinish = { finish() },
-                    themePrefs = themePrefs,
-                    onAppearanceChanged = { appearance = it },
-                    onImportFile = { callback ->
-                        importLauncherCallback = callback
-                        isLauncherPending = true
-                        importFileLauncher.launch(arrayOf("application/json", "text/plain"))
-                    },
-                    onExportFile = { filename, callback ->
-                        exportLauncherCallback = callback
-                        isLauncherPending = true
-                        exportFileLauncher.launch(filename)
-                    },
-                )
+                // Paint the themed background behind the NavHost so page
+                // transitions (and the first frame) never reveal the white
+                // window background in dark mode.
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background,
+                ) {
+                    SettingsNavHost(
+                        onFinish = { finish() },
+                        themePrefs = themePrefs,
+                        onAppearanceChanged = { appearance = it },
+                        onImportFile = { callback ->
+                            importLauncherCallback = callback
+                            isLauncherPending = true
+                            importFileLauncher.launch(arrayOf("application/json", "text/plain"))
+                        },
+                        onExportFile = { filename, callback ->
+                            exportLauncherCallback = callback
+                            isLauncherPending = true
+                            exportFileLauncher.launch(filename)
+                        },
+                    )
+                }
             }
         }
     }
@@ -1897,7 +1905,7 @@ fun AboutScreen(navController: NavHostController) {
                     },
                     supportingContent = {
                         Text(
-                            "Kavish",
+                            "DoubleGremlin181",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="widget_hint_text">#94A3B8</color>
+    <!-- Window background (dark). Matches DarkBackground = Night. -->
+    <color name="ft_window_background">#0E1020</color>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -2,4 +2,6 @@
 <resources>
     <color name="widget_hint_text">#9AA0A6</color>
     <color name="ic_launcher_background">#F5F2EC</color>
+    <!-- Window background (light). Matches LightBackground = Paper. -->
+    <color name="ft_window_background">#F5F2EC</color>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.FastTravel" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.FastTravel" parent="android:Theme.Material.Light.NoActionBar">
+        <!-- Dark-aware window background so dark mode doesn't flash white during
+             the activity-open / settings page transitions before Compose draws.
+             Resolves to the dark Night color via values-night/colors.xml. -->
+        <item name="android:windowBackground">@color/ft_window_background</item>
+    </style>
 </resources>

--- a/extension/src/options/screens/about.ts
+++ b/extension/src/options/screens/about.ts
@@ -37,7 +37,7 @@ export function renderAbout(main: HTMLElement): void {
     el(
       "div",
       { class: "card-body about-info" },
-      el("p", null, "Built by Kavish (GitHub @DoubleGremlin181)."),
+      el("p", null, "Built by DoubleGremlin181."),
       el("p", null, "Command catalog is community-sourced; contributions welcome via pull request."),
     ),
   );


### PR DESCRIPTION
## Dark-mode white flash (Android)
`Theme.FastTravel` extended **`android:Theme.Material.Light.NoActionBar`** — a hardcoded *light* theme with no `values-night` variant — so the window background (and the Android-12+ splash/starting window) was always **white**. In dark mode it flashed white on activity open and showed through the NavHost during settings page transitions before Compose drew its dark UI.

**Fix**
- `Theme.FastTravel` now sets `android:windowBackground` → `@color/ft_window_background`, which resolves to the dark **Night** color via `values-night/colors.xml`.
- `SettingsActivity` wraps its `NavHost` in a `Surface(colorScheme.background)` so page transitions / the first frame paint the themed background (also covers in-app forced-dark).

**Verified on the AVD in dark mode (cold launch, same window background as Settings):**

| | brightness on launch | % near-white |
|---|---|---|
| before (main) | ~246 (white splash) | 98% |
| after (fix) | ~27 (dark splash) | ~5% |

## Developer name
Updated the in-app developer/author name to **DoubleGremlin181** on both platforms: Android Settings "Author" row and the extension's About → Credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)