### PR TITLE
feat(android): installed apps as first-class commands + Local search settings

### DIFF
--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/AppLauncherId.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/AppLauncherId.kt
@@ -1,0 +1,25 @@
+package sh.kavi.fasttravel.core
+
+/**
+ * Installed apps are recorded in search history and ranked alongside real commands.
+ * To reuse the command-keyed [Frecency] and history machinery, an app launch is stored
+ * under a namespaced pseudo-command id of the form `app:<package>/<activity>`.
+ *
+ * Package names never contain `/`, and activity names may contain `.`/`$` but not `/`,
+ * so the first slash unambiguously separates the two halves.
+ */
+private const val APP_ID_PREFIX = "app:"
+
+fun installedAppId(packageName: String, activityName: String): String =
+    "$APP_ID_PREFIX$packageName/$activityName"
+
+fun isInstalledAppId(id: String?): Boolean = id != null && id.startsWith(APP_ID_PREFIX)
+
+/** Returns (packageName, activityName) for a valid app id, or null otherwise. */
+fun parseInstalledAppId(id: String): Pair<String, String>? {
+    if (!id.startsWith(APP_ID_PREFIX)) return null
+    val rest = id.substring(APP_ID_PREFIX.length)
+    val slash = rest.indexOf('/')
+    if (slash <= 0 || slash >= rest.length - 1) return null
+    return rest.substring(0, slash) to rest.substring(slash + 1)
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/ChipRanking.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/ChipRanking.kt
@@ -1,0 +1,34 @@
+package sh.kavi.fasttravel.core
+
+/**
+ * Builds the ordered list of ids that fill the empty-input shortcut grid, mixing
+ * real command ids with installed-app ids ([installedAppId]).
+ *
+ * An app only becomes a chip candidate once it has been launched — i.e. it appears in
+ * [history] — and only when [includeApps] is on. Final ordering is delegated to
+ * [Frecency], so a recently/often used app naturally outranks never-used commands while
+ * a cold start (no history) preserves command config order.
+ *
+ * Kept free of Android types so the candidate-set + gating logic is unit-testable.
+ */
+object ChipRanking {
+    fun rankedIds(
+        commandIds: List<String>,
+        history: List<Frecency.HistoryEntry>,
+        now: Long,
+        includeApps: Boolean,
+        limit: Int,
+    ): List<String> {
+        val appIds = if (includeApps) {
+            history.asSequence()
+                .mapNotNull { it.commandId }
+                .filter { isInstalledAppId(it) }
+                .distinct()
+                .toList()
+        } else {
+            emptyList()
+        }
+        val candidates = commandIds + appIds
+        return Frecency.rank(candidates, history, now).take(limit.coerceAtLeast(0))
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/InstalledAppResolver.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/InstalledAppResolver.kt
@@ -84,6 +84,25 @@ object InstalledAppResolver {
         }
     }
 
+    /**
+     * Rebuild an [InstalledApp] (with its current icon + label) from a previously
+     * stored package/activity pair — used to render history "Recent" rows and shortcut
+     * chips for launched apps. Returns null if the app is no longer installed.
+     */
+    fun findByComponent(context: Context, packageName: String, activityName: String): InstalledApp? {
+        val entry = ensureLoaded(context).firstOrNull {
+            val ai = it.resolveInfo.activityInfo
+            ai.packageName == packageName && ai.name == activityName
+        } ?: return null
+        val pm = context.packageManager
+        return InstalledApp(
+            label = entry.label,
+            packageName = packageName,
+            activityName = activityName,
+            icon = loadIcon(context, pm, entry.resolveInfo, isThemedIconMode(context), IconPackResolver.getActivePackPackage(context)),
+        )
+    }
+
     fun launchIntent(app: InstalledApp): Intent {
         return Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_LAUNCHER)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/SuggestionProvider.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/SuggestionProvider.kt
@@ -16,6 +16,9 @@ data class Suggestion(
     val commandName: String? = null,
     val commandIconUrl: String? = null,
     val isHistory: Boolean = false,
+    /** Non-null when this (history) suggestion represents a launched installed app.
+     *  Such rows render the app icon and launch the app instead of running a query. */
+    val installedApp: InstalledApp? = null,
 )
 
 /**

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
@@ -17,7 +17,11 @@ enum class ConfigRefreshInterval(val displayName: String, val hours: Long?) {
     }
 }
 
-class ThemePreferences(context: Context) {
+class ThemePreferences(private val prefs: SharedPreferences) {
+
+    constructor(context: Context) : this(
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    )
 
     companion object {
         private const val PREFS_NAME = "fast_travel_theme"
@@ -30,6 +34,7 @@ class ThemePreferences(context: Context) {
         private const val KEY_SHORTCUT_ROWS = "shortcut_rows"
         private const val KEY_AUTO_IGNORE_THRESHOLD = "auto_ignore_threshold"
         private const val KEY_CONFIG_SOURCE_DIRTY = "config_source_dirty"
+        const val KEY_INSTALLED_APPS_ENABLED = "installed_apps_enabled"
         const val DEFAULT_AUTO_IGNORE_THRESHOLD = 3
         const val AUTO_IGNORE_THRESHOLD_MIN = 1
         const val AUTO_IGNORE_THRESHOLD_MAX = 20
@@ -37,9 +42,6 @@ class ThemePreferences(context: Context) {
         const val DEFAULT_CONFIG_URL =
             "https://raw.githubusercontent.com/DoubleGremlin181/fast-travel-app/main/shared/config/default-config.json"
     }
-
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
     fun registerListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
         prefs.registerOnSharedPreferenceChangeListener(listener)
@@ -88,6 +90,12 @@ class ThemePreferences(context: Context) {
     var configSourceDirty: Boolean
         get() = prefs.getBoolean(KEY_CONFIG_SOURCE_DIRTY, false)
         set(value) { prefs.edit().putBoolean(KEY_CONFIG_SOURCE_DIRTY, value).apply() }
+
+    /** When on (default), installed apps are launchable from the search results row,
+     *  appear in "Recent" history, and rank into the empty-input shortcut chips. */
+    var installedAppsEnabled: Boolean
+        get() = prefs.getBoolean(KEY_INSTALLED_APPS_ENABLED, true)
+        set(value) { prefs.edit().putBoolean(KEY_INSTALLED_APPS_ENABLED, value).apply() }
 
     var shortcutRows: Int
         get() = prefs.getInt(KEY_SHORTCUT_ROWS, 2)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/ChipItem.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/ChipItem.kt
@@ -1,0 +1,13 @@
+package sh.kavi.fasttravel.ui
+
+import sh.kavi.fasttravel.core.Command
+import sh.kavi.fasttravel.core.InstalledApp
+
+/**
+ * An entry in the empty-input shortcut grid. Commands and launched installed apps are
+ * ranked together (see [sh.kavi.fasttravel.core.ChipRanking]) and rendered side by side.
+ */
+sealed interface ChipItem {
+    data class Cmd(val command: Command) : ChipItem
+    data class App(val app: InstalledApp) : ChipItem
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -371,7 +371,7 @@ fun SearchScreen(
     val query by viewModel.query.collectAsState()
     val suggestions by viewModel.suggestions.collectAsState()
     val searchState by viewModel.searchState.collectAsState()
-    val chipCommands by viewModel.chipCommands.collectAsState()
+    val chipItems by viewModel.chipItems.collectAsState()
     val installedApps by viewModel.installedApps.collectAsState()
     val groupColorMap by viewModel.groupColorMap.collectAsState()
     val context = LocalContext.current
@@ -590,6 +590,7 @@ fun SearchScreen(
                     onSuggestionPopulate = { s -> viewModel.onQueryChanged(s.text) },
                     onHistoryRemove = { q -> viewModel.removeHistoryEntry(q) },
                     onAppLaunch = { app ->
+                        viewModel.recordAppLaunch(app)
                         context.startActivity(InstalledAppResolver.launchIntent(app))
                     },
                     onCommandAutocompletePick = { cmd ->
@@ -603,10 +604,10 @@ fun SearchScreen(
                 )
             } else {
                 UnfocusedContent(
-                    chipCommands = chipCommands,
+                    chipItems = chipItems,
                     groupColorMap = groupColorMap,
                     shortcutRows = shortcutRows,
-                    onChipClick = { command ->
+                    onCommandClick = { command ->
                         val trigger = command.triggers.firstOrNull() ?: return@UnfocusedContent
                         if (command.type == CommandType.Redirect) {
                             viewModel.onSearch(trigger)
@@ -615,6 +616,10 @@ fun SearchScreen(
                             focusRequester.requestFocus()
                             keyboardController?.show()
                         }
+                    },
+                    onAppClick = { app ->
+                        viewModel.recordAppLaunch(app)
+                        context.startActivity(InstalledAppResolver.launchIntent(app))
                     },
                 )
             }
@@ -749,7 +754,10 @@ private fun FocusedContent(
                             suggestion = suggestion,
                             viewModel = viewModel,
                             groupColorMap = groupColorMap,
-                            onClick = { onSuggestionClick(suggestion) },
+                            onClick = {
+                                val app = suggestion.installedApp
+                                if (app != null) onAppLaunch(app) else onSuggestionClick(suggestion)
+                            },
                             onRemoveConfirmed = { onHistoryRemove(suggestion.text) },
                             onPopulate = { onSuggestionPopulate(suggestion) },
                         )
@@ -984,6 +992,7 @@ private fun HistoryRow(
         )
     }
 
+    val launchableApp = suggestion.installedApp
     val matchedCommand = suggestion.commandTrigger?.let { viewModel.findCommandByTrigger(it) }
     // Default Google favicon for unmatched (search-only) history rows so we don't
     // fall back to a per-row letter monogram that looks random.
@@ -1008,17 +1017,28 @@ private fun HistoryRow(
             )
             .padding(horizontal = 8.dp, vertical = 12.dp)
             .semantics {
-                contentDescription =
+                contentDescription = if (launchableApp != null) {
+                    "Recent app: ${suggestion.displayText}. Long press to remove."
+                } else {
                     "Recent search: ${suggestion.displayText}. Long press to remove."
+                }
             },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        CommandFavicon(
-            iconUrl = favicon,
-            trigger = triggerForMonogram,
-            groupColorHex = groupColorHex,
-            size = 24.dp,
-        )
+        if (launchableApp != null) {
+            AsyncImage(
+                model = launchableApp.icon,
+                contentDescription = "${launchableApp.label} icon",
+                modifier = Modifier.size(24.dp).clip(RoundedCornerShape(6.dp)),
+            )
+        } else {
+            CommandFavicon(
+                iconUrl = favicon,
+                trigger = triggerForMonogram,
+                groupColorHex = groupColorHex,
+                size = 24.dp,
+            )
+        }
         Spacer(modifier = Modifier.width(12.dp))
         Text(
             text = suggestion.displayText,
@@ -1028,14 +1048,18 @@ private fun HistoryRow(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
-        IconButton(onClick = onPopulate, modifier = Modifier.size(32.dp)) {
-            // ArrowOutward points NE; rotate -90° -> NW arrow ("↖") per spec.
-            Icon(
-                imageVector = Icons.Default.ArrowOutward,
-                contentDescription = "Populate search bar",
-                modifier = Modifier.size(20.dp).rotate(-90f),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-            )
+        // Apps launch directly on tap, so the "populate search bar" affordance only
+        // applies to query rows.
+        if (launchableApp == null) {
+            IconButton(onClick = onPopulate, modifier = Modifier.size(32.dp)) {
+                // ArrowOutward points NE; rotate -90° -> NW arrow ("↖") per spec.
+                Icon(
+                    imageVector = Icons.Default.ArrowOutward,
+                    contentDescription = "Populate search bar",
+                    modifier = Modifier.size(20.dp).rotate(-90f),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                )
+            }
         }
     }
 }
@@ -1161,12 +1185,13 @@ private fun SuggestionRow(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun UnfocusedContent(
-    chipCommands: List<Command>,
+    chipItems: List<ChipItem>,
     groupColorMap: Map<String, String>,
     shortcutRows: Int,
-    onChipClick: (Command) -> Unit,
+    onCommandClick: (Command) -> Unit,
+    onAppClick: (InstalledApp) -> Unit,
 ) {
-    if (chipCommands.isEmpty()) return
+    if (chipItems.isEmpty()) return
 
     val rows = shortcutRows.coerceIn(1, 3)
 
@@ -1178,13 +1203,50 @@ private fun UnfocusedContent(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         maxLines = rows,
     ) {
-        for (command in chipCommands) {
-            CommandChip(
-                command = command,
-                groupColorHex = groupColorMap[command.id],
-                onClick = { onChipClick(command) },
-            )
+        for (item in chipItems) {
+            when (item) {
+                is ChipItem.Cmd -> CommandChip(
+                    command = item.command,
+                    groupColorHex = groupColorMap[item.command.id],
+                    onClick = { onCommandClick(item.command) },
+                )
+                is ChipItem.App -> AppChip(
+                    app = item.app,
+                    onClick = { onAppClick(item.app) },
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun AppChip(
+    app: InstalledApp,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .semantics { contentDescription = "Open ${app.label}" },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = app.icon,
+            contentDescription = "${app.label} icon",
+            modifier = Modifier.size(24.dp).clip(RoundedCornerShape(6.dp)),
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Text(
+            text = app.label,
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.SharedPreferences
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import sh.kavi.fasttravel.core.ChipRanking
 import sh.kavi.fasttravel.core.Command
 import sh.kavi.fasttravel.core.CommandParser
 import sh.kavi.fasttravel.core.CommandType
@@ -17,6 +18,9 @@ import sh.kavi.fasttravel.core.ParseInput
 import sh.kavi.fasttravel.core.ParseOutput
 import sh.kavi.fasttravel.core.Suggestion
 import sh.kavi.fasttravel.core.SuggestionProvider
+import sh.kavi.fasttravel.core.installedAppId
+import sh.kavi.fasttravel.core.isInstalledAppId
+import sh.kavi.fasttravel.core.parseInstalledAppId
 import sh.kavi.fasttravel.core.resolveIconUrl
 import sh.kavi.fasttravel.data.AutoIgnoreStore
 import sh.kavi.fasttravel.data.ConfigRepository
@@ -57,9 +61,10 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     private var config: FastTravelConfig? = null
     private var suggestionJob: Job? = null
     private var installedAppsJob: Job? = null
+    private var chipJob: Job? = null
 
-    private val _chipCommands = MutableStateFlow<List<Command>>(emptyList())
-    val chipCommands: StateFlow<List<Command>> = _chipCommands.asStateFlow()
+    private val _chipItems = MutableStateFlow<List<ChipItem>>(emptyList())
+    val chipItems: StateFlow<List<ChipItem>> = _chipItems.asStateFlow()
 
     private val _installedApps = MutableStateFlow<List<InstalledApp>>(emptyList())
     val installedApps: StateFlow<List<InstalledApp>> = _installedApps.asStateFlow()
@@ -77,7 +82,13 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
      */
     private val prefsListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (key == "shortcut_rows") updateChipCommands()
+            if (key == "shortcut_rows" || key == ThemePreferences.KEY_INSTALLED_APPS_ENABLED) {
+                updateChipCommands()
+            }
+            // Toggling installed apps changes whether app launches show under "Recent".
+            if (key == ThemePreferences.KEY_INSTALLED_APPS_ENABLED && _query.value.isBlank()) {
+                config?.let { _suggestions.value = getHistorySuggestions(it) }
+            }
         }
 
     // Auto-ignore tracking for false positive typos
@@ -138,17 +149,53 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         // ~4 chips per row fits the Figma spec's pill grid.
         val targetCount = (shortcutRows * 4).coerceAtLeast(4)
 
-        // Rank by frecency (usage frequency + recency); empty history falls back
-        // to config order. Shared with the extension via
-        // shared/test-fixtures/frecency.fixtures.json.
+        // Rank commands and (when enabled) launched installed apps together by frecency;
+        // empty history falls back to config order. Command frecency is shared with the
+        // extension via shared/test-fixtures/frecency.fixtures.json.
         val history = searchHistory.getHistory().map {
             Frecency.HistoryEntry(it.commandId, it.timestamp)
         }
+        val appsEnabled = themePrefs.installedAppsEnabled
+        val rankedIds = ChipRanking.rankedIds(
+            commandIds = standardCommands.map { it.id },
+            history = history,
+            now = System.currentTimeMillis(),
+            includeApps = appsEnabled,
+            limit = targetCount,
+        )
         val byId = standardCommands.associateBy { it.id }
-        _chipCommands.value = Frecency
-            .rank(standardCommands.map { it.id }, history, System.currentTimeMillis())
-            .mapNotNull { byId[it] }
-            .take(targetCount)
+
+        // Fast path: no app chips (cold start or toggle off) — resolve synchronously.
+        chipJob?.cancel()
+        if (rankedIds.none { isInstalledAppId(it) }) {
+            _chipItems.value = rankedIds.mapNotNull { id -> byId[id]?.let { ChipItem.Cmd(it) } }
+            return
+        }
+
+        // App chips need a PackageManager lookup + icon decode — resolve off the main thread.
+        chipJob = viewModelScope.launch {
+            val items = withContext(Dispatchers.Default) {
+                rankedIds.mapNotNull { id ->
+                    if (isInstalledAppId(id)) {
+                        val (pkg, activity) = parseInstalledAppId(id) ?: return@mapNotNull null
+                        InstalledAppResolver.findByComponent(getApplication(), pkg, activity)
+                            ?.let { ChipItem.App(it) }
+                    } else {
+                        byId[id]?.let { ChipItem.Cmd(it) }
+                    }
+                }
+            }
+            _chipItems.value = items
+        }
+    }
+
+    /**
+     * Record an installed-app launch in history (under its [installedAppId]) so it surfaces
+     * in "Recent" and ranks into the shortcut chips. The Activity performs the actual launch.
+     */
+    fun recordAppLaunch(app: InstalledApp) {
+        searchHistory.addEntry(app.label, installedAppId(app.packageName, app.activityName))
+        updateChipCommands()
     }
 
     private fun flattenCommands(groups: List<Group>): List<Command> = groups.flatMap { it.commands }
@@ -244,7 +291,7 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         }
 
         installedAppsJob?.cancel()
-        if (newQuery.isBlank()) {
+        if (newQuery.isBlank() || !themePrefs.installedAppsEnabled) {
             _installedApps.value = emptyList()
         } else {
             installedAppsJob = viewModelScope.launch {
@@ -293,20 +340,36 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         val history = searchHistory.getHistory()
         if (history.isEmpty()) return emptyList()
 
+        val appsEnabled = themePrefs.installedAppsEnabled
         val triggerMap = CommandParser.buildTriggerMap(config)
-        return history.distinctBy { it.query }.take(10).map { entry ->
-            val cmd = entry.commandId?.let { id ->
-                triggerMap.values.find { it.id == id }
+        return history.distinctBy { it.query }
+            // Hide installed-app launches from "Recent" when the feature is off.
+            .filter { appsEnabled || !isInstalledAppId(it.commandId) }
+            .take(10)
+            .mapNotNull { entry ->
+                val cid = entry.commandId
+                if (isInstalledAppId(cid)) {
+                    val (pkg, activity) = parseInstalledAppId(cid!!) ?: return@mapNotNull null
+                    val app = InstalledAppResolver.findByComponent(getApplication(), pkg, activity)
+                        ?: return@mapNotNull null  // app was uninstalled — drop the entry
+                    Suggestion(
+                        text = entry.query,
+                        displayText = app.label,
+                        isHistory = true,
+                        installedApp = app,
+                    )
+                } else {
+                    val cmd = cid?.let { id -> triggerMap.values.find { it.id == id } }
+                    Suggestion(
+                        text = entry.query,
+                        displayText = entry.query,
+                        commandTrigger = cmd?.triggers?.firstOrNull(),
+                        commandName = cmd?.name,
+                        commandIconUrl = cmd?.let { resolveIconUrl(it, DeviceType.Android) },
+                        isHistory = true,
+                    )
+                }
             }
-            Suggestion(
-                text = entry.query,
-                displayText = entry.query,
-                commandTrigger = cmd?.triggers?.firstOrNull(),
-                commandName = cmd?.name,
-                commandIconUrl = cmd?.let { resolveIconUrl(it, DeviceType.Android) },
-                isHistory = true,
-            )
-        }
     }
 
     fun onSearch(searchQuery: String) {

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -169,6 +169,7 @@ sealed class SettingsRoute(val route: String) {
     }
     data object IgnoreList : SettingsRoute("config/ignoreList")
     data object SearchHistoryScreen : SettingsRoute("search_history")
+    data object LocalSearch : SettingsRoute("local_search")
     data object About : SettingsRoute("about")
     data object Configuration : SettingsRoute("configuration")
     data object ImportExport : SettingsRoute("import_export")
@@ -439,6 +440,12 @@ fun SettingsNavHost(
                 snackbarHostState = snackbarHostState,
             )
         }
+        composable(SettingsRoute.LocalSearch.route) {
+            LocalSearchScreen(
+                navController = navController,
+                themePrefs = themePrefs,
+            )
+        }
         composable(SettingsRoute.About.route) {
             AboutScreen(navController = navController)
         }
@@ -570,6 +577,12 @@ fun SettingsHomeScreen(
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
                 NavigableListItem(
+                    headlineText = "Local search",
+                    supportingText = "Installed apps",
+                    onClick = { navController.navigate(SettingsRoute.LocalSearch.route) },
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+                NavigableListItem(
                     headlineText = "Ignore list",
                     supportingText = pluralize(config?.ignoreList?.size ?: 0, "item"),
                     onClick = { navController.navigate(SettingsRoute.IgnoreList.route) },
@@ -589,6 +602,73 @@ fun SettingsHomeScreen(
             Spacer(modifier = Modifier.height(32.dp))
         }
     }
+}
+
+// ==================== Local Search Screen ====================
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocalSearchScreen(
+    navController: NavHostController,
+    themePrefs: ThemePreferences,
+) {
+    var installedAppsEnabled by remember { mutableStateOf(themePrefs.installedAppsEnabled) }
+
+    Scaffold(
+        topBar = { SettingsTopBar(title = "Local search", onBack = { navController.popBackStack() }) },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+            SettingsCard {
+                SettingsSwitchItem(
+                    headlineText = "Show installed apps",
+                    supportingText = "Launch installed apps from search results, recents, and shortcuts.",
+                    checked = installedAppsEnabled,
+                    onCheckedChange = {
+                        installedAppsEnabled = it
+                        themePrefs.installedAppsEnabled = it
+                    },
+                )
+            }
+            // Future on-device, non-web options (e.g. the `s` local file-search command,
+            // issue #25) will live on this screen.
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+fun SettingsSwitchItem(
+    headlineText: String,
+    supportingText: String? = null,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(text = headlineText, style = MaterialTheme.typography.bodyLarge)
+        },
+        supportingContent = if (supportingText != null) {
+            {
+                Text(
+                    text = supportingText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else null,
+        trailingContent = {
+            Switch(checked = checked, onCheckedChange = onCheckedChange)
+        },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        modifier = Modifier.clickable { onCheckedChange(!checked) },
+    )
 }
 
 // ==================== Configuration Screen ====================

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/core/AppLauncherIdTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/core/AppLauncherIdTest.kt
@@ -1,0 +1,54 @@
+package sh.kavi.fasttravel.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Installed apps are stored in history under a namespaced pseudo-command id so they
+ * can be ranked alongside real commands by [Frecency]. These helpers must round-trip
+ * a (package, activity) pair through that id format unambiguously.
+ */
+class AppLauncherIdTest {
+
+    @Test
+    fun `installedAppId builds the app prefixed id`() {
+        assertEquals(
+            "app:com.google.android.apps.maps/com.google.android.maps.MapsActivity",
+            installedAppId(
+                "com.google.android.apps.maps",
+                "com.google.android.maps.MapsActivity",
+            ),
+        )
+    }
+
+    @Test
+    fun `isInstalledAppId distinguishes app ids from command ids and null`() {
+        assertTrue(isInstalledAppId("app:com.foo/com.foo.Main"))
+        assertFalse(isInstalledAppId("google"))
+        assertFalse(isInstalledAppId(null))
+    }
+
+    @Test
+    fun `parseInstalledAppId round-trips a package and activity`() {
+        val pkg = "com.foo.bar"
+        val activity = "com.foo.bar.MainActivity"
+        val parsed = parseInstalledAppId(installedAppId(pkg, activity))
+        assertEquals(pkg to activity, parsed)
+    }
+
+    @Test
+    fun `parseInstalledAppId keeps inner-class activity names intact`() {
+        // Activity names can contain '$' for inner classes; only the first '/'
+        // separates package from activity.
+        val parsed = parseInstalledAppId("app:com.foo/com.foo.Outer\$Inner")
+        assertEquals("com.foo" to "com.foo.Outer\$Inner", parsed)
+    }
+
+    @Test
+    fun `parseInstalledAppId returns null for a non-app id`() {
+        assertNull(parseInstalledAppId("google"))
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/core/ChipRankingTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/core/ChipRankingTest.kt
@@ -1,0 +1,85 @@
+package sh.kavi.fasttravel.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * [ChipRanking] decides which command / installed-app ids fill the empty-input
+ * shortcut grid. Apps only become chips once they've been launched (i.e. appear in
+ * history) and only when the installed-apps toggle is on. Ranking itself is delegated
+ * to [Frecency], so this verifies the candidate-set construction + toggle gating.
+ */
+class ChipRankingTest {
+
+    private val now = 1_000_000_000_000L
+    private val dayMs = 86_400_000L
+
+    private fun used(id: String, daysAgo: Long) =
+        Frecency.HistoryEntry(id, now - daysAgo * dayMs)
+
+    @Test
+    fun `cold start with no history keeps command config order`() {
+        val ranked = ChipRanking.rankedIds(
+            commandIds = listOf("g", "yt", "r"),
+            history = emptyList(),
+            now = now,
+            includeApps = true,
+            limit = 8,
+        )
+        assertEquals(listOf("g", "yt", "r"), ranked)
+    }
+
+    @Test
+    fun `launched app becomes a candidate when apps are enabled`() {
+        val appId = installedAppId("com.maps", "com.maps.Main")
+        val ranked = ChipRanking.rankedIds(
+            commandIds = listOf("g", "yt"),
+            history = listOf(used(appId, daysAgo = 0)),
+            now = now,
+            includeApps = true,
+            limit = 8,
+        )
+        assertTrue(ranked.contains(appId), "recently launched app should be a chip candidate")
+    }
+
+    @Test
+    fun `app candidates are dropped when apps are disabled`() {
+        val appId = installedAppId("com.maps", "com.maps.Main")
+        val ranked = ChipRanking.rankedIds(
+            commandIds = listOf("g", "yt"),
+            history = listOf(used(appId, daysAgo = 0)),
+            now = now,
+            includeApps = false,
+            limit = 8,
+        )
+        assertFalse(ranked.contains(appId), "apps must not appear as chips when the toggle is off")
+        assertEquals(listOf("g", "yt"), ranked)
+    }
+
+    @Test
+    fun `a recently used app outranks an unused command`() {
+        val appId = installedAppId("com.maps", "com.maps.Main")
+        val ranked = ChipRanking.rankedIds(
+            commandIds = listOf("g", "yt"),
+            history = listOf(used(appId, daysAgo = 0)),
+            now = now,
+            includeApps = true,
+            limit = 8,
+        )
+        assertEquals(appId, ranked.first(), "a used app should rank above never-used commands")
+    }
+
+    @Test
+    fun `limit caps the number of chips`() {
+        val ranked = ChipRanking.rankedIds(
+            commandIds = listOf("a", "b", "c", "d", "e"),
+            history = emptyList(),
+            now = now,
+            includeApps = true,
+            limit = 3,
+        )
+        assertEquals(listOf("a", "b", "c"), ranked)
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
@@ -1,0 +1,70 @@
+package sh.kavi.fasttravel.data
+
+import android.content.SharedPreferences
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ThemePreferencesTest {
+
+    private fun newPrefs(): ThemePreferences = ThemePreferences(TPFakePrefs())
+
+    @Test
+    fun `installedAppsEnabled defaults to on`() {
+        // Default must stay ON so existing users keep today's app-launch behavior.
+        assertTrue(newPrefs().installedAppsEnabled)
+    }
+
+    @Test
+    fun `installedAppsEnabled persists when toggled off and back on`() {
+        val prefs = newPrefs()
+
+        prefs.installedAppsEnabled = false
+        assertFalse(prefs.installedAppsEnabled)
+
+        prefs.installedAppsEnabled = true
+        assertTrue(prefs.installedAppsEnabled)
+    }
+}
+
+private class TPFakePrefs : SharedPreferences {
+    private val storage = mutableMapOf<String, Any?>()
+
+    override fun getAll(): MutableMap<String, *> = storage.toMutableMap()
+    override fun getString(key: String?, defValue: String?): String? = storage[key] as? String ?: defValue
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? =
+        storage[key] as? MutableSet<String> ?: defValues
+    override fun getInt(key: String?, defValue: Int): Int = (storage[key] as? Int) ?: defValue
+    override fun getLong(key: String?, defValue: Long): Long = (storage[key] as? Long) ?: defValue
+    override fun getFloat(key: String?, defValue: Float): Float = (storage[key] as? Float) ?: defValue
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean = (storage[key] as? Boolean) ?: defValue
+    override fun contains(key: String?): Boolean = storage.containsKey(key)
+    override fun edit(): SharedPreferences.Editor = TPFakeEditor(storage)
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+}
+
+private class TPFakeEditor(private val storage: MutableMap<String, Any?>) : SharedPreferences.Editor {
+    private val pending = mutableMapOf<String, Any?>()
+    private val removed = mutableSetOf<String>()
+    private var clearAll = false
+
+    override fun putString(key: String?, value: String?) = apply { if (key != null) pending[key] = value }
+    override fun putStringSet(key: String?, values: MutableSet<String>?) = apply { if (key != null) pending[key] = values }
+    override fun putInt(key: String?, value: Int) = apply { if (key != null) pending[key] = value }
+    override fun putLong(key: String?, value: Long) = apply { if (key != null) pending[key] = value }
+    override fun putFloat(key: String?, value: Float) = apply { if (key != null) pending[key] = value }
+    override fun putBoolean(key: String?, value: Boolean) = apply { if (key != null) pending[key] = value }
+    override fun remove(key: String?) = apply { if (key != null) removed.add(key) }
+    override fun clear() = apply { clearAll = true }
+    override fun commit(): Boolean { flush(); return true }
+    override fun apply() = flush()
+
+    private fun flush() {
+        if (clearAll) storage.clear()
+        for (key in removed) storage.remove(key)
+        for ((k, v) in pending) storage[k] = v
+        pending.clear(); removed.clear(); clearAll = false
+    }
+}


### PR DESCRIPTION
## What & why

Installed apps were already launchable from a dedicated row while typing, but were **not** recorded in history, didn't rank into the empty-input shortcut chips, and had **no setting**. This promotes them to first-class, command-like entries (per the user request: apps treated as commands "for all intents and purposes", additive so name clashes still show the real command/search).

## Changes

- **History + chips:** an app launch is recorded under an `app:<package>/<activity>` pseudo-command id (`AppLauncherId`), so it surfaces in **Recent** and ranks into the shortcut chips alongside commands via the shared `Frecency` machinery. `ChipRanking` builds the mixed command+app candidate set; chips render as a `ChipItem` union (`CommandChip` / new `AppChip`).
- **Toggle (default ON):** a single "Show installed apps" switch gates the whole feature — live row, Recent, and chips. Turning it off hides apps everywhere and live-refreshes via the existing prefs listener.
- **New "Local search" settings submenu:** houses the toggle now; placeholder for future on-device options (e.g. the `s` local file-search command, #25). Adds a reusable `SettingsSwitchItem`.
- **Clash handling:** apps are *additive* — command autocomplete, the matched-command chip, and the API/default-search suggestion list are untouched, so a clashing name still shows the real command + Google suggestion.

## Hybrid behavior (as designed)

The live typing apps row is unchanged; apps additionally now appear in Recent + chips once launched.

## Tests / verification

- New unit tests: `AppLauncherIdTest` (id round-trip), `ChipRankingTest` (frecency mixing + toggle gating), `ThemePreferencesTest` (default-ON invariant). `ThemePreferences` gained a `SharedPreferences` constructor to enable testing.
- `./gradlew testDebugUnitTest` — all pass. `./gradlew assembleDebug` — builds.
- Manual on-device checks recommended (toggle off→on, launch→Recent/chip, name-clash still shows command + Google).

## Release

Intended to ship as **minor 2.0.4 → 2.1.0** via the `release.yml` workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)