### PR TITLE
fix(android): keep uninstalled apps in history/chips, toast on launch

### DIFF
--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/InstalledAppResolver.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/InstalledAppResolver.kt
@@ -103,6 +103,28 @@ object InstalledAppResolver {
         )
     }
 
+    /**
+     * Always returns an [InstalledApp] for a stored history/chip entry: the live app when
+     * installed, otherwise a placeholder using the stored [label] and the system default
+     * app icon. This keeps a previously-launched app visible (and re-launchable after a
+     * reinstall) instead of vanishing while it's uninstalled — the launch site shows a
+     * toast if it's still gone when tapped.
+     */
+    fun resolveForHistory(
+        context: Context,
+        packageName: String,
+        activityName: String,
+        label: String,
+    ): InstalledApp {
+        return findByComponent(context, packageName, activityName)
+            ?: InstalledApp(
+                label = label,
+                packageName = packageName,
+                activityName = activityName,
+                icon = context.packageManager.defaultActivityIcon,
+            )
+    }
+
     fun launchIntent(app: InstalledApp): Intent {
         return Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_LAUNCHER)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -1,11 +1,13 @@
 package sh.kavi.fasttravel.ui
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -378,6 +380,19 @@ fun SearchScreen(
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
+    // Launch an installed app, recording the launch on success. A launched app stays in
+    // history/chips even after it's uninstalled (it may be reinstalled); if it's still gone
+    // when tapped, startActivity throws — show a toast instead of crashing. The entry is
+    // kept, so it works again once the app is reinstalled.
+    val launchApp: (InstalledApp) -> Unit = { app ->
+        try {
+            context.startActivity(InstalledAppResolver.launchIntent(app))
+            viewModel.recordAppLaunch(app)
+        } catch (_: ActivityNotFoundException) {
+            Toast.makeText(context, "${app.label} is no longer installed", Toast.LENGTH_SHORT).show()
+        }
+    }
+
     var isSearchFocused by remember { mutableStateOf(false) }
 
     val isDark = isSystemInDarkTheme()
@@ -589,10 +604,7 @@ fun SearchScreen(
                     },
                     onSuggestionPopulate = { s -> viewModel.onQueryChanged(s.text) },
                     onHistoryRemove = { q -> viewModel.removeHistoryEntry(q) },
-                    onAppLaunch = { app ->
-                        viewModel.recordAppLaunch(app)
-                        context.startActivity(InstalledAppResolver.launchIntent(app))
-                    },
+                    onAppLaunch = launchApp,
                     onCommandAutocompletePick = { cmd ->
                         val trig = cmd.triggers.firstOrNull() ?: return@FocusedContent
                         if (cmd.type == CommandType.Redirect) {
@@ -617,10 +629,7 @@ fun SearchScreen(
                             keyboardController?.show()
                         }
                     },
-                    onAppClick = { app ->
-                        viewModel.recordAppLaunch(app)
-                        context.startActivity(InstalledAppResolver.launchIntent(app))
-                    },
+                    onAppClick = launchApp,
                 )
             }
         }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -152,7 +152,8 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         // Rank commands and (when enabled) launched installed apps together by frecency;
         // empty history falls back to config order. Command frecency is shared with the
         // extension via shared/test-fixtures/frecency.fixtures.json.
-        val history = searchHistory.getHistory().map {
+        val rawHistory = searchHistory.getHistory()
+        val history = rawHistory.map {
             Frecency.HistoryEntry(it.commandId, it.timestamp)
         }
         val appsEnabled = themePrefs.installedAppsEnabled
@@ -172,14 +173,26 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
             return
         }
 
+        // Most-recent stored label per app id, used as the chip label (and the placeholder
+        // label while the app is uninstalled). rawHistory is newest-first.
+        val appLabels = HashMap<String, String>()
+        for (h in rawHistory) {
+            val c = h.commandId
+            if (isInstalledAppId(c) && c !in appLabels) appLabels[c!!] = h.query
+        }
+
         // App chips need a PackageManager lookup + icon decode — resolve off the main thread.
         chipJob = viewModelScope.launch {
             val items = withContext(Dispatchers.Default) {
                 rankedIds.mapNotNull { id ->
                     if (isInstalledAppId(id)) {
                         val (pkg, activity) = parseInstalledAppId(id) ?: return@mapNotNull null
-                        InstalledAppResolver.findByComponent(getApplication(), pkg, activity)
-                            ?.let { ChipItem.App(it) }
+                        // Keep ranking a launched app even while uninstalled (placeholder
+                        // icon); the chip toasts if it's still gone when tapped.
+                        val app = InstalledAppResolver.resolveForHistory(
+                            getApplication(), pkg, activity, appLabels[id] ?: pkg,
+                        )
+                        ChipItem.App(app)
                     } else {
                         byId[id]?.let { ChipItem.Cmd(it) }
                     }
@@ -350,8 +363,10 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
                 val cid = entry.commandId
                 if (isInstalledAppId(cid)) {
                     val (pkg, activity) = parseInstalledAppId(cid!!) ?: return@mapNotNull null
-                    val app = InstalledAppResolver.findByComponent(getApplication(), pkg, activity)
-                        ?: return@mapNotNull null  // app was uninstalled — drop the entry
+                    // Keep showing a launched app even while it's uninstalled (it may be
+                    // reinstalled). resolveForHistory falls back to a placeholder icon; the
+                    // launch site toasts if it's still gone when tapped.
+                    val app = InstalledAppResolver.resolveForHistory(getApplication(), pkg, activity, entry.query)
                     Suggestion(
                         text = entry.query,
                         displayText = app.label,


### PR DESCRIPTION
## Behavior

A launched app (recorded in Recent + shortcut chips by #54) **stays** in history/chips even after it's uninstalled — it is **not** removed or forgotten, because the user may reinstall it, at which point it simply works again.

- **While uninstalled:** the entry still shows, rendered with the system default app icon (`InstalledAppResolver.resolveForHistory` returns the live app when installed, else a placeholder using the stored label + `PackageManager.defaultActivityIcon`). Previously these entries were filtered out (vanished).
- **Tapping it while still gone:** all app launches route through one `launchApp` helper that catches `ActivityNotFoundException` and shows a **"<app> is no longer installed"** toast instead of crashing. Launches are recorded only on success.
- **After reinstall:** `resolveForHistory` resolves the live app again, so the entry's real icon returns and it launches normally.

## Why the change from the first revision

The initial version *removed* the entry from history on a failed launch. Per review, that's wrong — apps get reinstalled, so the entry should persist; we just need the access to be graceful (toast).

## Tests

`./gradlew testDebugUnitTest` passes; `assembleDebug` builds. Follow-up to #54 — candidate for a 2.1.1 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
