### PR TITLE
chore: roll back 2.1.1 bump + harden release to self-clean on publish failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         run: node tools/bump-version.mjs beta ${{ github.event.pull_request.number }}
 
       - name: Commit and tag version bump
+        id: commit_bump
         if: github.event_name == 'workflow_dispatch'
         run: |
           git add package.json extension/package.json extension/manifest.json \
@@ -194,3 +195,22 @@ jobs:
             firefox-extension.zip
             android/app/build/outputs/apk/release/app-release.apk
             android/app/build/outputs/bundle/release/app-release.aab
+
+      # ── Roll back the version bump if anything after it failed ─────────────
+      # The bump commit + tag are pushed to `main` before publishing, so a failed
+      # publish (e.g. a store still in initial review rejecting a stacked upload)
+      # would otherwise strand them on `main` and block a clean re-run. Undo both
+      # so the workflow can simply be re-run once the cause is resolved. Only runs
+      # when the bump was actually committed/pushed (commit_bump succeeded); uses a
+      # revert + normal push (RELEASE_PAT bypasses required checks, but not force).
+      - name: Roll back version bump on failure
+        if: failure() && github.event_name == 'workflow_dispatch' && steps.commit_bump.outcome == 'success'
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          echo "::warning::Release failed after bumping to v$VERSION — reverting the bump commit + tag so the run can be retried cleanly."
+          # Delete the tag on the remote and locally (no-op if already gone).
+          git push origin ":refs/tags/v$VERSION" || true
+          git tag -d "v$VERSION" 2>/dev/null || true
+          # Revert the bump commit (HEAD — nothing is committed after it) and push.
+          git revert --no-edit HEAD
+          git push origin HEAD:main

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "sh.kavi.fasttravel"
         minSdk = 26
         targetSdk = 36
-        versionCode = 8
-        versionName = "2.1.1"
+        versionCode = 7
+        versionName = "2.1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Fast Travel",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "default_locale": "en",
   "description": "Turn your search bar into a command line for the web. Define short triggers and jump straight to the sites and searches you use.",
   "permissions": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-travel-extension",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "private": true,
   "description": "Fast Travel browser extension",
   "scripts": {

--- a/extension/src/options/screens/about.ts
+++ b/extension/src/options/screens/about.ts
@@ -11,7 +11,7 @@ export function renderAbout(main: HTMLElement): void {
       "p",
       null,
       "Fast Travel ",
-      el("span", { class: "version-badge" }, "v2.1.1"),
+      el("span", { class: "version-badge" }, "v2.1.0"),
     ),
   );
   body.appendChild(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-travel",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "private": true,
   "description": "Command-based search engine replacement - browser extension + native mobile app",
   "workspaces": [


### PR DESCRIPTION
Holds the 2.1.1 release and unblocks a clean re-run later. Two changes:

## 1. Roll back the stranded 2.1.1 version bump
The 2.1.1 release run bumped + tagged before publishing, then **failed** at *Publish to Chrome Web Store* (`ITEM_NOT_UPDATABLE` — 2.1.0 is still in the store's initial review, so Chrome refuses a stacked upload). Firefox/Play/GitHub-release were skipped. Net: nothing published, but the bump commit + `v2.1.1` tag were left on `main`.

This reverts the bump so `main` is back at **2.1.0** (versionCode 7). The `v2.1.1` tag is deleted separately (out of band).

## 2. Harden `release.yml` to self-clean on failure
New `if: failure()` step (gated on the bump having actually been committed/pushed) that **reverts the bump commit and deletes the tag** when a later step fails — so a failed publish no longer strands a version on `main` and the workflow can simply be re-run once the cause is resolved. Uses a revert + normal push (the `RELEASE_PAT` bypasses required checks but not force-push).

## Holding the release
No new release is triggered. Once the stores approve the in-review 2.1.0, re-running the Release workflow (`bump=patch`) will cleanly produce 2.1.1 again. (Open infra issues: #36/#37/#38.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
