### PR TITLE
ci(auto-update-domains): reuse RELEASE_PAT so the bot PR auto-merges

### DIFF
--- a/.github/workflows/auto-update-domains.yml
+++ b/.github/workflows/auto-update-domains.yml
@@ -12,10 +12,11 @@ name: Auto-update domains
 #   3. The patched config and auto-update mapping must validate.
 #
 # NOTE: For the required CI checks to actually run on the bot's PR (and thus for
-# auto-merge to complete), set an `AUTOMATION_PAT` repo secret — a fine-grained
-# PAT with contents+pull-requests write. PRs opened with the default GITHUB_TOKEN
-# do NOT trigger other workflows, so without the PAT the PR is opened but its
-# required checks never run and it must be merged by hand.
+# auto-merge to complete), this uses the `RELEASE_PAT` repo secret — a maintainer
+# PAT with contents+pull-requests write (shared with the release workflow). PRs
+# opened with the default GITHUB_TOKEN do NOT trigger other workflows, so without
+# the PAT the PR is opened but its required checks never run and it must be
+# merged by hand.
 
 on:
   schedule:
@@ -36,7 +37,7 @@ jobs:
         with:
           # Use the PAT (if set) so the branch push is attributed to it and the
           # PR triggers CI; falls back to the default token otherwise.
-          token: ${{ secrets.AUTOMATION_PAT || github.token }}
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Setup Node.js
         # actions/setup-node@v4.4.0
@@ -58,7 +59,7 @@ jobs:
 
       - name: Open PR with domain updates (if any)
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATION_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
         run: |
           if git diff --quiet shared/config/default-config.json; then
             echo "No config changes — nothing to commit."


### PR DESCRIPTION
## What
Point the **Auto-update domains** workflow at the existing `RELEASE_PAT` secret instead of an unconfigured `AUTOMATION_PAT` (two token references + the explanatory note).

## Why
The weekly domain bot was failing. The most recent run (2026-06-22) patched the config, pushed a branch, then errored at PR creation:

> `pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests`

Root cause is the well-known GitHub guard: PRs/pushes by the default `GITHUB_TOKEN` don't trigger other workflows, so the bot PR's required checks never run and auto-merge can't complete. Using a real PAT identity fixes both PR creation and CI triggering.

Rather than add a separate `AUTOMATION_PAT`, this reuses the maintainer `RELEASE_PAT` (now also scoped with **Pull requests: write**), shared with the release workflow. The `|| github.token` fallback is preserved.

## Companion repo changes (done out-of-band)
- ✅ `RELEASE_PAT` updated with Pull requests: write
- ✅ "Allow auto-merge" enabled on the repo
- ✅ Orphaned `auto-update-domains/2026-06-22` branch deleted

## Verify after merge
Actions → Auto-update domains → Run workflow → confirm it opens a PR whose 4 required checks run and which auto-merges when green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)