### PR TITLE
fix(extension): apply theme before first paint to remove new-tab flash

### DIFF
--- a/extension/scripts/build.mjs
+++ b/extension/scripts/build.mjs
@@ -18,7 +18,6 @@ const entryPoints = [
   "src/newtab/newtab.ts",
   "src/options/options.ts",
   "src/popup/popup.ts",
-  "src/ui/apply-theme.ts",
 ];
 
 await esbuild.build({
@@ -31,6 +30,20 @@ await esbuild.build({
   minify: false,
   splitting: true,
   loader: { ".json": "json" },
+});
+
+// apply-theme is loaded as a render-blocking CLASSIC <script> (not a module) so
+// it runs synchronously before first paint and applies the saved theme without a
+// FOUC flash. A classic <script> can't load an ESM file, so emit it as a
+// standalone IIFE (no splitting/imports) at dist/ui/apply-theme.js.
+await esbuild.build({
+  entryPoints: [resolve(root, "src/ui/apply-theme.ts")],
+  bundle: true,
+  outfile: resolve(dist, "ui/apply-theme.js"),
+  format: "iife",
+  target: "es2022",
+  sourcemap: true,
+  minify: false,
 });
 
 // Copy static files

--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -15,25 +15,10 @@ const REFRESH_INTERVAL_KEY = "fast-travel-refresh-interval";
 const LAST_SYNCED_KEY = "fast-travel-last-synced";
 const REFRESH_ALARM = "config-refresh";
 const CONFIG_FETCH_TIMEOUT_MS = 5000;
-const APPEARANCE_KEY = "fast-travel-appearance";
 
-/**
- * Keep chrome.storage.session mirroring the appearance prefs from
- * chrome.storage.sync so the pre-paint apply-theme script can read them
- * without an async round-trip to sync storage (which is slower and may be
- * unavailable offline). Called on install, startup, and whenever sync changes.
- */
-async function syncAppearanceToSession(): Promise<void> {
-  try {
-    const v = await chrome.storage.sync.get(APPEARANCE_KEY);
-    const prefs = v[APPEARANCE_KEY];
-    if (prefs !== undefined) {
-      await chrome.storage.session.set({ [APPEARANCE_KEY]: prefs });
-    }
-  } catch {
-    // storage.sync or storage.session may be unavailable; pre-paint falls back to defaults
-  }
-}
+// Appearance prefs are mirrored to localStorage by the page (appearance.ts) and
+// read synchronously before first paint by apply-theme.ts. The service worker is
+// no longer involved in theming (it has no localStorage and runs async).
 
 type RefreshInterval = "manual" | "daily" | "weekly";
 
@@ -280,7 +265,6 @@ chrome.runtime.onInstalled.addListener(async () => {
   }
   scheduleRefresh();
   installSearchRedirectRule();
-  syncAppearanceToSession();
 });
 
 // Reinstall the rule on every worker startup — dynamic rules persist across
@@ -289,26 +273,15 @@ chrome.runtime.onInstalled.addListener(async () => {
 // Also refresh config unless user has locally-edited (dirty) config.
 chrome.runtime.onStartup.addListener(async () => {
   installSearchRedirectRule();
-  syncAppearanceToSession();
   if (!(await isDirty())) {
     fetchAndStoreConfig();
   }
 });
 
 // When the refresh interval changes in settings, reschedule the alarm.
-// Also mirror appearance prefs from sync -> session so the pre-paint script
-// sees fresh values on the next page load.
 chrome.storage.onChanged.addListener((changes, areaName) => {
   if (areaName === "local" && changes[REFRESH_INTERVAL_KEY]) {
     scheduleRefresh();
-  }
-  if (areaName === "sync" && changes[APPEARANCE_KEY]) {
-    const newValue = changes[APPEARANCE_KEY].newValue;
-    if (newValue === undefined) {
-      chrome.storage.session.remove(APPEARANCE_KEY).catch(() => {});
-    } else {
-      chrome.storage.session.set({ [APPEARANCE_KEY]: newValue }).catch(() => {});
-    }
   }
 });
 

--- a/extension/src/newtab/newtab.html
+++ b/extension/src/newtab/newtab.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fast Travel</title>
-    <script type="module" src="../ui/apply-theme.js"></script>
+    <!-- Classic (non-module) so it's render-blocking and runs synchronously
+         before first paint — applies the saved theme to avoid a FOUC flash. -->
+    <script src="../ui/apply-theme.js"></script>
     <link rel="stylesheet" href="../ui/tokens.css" />
     <link rel="stylesheet" href="newtab.css" />
   </head>

--- a/extension/src/options/options.html
+++ b/extension/src/options/options.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fast Travel — Settings</title>
-    <script type="module" src="../ui/apply-theme.js"></script>
+    <!-- Classic (non-module) so it's render-blocking and runs synchronously
+         before first paint — applies the saved theme to avoid a FOUC flash. -->
+    <script src="../ui/apply-theme.js"></script>
     <link rel="stylesheet" href="../ui/tokens.css" />
     <link rel="stylesheet" href="options.css" />
   </head>

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fast Travel</title>
-    <script type="module" src="../ui/apply-theme.js"></script>
+    <!-- Classic (non-module) so it's render-blocking and runs synchronously
+         before first paint — applies the saved theme to avoid a FOUC flash. -->
+    <script src="../ui/apply-theme.js"></script>
     <link rel="stylesheet" href="../ui/tokens.css" />
     <link rel="stylesheet" href="popup.css" />
   </head>

--- a/extension/src/ui/appearance.ts
+++ b/extension/src/ui/appearance.ts
@@ -15,12 +15,27 @@ export interface AppearancePrefs {
 const STORAGE_KEY = "fast-travel-appearance";
 const DEFAULTS: AppearancePrefs = { mode: "system", variant: "material", shape: "pill" };
 
+/**
+ * Mirror prefs to localStorage so the pre-paint shim (apply-theme.ts) can read
+ * them synchronously before first paint — chrome.storage is async-only and would
+ * paint the wrong theme first (FOUC). Page-only; wrapped because localStorage may
+ * be unavailable (the shim then falls back to system via matchMedia).
+ */
+function mirrorToLocalStorage(prefs: AppearancePrefs): void {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    } catch {
+        // ignore — pre-paint falls back to system
+    }
+}
+
 export async function getAppearance(): Promise<AppearancePrefs> {
     const stored = await chrome.storage.sync.get(STORAGE_KEY);
     return { ...DEFAULTS, ...(stored[STORAGE_KEY] ?? {}) };
 }
 
 export async function setAppearance(prefs: AppearancePrefs): Promise<void> {
+    mirrorToLocalStorage(prefs);
     await chrome.storage.sync.set({ [STORAGE_KEY]: prefs });
 }
 
@@ -35,6 +50,10 @@ export function subscribe(listener: (prefs: AppearancePrefs) => void): () => voi
 }
 
 export function applyAppearance(prefs: AppearancePrefs) {
+    // Refresh the synchronous mirror every time prefs are applied (each page's
+    // init applies the chrome.storage.sync source of truth), so the next page
+    // load's pre-paint shim reads an up-to-date value.
+    mirrorToLocalStorage(prefs);
     const html = document.documentElement;
     const resolvedMode = prefs.mode === "system"
         ? (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")

--- a/extension/src/ui/apply-theme.ts
+++ b/extension/src/ui/apply-theme.ts
@@ -1,18 +1,37 @@
 /**
- * Applied to <html> before first paint to avoid FOUC.
+ * Pre-paint theme shim. Loaded as a render-blocking *classic* script (NOT a
+ * module — see newtab/options/popup HTML) so it executes synchronously before
+ * first paint, preventing a theme flash (FOUC) in either direction.
  *
- * Reads the session-mirrored appearance prefs (populated by the service worker
- * from chrome.storage.sync on install/startup/change) and applies them.
+ * chrome.storage is async-only and can't be read before paint, so this reads the
+ * synchronous localStorage mirror written by appearance.ts (setAppearance /
+ * applyAppearance). "system" mode resolves via matchMedia. The full source of
+ * truth (chrome.storage.sync) is reconciled a moment later by each page's init
+ * (applyAppearance), which also refreshes the mirror.
+ *
+ * Kept self-contained (no imports) so esbuild emits it as a standalone IIFE that
+ * a classic <script> can load (MV3 CSP `script-src 'self'` forbids inline). The
+ * dataset logic mirrors applyAppearance() in appearance.ts — keep them in sync.
  */
-import type { AppearancePrefs } from "./appearance.js";
-
-(async () => {
+(() => {
     try {
-        const session = await chrome.storage.session.get("fast-travel-appearance");
-        const { applyAppearance } = await import("./appearance.js");
-        const defaults: AppearancePrefs = { mode: "system", variant: "material", shape: "pill" };
-        applyAppearance({ ...defaults, ...(session["fast-travel-appearance"] ?? {}) });
+        const raw = localStorage.getItem("fast-travel-appearance");
+        const p = raw ? JSON.parse(raw) : null;
+        const mode: string = p?.mode ?? "system";
+        const variant: string = p?.variant ?? "material";
+        const shape: string = p?.shape ?? "pill";
+        const dark =
+            mode === "system"
+                ? matchMedia("(prefers-color-scheme: dark)").matches
+                : mode === "dark";
+        const el = document.documentElement;
+        // AMOLED is a dark variant regardless of resolved mode (see appearance.ts).
+        el.dataset.mode = variant === "amoled" ? "dark" : dark ? "dark" : "light";
+        el.dataset.variant = variant;
+        el.dataset.shape = shape;
+        if (p?.accent) el.style.setProperty("--custom-accent", p.accent);
     } catch {
-        // Fallback to defaults — applyAppearance has defaults
+        // Fall back to the CSS :root defaults (light). The Material-You accent
+        // palette (if any) is applied later, additively, by applyAppearance().
     }
 })();

--- a/extension/tests/e2e/theme-flash.spec.ts
+++ b/extension/tests/e2e/theme-flash.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "./fixtures";
+import type { Page, BrowserContext } from "@playwright/test";
+
+// Theme-FOUC regression tests.
+//
+// The new tab must paint the *selected* theme on the very first frame — no white
+// flash for a dark user, and no reverse (dark) flash for a user who picked light
+// while their OS is dark.
+//
+// We capture the first painted frame by installing, via addInitScript (which runs
+// before any of the page's own scripts), a requestAnimationFrame callback that
+// records document.body's computed background color. rAF fires right before the
+// first paint, so it reflects exactly what the user first sees. The same init
+// script seeds localStorage so the render-blocking pre-paint shim can read the
+// selected theme synchronously.
+
+const LIGHT_BG = "rgb(245, 242, 236)"; // --bg #f5f2ec
+const DARK_BG = "rgb(14, 16, 32)"; //    --bg #0e1020
+
+type Prefs = { mode: string; variant: string; shape: string };
+
+async function firstFrameBg(
+  context: BrowserContext,
+  extensionId: string,
+  prefs: Prefs | null,
+  os: "dark" | "light",
+): Promise<string> {
+  const page: Page = await context.newPage();
+  // Isolate the pre-paint shim: block the deferred main bundle so its async
+  // re-apply (applyAppearance(await getAppearance()) from chrome.storage.sync)
+  // can't race the first-frame capture. In real use sync and the localStorage
+  // mirror are written together (setAppearance), so they agree and the shim's
+  // first-paint value is also the final value — this isolates exactly that.
+  await page.route("**/newtab.js", (route) => route.abort());
+  await page.addInitScript((p) => {
+    const w = window as unknown as { __bg?: string | null };
+    if (p) {
+      try {
+        localStorage.setItem("fast-travel-appearance", JSON.stringify(p));
+      } catch {
+        /* ignore */
+      }
+    }
+    w.__bg = null;
+    // Record the background of the first frame that actually has a <body> to
+    // paint. rAF fires immediately before that paint, so this is what the user
+    // first sees. Re-arm until <body> exists, then capture exactly once.
+    const capture = () => {
+      if (document.body) {
+        w.__bg = getComputedStyle(document.body).backgroundColor;
+      } else {
+        requestAnimationFrame(capture);
+      }
+    };
+    requestAnimationFrame(capture);
+  }, prefs);
+  await page.emulateMedia({ colorScheme: os });
+  await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
+  await page.waitForFunction(
+    () => (window as unknown as { __bg?: string | null }).__bg !== null,
+  );
+  return page.evaluate(() => (window as unknown as { __bg?: string | null }).__bg ?? "");
+}
+
+// System mode resolves from the OS, so this passes regardless of the fix; it is a
+// guard against system resolution regressing. The discriminating cases below
+// (explicit theme opposite the OS) are what prove the flash/reverse-flash fix.
+test("system theme on a dark OS paints dark on the first frame", async ({
+  context,
+  extensionId,
+}) => {
+  const bg = await firstFrameBg(
+    context,
+    extensionId,
+    { mode: "system", variant: "material", shape: "pill" },
+    "dark",
+  );
+  expect(bg).toBe(DARK_BG);
+});
+
+test("explicit dark theme on a light OS paints dark on the first frame", async ({
+  context,
+  extensionId,
+}) => {
+  const bg = await firstFrameBg(
+    context,
+    extensionId,
+    { mode: "dark", variant: "material", shape: "pill" },
+    "light",
+  );
+  expect(bg).toBe(DARK_BG);
+});
+
+test("explicit light theme on a dark OS paints light on the first frame (no reverse flash)", async ({
+  context,
+  extensionId,
+}) => {
+  const bg = await firstFrameBg(
+    context,
+    extensionId,
+    { mode: "light", variant: "material", shape: "pill" },
+    "dark",
+  );
+  expect(bg).toBe(LIGHT_BG);
+});


### PR DESCRIPTION
## Problem

Pressing **Ctrl+T** with the browser in dark mode showed a white/beige flash — the new tab's first paint was the light default, then snapped to dark.

Root cause: the theme was applied **after** first paint. `apply-theme.js` was loaded as `<script type="module">` (deferred) and was an **async** IIFE that `await`ed `chrome.storage.session` before setting `data-mode` — `chrome.storage` is async-only, so it could never beat the paint. `tokens.css` `:root` defaults to light, so CSS painted light first. A related finding: the old path also didn't honor the *selected* theme on the first frame (it fell back to `system`→OS).

This is the browser-extension analog of the Android fix in #52 (paint the real themed background before content renders).

## Fix

Apply the selected theme **synchronously, before first paint**:

- **`apply-theme.ts`** rewritten as a sync, import-free shim that reads a **`localStorage` mirror** of the prefs (+ `matchMedia` for `system`) and sets `data-mode/variant/shape`. Loaded as a render-blocking **classic** `<script src>` (not a module). MV3 CSP forbids inline scripts, so `build.mjs` emits it as a standalone IIFE.
- **`appearance.ts`** mirrors prefs to `localStorage` in `setAppearance()` and `applyAppearance()` so the shim has a synchronous source.
- Removed the now-dead `chrome.storage.session` theme mirror from the service worker.
- No `tokens.css`/manifest change.

Honors the chosen theme with **no flash in either direction** — a user who picks Light on a dark OS no longer sees a reverse (dark) flash either.

## Verification

- New e2e `tests/e2e/theme-flash.spec.ts` captures the **first painted frame** (rAF recorder via `addInitScript`, with `newtab.js` blocked to remove the async race) and asserts it matches the selected theme. Confirmed **RED on the old code** (system+dark-OS and dark-selected both paint light), **GREEN after the fix**.
- Full suite: **206/206 unit**, **47/47 e2e**. Clean build (IIFE output verified — no `import`/`export`).

### Residual edge
A brand-new profile (cold `localStorage` mirror) gets one `system`/matchMedia-based first frame, then `chrome.storage.sync` reconciles. Unavoidable without a synchronous cross-device store; the common returning-visitor case has zero flash.

## Test plan
- [x] `cd extension && npm run build`
- [x] `cd extension && npm test` (206 passing)
- [x] `cd extension && npm run test:e2e` (47 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NW24hiCXYeENr1pDqRjHN
