### PR TITLE
Move the user ignore list to a device-local store (no more config dirty-pause)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -112,6 +112,9 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.14.1")
     testImplementation("androidx.test:core:1.5.0")
 
+    // Coroutines test (control the Main dispatcher / virtual time in ViewModel tests)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+
     // Instrumented tests (Compose UI testing)
     androidTestImplementation(composeBom)
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/android/app/src/androidTest/kotlin/sh/kavi/fasttravel/ui/ConfigEditingTest.kt
+++ b/android/app/src/androidTest/kotlin/sh/kavi/fasttravel/ui/ConfigEditingTest.kt
@@ -13,6 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import sh.kavi.fasttravel.data.ConfigRefreshInterval
+import sh.kavi.fasttravel.data.LocalIgnoreStore
 import sh.kavi.fasttravel.data.ThemePreferences
 
 @RunWith(AndroidJUnit4::class)
@@ -29,6 +30,8 @@ class ConfigEditingTest {
         themePrefs = ThemePreferences(ctx)
         themePrefs.configSourceDirty = false
         themePrefs.configRefreshInterval = ConfigRefreshInterval.DAILY
+        // Ensure a clean slate for the device-local ignore test across runs.
+        LocalIgnoreStore(ctx).remove("testword")
     }
 
     @Test
@@ -54,11 +57,19 @@ class ConfigEditingTest {
     }
 
     @Test
-    fun addIgnoreWord_setsDirtyFlag() {
+    fun addIgnoreWord_storesLocallyWithoutDirtyingConfig() {
         composeTestRule.onNodeWithText("Ignore list").performClick()
         composeTestRule.onNodeWithText("Add a term…").performTextInput("testword")
         composeTestRule.onNodeWithContentDescription("Add").performClick()
         composeTestRule.waitForIdle()
-        assert(themePrefs.configSourceDirty) { "Expected dirty flag to be true after adding ignore word" }
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        // The ignore list is now device-local: the word is stored there…
+        assert(LocalIgnoreStore(ctx).contains("testword")) {
+            "Expected 'testword' in the device-local ignore store after adding"
+        }
+        // …and the config is NOT dirtied, so remote auto-refresh stays active.
+        assert(!themePrefs.configSourceDirty) {
+            "Adding an ignore word must NOT dirty the config (it is device-local now)"
+        }
     }
 }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/EffectiveIgnoreList.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/EffectiveIgnoreList.kt
@@ -3,22 +3,27 @@ package sh.kavi.fasttravel.core
 import sh.kavi.fasttravel.data.AutoIgnoreStore
 
 /**
- * Compute the effective ignore list: the union of [permanent] entries (always
- * ignored) and "active" auto-ignore [candidates] — those whose dismissal count
- * has reached [threshold] and that the user has not pinned via
- * [AutoIgnoreStore.Candidate.doNotIgnore].
+ * Compute the effective ignore list merged from three sources:
+ *  - [permanent]: the config's baseline ignoreList (shared, ships in the config).
+ *  - [local]: the user's device-local ignore additions. Kept OUT of the config
+ *    on purpose so editing it never marks the config dirty / pauses remote
+ *    auto-refresh — it's merged here at parse time instead.
+ *  - [candidates]: "active" auto-ignore entries — those whose dismissal count has
+ *    reached [threshold] and that the user has not pinned via
+ *    [AutoIgnoreStore.Candidate.doNotIgnore].
  *
  * All output triggers are lowercased and deduplicated while preserving insertion
- * order: permanent entries come first, followed by any candidates not already
- * listed permanently.
+ * order: baseline first, then local additions, then active candidates.
  */
 fun effectiveIgnoreList(
     permanent: List<String>,
+    local: Set<String>,
     candidates: Map<String, AutoIgnoreStore.Candidate>,
     threshold: Int,
 ): List<String> {
     val out = LinkedHashSet<String>()
     for (p in permanent) out.add(p.lowercase())
+    for (l in local) out.add(l.lowercase())
     for ((trigger, cand) in candidates) {
         if (!cand.doNotIgnore && cand.count >= threshold) {
             out.add(trigger.lowercase())

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/LocalIgnoreStore.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/LocalIgnoreStore.kt
@@ -1,0 +1,56 @@
+package sh.kavi.fasttravel.data
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Device-local list of triggers the user has chosen to permanently ignore for
+ * typo detection.
+ *
+ * Deliberately kept OUT of the config document: the ignore list is a personal,
+ * per-device preference, not shared command config. Storing user ignores here
+ * (instead of in `FastTravelConfig.ignoreList`) means adding/removing one never
+ * marks the config dirty and never pauses remote auto-refresh. The entries are
+ * merged into the effective ignore list at parse time by [effectiveIgnoreList],
+ * alongside the config's baseline ignoreList and the auto-ignore candidates.
+ *
+ * Triggers are stored lowercased; all reads/writes lowercase first.
+ */
+class LocalIgnoreStore internal constructor(private val prefs: SharedPreferences) {
+
+    constructor(context: Context) : this(
+        context.applicationContext.getSharedPreferences(PREFS_NAME, 0),
+    )
+
+    /** All locally-ignored triggers (lowercased). */
+    fun all(): Set<String> =
+        // getStringSet returns a shared, must-not-mutate instance — copy it.
+        prefs.getStringSet(KEY_ENTRIES, emptySet())!!.toSet()
+
+    fun contains(trigger: String): Boolean {
+        val t = trigger.trim().lowercase()
+        return all().contains(t)
+    }
+
+    /** Add [trigger] (lowercased). No-op for blank input or an existing entry. */
+    fun add(trigger: String) {
+        val t = trigger.trim().lowercase()
+        if (t.isEmpty()) return
+        val current = all()
+        if (current.contains(t)) return
+        prefs.edit().putStringSet(KEY_ENTRIES, current + t).apply()
+    }
+
+    /** Remove [trigger] if present (case-insensitive). */
+    fun remove(trigger: String) {
+        val t = trigger.trim().lowercase()
+        val current = all()
+        if (!current.contains(t)) return
+        prefs.edit().putStringSet(KEY_ENTRIES, current - t).apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "fast_travel_local_ignore"
+        const val KEY_ENTRIES = "entries"
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -24,9 +24,9 @@ import sh.kavi.fasttravel.core.parseInstalledAppId
 import sh.kavi.fasttravel.core.resolveIconUrl
 import sh.kavi.fasttravel.data.AutoIgnoreStore
 import sh.kavi.fasttravel.data.ConfigRepository
+import sh.kavi.fasttravel.data.LocalIgnoreStore
 import sh.kavi.fasttravel.data.SearchHistory
 import sh.kavi.fasttravel.data.ThemePreferences
-import sh.kavi.fasttravel.data.withIgnoreAdded
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -94,6 +94,10 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     // Auto-ignore tracking for false positive typos
     private val autoIgnoreStore = AutoIgnoreStore(application)
 
+    // User's device-local permanent ignore list (kept out of the config so it
+    // never dirties it / pauses remote auto-refresh).
+    private val localIgnoreStore = LocalIgnoreStore(application)
+
     init {
         loadCommonWords(application)
         themePrefs.registerListener(prefsListener)
@@ -136,6 +140,7 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     private fun effectiveConfig(cfg: FastTravelConfig): FastTravelConfig {
         val effective = sh.kavi.fasttravel.core.effectiveIgnoreList(
             permanent = cfg.ignoreList,
+            local = localIgnoreStore.all(),
             candidates = autoIgnoreStore.all(),
             threshold = themePrefs.autoIgnoreThreshold,
         )
@@ -432,18 +437,12 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         if (state is SearchState.TypoSuggestion) {
             val trigger = state.typo.originalQuery.split(Regex("\\s+"))[0]
 
-            // Promote to permanent list + delete the candidate record (count + DNI).
-            viewModelScope.launch {
-                val store = sh.kavi.fasttravel.data.EditableConfigStore(getApplication())
-                val current = configRepository.getConfig()
-                if (current.ignoreList.none { it.equals(trigger, ignoreCase = true) }) {
-                    val updated = current.withIgnoreAdded(trigger)
-                    store.saveLocalConfigAndAwait(updated)
-                    config = configRepository.getConfig()
-                    config?.let { _groupColorMap.value = buildGroupColorMap(it.groups) }
-                }
-                autoIgnoreStore.remove(trigger)
-            }
+            // Add to the DEVICE-LOCAL ignore list — deliberately NOT the config, so
+            // a permanent ignore never dirties the config or pauses remote
+            // auto-refresh. It's merged back in by effectiveConfig/effectiveIgnoreList
+            // at parse time. Drop any auto-ignore candidate so the manual add wins.
+            localIgnoreStore.add(trigger)
+            autoIgnoreStore.remove(trigger)
 
             // Execute the search as if the trigger were ignored (one-shot override).
             val cfg = config ?: return

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -127,6 +127,7 @@ import sh.kavi.fasttravel.data.ConfigRefreshScheduler
 import sh.kavi.fasttravel.data.ConfigRepository
 import sh.kavi.fasttravel.data.ConfigValidator
 import sh.kavi.fasttravel.data.EditableConfigStore
+import sh.kavi.fasttravel.data.LocalIgnoreStore
 import sh.kavi.fasttravel.data.SearchHistory
 import sh.kavi.fasttravel.data.ThemePreferences
 import sh.kavi.fasttravel.data.allGroupIds
@@ -138,8 +139,6 @@ import sh.kavi.fasttravel.data.withGroupAdded
 import sh.kavi.fasttravel.data.withGroupDeleted
 import sh.kavi.fasttravel.data.withGroupMoved
 import sh.kavi.fasttravel.data.withGroupUpdated
-import sh.kavi.fasttravel.data.withIgnoreAdded
-import sh.kavi.fasttravel.data.withIgnoreRemoved
 import sh.kavi.fasttravel.ui.appearance.AppearanceMode
 import sh.kavi.fasttravel.ui.appearance.AppearanceShape
 import sh.kavi.fasttravel.ui.appearance.AppearanceVariant
@@ -307,7 +306,6 @@ fun SettingsNavHost(
             SettingsHomeScreen(
                 navController = navController,
                 onBack = onFinish,
-                config = config,
             )
         }
         composable(SettingsRoute.Appearance.route) {
@@ -427,9 +425,6 @@ fun SettingsNavHost(
         composable(SettingsRoute.IgnoreList.route) {
             IgnoreListScreen(
                 navController = navController,
-                config = config,
-                editableStore = editableStore,
-                onConfigChanged = refreshConfig,
                 snackbarHostState = snackbarHostState,
             )
         }
@@ -550,8 +545,10 @@ fun NavigableListItem(
 fun SettingsHomeScreen(
     navController: NavHostController,
     onBack: () -> Unit,
-    config: FastTravelConfig?,
 ) {
+    // The ignore-list count reflects the user's device-local list (read fresh each
+    // composition, so it updates when returning from the Ignore List screen).
+    val ignoreCount = LocalIgnoreStore(LocalContext.current).all().size
     Scaffold(
         topBar = { SettingsTopBar(title = "Settings", onBack = onBack) },
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
@@ -584,7 +581,7 @@ fun SettingsHomeScreen(
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
                 NavigableListItem(
                     headlineText = "Ignore list",
-                    supportingText = pluralize(config?.ignoreList?.size ?: 0, "item"),
+                    supportingText = pluralize(ignoreCount, "item"),
                     onClick = { navController.navigate(SettingsRoute.IgnoreList.route) },
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
@@ -1324,13 +1321,11 @@ private data class CandidateRow(
 @Composable
 fun IgnoreListScreen(
     navController: NavHostController,
-    config: FastTravelConfig?,
-    editableStore: EditableConfigStore,
-    onConfigChanged: () -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
     val context = LocalContext.current
     val autoIgnoreStore = remember { AutoIgnoreStore(context) }
+    val localIgnoreStore = remember { LocalIgnoreStore(context) }
     val themePrefs = remember { ThemePreferences(context) }
 
     var newItem by remember { mutableStateOf("") }
@@ -1344,9 +1339,12 @@ fun IgnoreListScreen(
     var candidateSheetFor by remember { mutableStateOf<CandidateRow?>(null) }
     var showResetDialog by remember { mutableStateOf(false) }
 
-    // Derived data
-    val permanentList: List<String> = remember(config, refreshTick) {
-        (config?.ignoreList.orEmpty()).map { it.lowercase() }.distinct().sorted()
+    // Derived data — the user's DEVICE-LOCAL ignore list (not the config baseline).
+    // Adding/removing here only touches the local store, so it never dirties the
+    // config or pauses remote auto-refresh. Common-words typo suppression is a
+    // separate, hidden mechanism and is intentionally not surfaced here.
+    val permanentList: List<String> = remember(refreshTick) {
+        localIgnoreStore.all().map { it.lowercase() }.distinct().sorted()
     }
     val candidateList: List<CandidateRow> = remember(refreshTick, threshold) {
         autoIgnoreStore.all().map { (trigger, c) ->
@@ -1361,38 +1359,25 @@ fun IgnoreListScreen(
 
     fun submitAdd() {
         if (newItem.isBlank()) return
-        val cfg = config ?: return
-        val trimmed = newItem.trim()
-        if (cfg.ignoreList.none { it.equals(trimmed, ignoreCase = true) }) {
-            editableStore.saveLocalConfig(cfg.withIgnoreAdded(trimmed))
-            markDirtyAndCancelRefresh(context, themePrefs)
-        }
+        // Device-local only — no config write, no dirty flag.
+        localIgnoreStore.add(newItem)
         // If the trigger was a candidate (possibly red-flagged), delete it so
         // manual add wins cleanly. Matches the design doc's "manual add
         // overrides red flag" rule.
-        autoIgnoreStore.remove(trimmed)
+        autoIgnoreStore.remove(newItem.trim())
         newItem = ""
-        onConfigChanged()
         refreshTick++
     }
 
     fun removePermanent(trigger: String) {
-        val cfg = config ?: return
-        editableStore.saveLocalConfig(cfg.withIgnoreRemoved(trigger))
-        markDirtyAndCancelRefresh(context, themePrefs)
+        localIgnoreStore.remove(trigger)
         // No counter side-effect: permanent entries never had active counters.
-        onConfigChanged()
         refreshTick++
     }
 
     fun confirmCandidate(trigger: String) {
-        val cfg = config ?: return
-        if (cfg.ignoreList.none { it.equals(trigger, ignoreCase = true) }) {
-            editableStore.saveLocalConfig(cfg.withIgnoreAdded(trigger))
-            markDirtyAndCancelRefresh(context, themePrefs)
-        }
+        localIgnoreStore.add(trigger)
         autoIgnoreStore.remove(trigger)
-        onConfigChanged()
         refreshTick++
     }
 

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/core/EffectiveIgnoreListTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/core/EffectiveIgnoreListTest.kt
@@ -15,7 +15,34 @@ class EffectiveIgnoreListTest {
             listOf("cat"),
             effectiveIgnoreList(
                 permanent = listOf("cat"),
+                local = emptySet(),
                 candidates = emptyMap(),
+                threshold = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `local entries are always included`() {
+        assertEquals(
+            listOf("scholr"),
+            effectiveIgnoreList(
+                permanent = emptyList(),
+                local = setOf("scholr"),
+                candidates = emptyMap(),
+                threshold = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `baseline, local and active candidates merge in order, deduped lowercase`() {
+        assertEquals(
+            listOf("base", "mine", "auto"),
+            effectiveIgnoreList(
+                permanent = listOf("BASE"),
+                local = setOf("Mine", "base"), // "base" dups the baseline
+                candidates = mapOf("auto" to c(count = 3), "low" to c(count = 1)),
                 threshold = 3,
             ),
         )
@@ -27,6 +54,7 @@ class EffectiveIgnoreListTest {
             listOf("fcb"),
             effectiveIgnoreList(
                 permanent = emptyList(),
+                local = emptySet(),
                 candidates = mapOf("fcb" to c(count = 3)),
                 threshold = 3,
             ),
@@ -39,6 +67,7 @@ class EffectiveIgnoreListTest {
             emptyList<String>(),
             effectiveIgnoreList(
                 permanent = emptyList(),
+                local = emptySet(),
                 candidates = mapOf("fcb" to c(count = 2)),
                 threshold = 3,
             ),
@@ -51,6 +80,7 @@ class EffectiveIgnoreListTest {
             emptyList<String>(),
             effectiveIgnoreList(
                 permanent = emptyList(),
+                local = emptySet(),
                 candidates = mapOf("fcb" to c(count = 10, dni = true)),
                 threshold = 3,
             ),
@@ -63,6 +93,20 @@ class EffectiveIgnoreListTest {
             listOf("fcb"),
             effectiveIgnoreList(
                 permanent = listOf("fcb"),
+                local = emptySet(),
+                candidates = mapOf("fcb" to c(count = 10, dni = true)),
+                threshold = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `local wins even if also flagged DNI as candidate`() {
+        assertEquals(
+            listOf("fcb"),
+            effectiveIgnoreList(
+                permanent = emptyList(),
+                local = setOf("fcb"),
                 candidates = mapOf("fcb" to c(count = 10, dni = true)),
                 threshold = 3,
             ),
@@ -75,6 +119,7 @@ class EffectiveIgnoreListTest {
             listOf("cat"),
             effectiveIgnoreList(
                 permanent = listOf("CAT", "cat"),
+                local = emptySet(),
                 candidates = mapOf("cat" to c(count = 5, dni = false)),
                 threshold = 3,
             ),
@@ -87,6 +132,7 @@ class EffectiveIgnoreListTest {
             emptyList<String>(),
             effectiveIgnoreList(
                 permanent = emptyList(),
+                local = emptySet(),
                 candidates = emptyMap(),
                 threshold = 3,
             ),

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/data/LocalIgnoreStoreTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/data/LocalIgnoreStoreTest.kt
@@ -1,0 +1,55 @@
+package sh.kavi.fasttravel.data
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class LocalIgnoreStoreTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private fun newStore() = LocalIgnoreStore(context)
+
+    @Test
+    fun `empty store returns empty set`() {
+        assertEquals(emptySet<String>(), newStore().all())
+        assertFalse(newStore().contains("anything"))
+    }
+
+    @Test
+    fun `add stores the trigger lowercased and survives a fresh instance`() {
+        newStore().add("ScHoLr")
+
+        // A new instance reads the same persisted prefs.
+        val store = newStore()
+        assertEquals(setOf("scholr"), store.all())
+        assertTrue(store.contains("scholr"))
+        assertTrue(store.contains("SCHOLR")) // case-insensitive
+    }
+
+    @Test
+    fun `add is idempotent and ignores blanks`() {
+        val store = newStore()
+        store.add("dupe")
+        store.add("DUPE")
+        store.add("   ")
+        assertEquals(setOf("dupe"), store.all())
+    }
+
+    @Test
+    fun `remove deletes case-insensitively`() {
+        val store = newStore()
+        store.add("one")
+        store.add("two")
+        store.remove("ONE")
+        assertEquals(setOf("two"), store.all())
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/SearchViewModelTypoIgnoreTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/SearchViewModelTypoIgnoreTest.kt
@@ -1,0 +1,128 @@
+package sh.kavi.fasttravel.ui
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import sh.kavi.fasttravel.data.ConfigRefreshInterval
+import sh.kavi.fasttravel.data.EditableConfigStore
+import sh.kavi.fasttravel.data.LocalIgnoreStore
+import sh.kavi.fasttravel.data.ThemePreferences
+
+/**
+ * Regression tests for the Android typo-ignore behaviour.
+ *
+ * The user's permanent ignores live in a device-local store ([LocalIgnoreStore]),
+ * NOT in the config document — so ignoring a typo must (1) stick, (2) NOT dirty
+ * the config / pause remote auto-refresh, and (3) stop the typo from prompting.
+ * Auto-ignore tracking is a separate device-local mechanism and is covered too.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class SearchViewModelTypoIgnoreTest {
+
+    private val app: Application = ApplicationProvider.getApplicationContext()
+    private val scheduler = TestCoroutineScheduler()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher(scheduler))
+
+        // The user is on the REMOTE config (not dirty) with a fresh cache that
+        // contains the "scholar" command, so "scholr" is a detectable typo.
+        val themePrefs = ThemePreferences(app)
+        themePrefs.configSourceDirty = false
+        themePrefs.configRefreshInterval = ConfigRefreshInterval.MANUAL // cache never expires
+        themePrefs.configUrl = "no-protocol-url" // belt-and-suspenders: never hit the network
+        EditableConfigStore(app).clearLocalConfig()
+
+        val configJson = app.assets.open("default-config.json")
+            .bufferedReader().use { it.readText() }
+        app.getSharedPreferences("fast_travel_config", Context.MODE_PRIVATE)
+            .edit()
+            .putString("cached_config_json", configJson)
+            .putLong("cache_timestamp", 1_000_000L)
+            .apply()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `ignoring a typo persists it device-locally without dirtying the config`() {
+        val vm = SearchViewModel(app)
+        scheduler.advanceUntilIdle() // let init load the cached config
+
+        // Precondition: the typo card appears (detection works).
+        vm.onSearch("scholr")
+        assertTrue(
+            "expected a typo suggestion for 'scholr'",
+            vm.searchState.value is SearchState.TypoSuggestion,
+        )
+
+        // Act: user taps "Add to ignore list".
+        vm.ignoreTypo()
+        scheduler.advanceUntilIdle()
+
+        // Persisted to the DEVICE-LOCAL store…
+        assertTrue(
+            "ignored typo 'scholr' must be in the device-local ignore store",
+            LocalIgnoreStore(app).contains("scholr"),
+        )
+        // …and the config was NOT dirtied, so remote auto-refresh is not paused.
+        assertFalse(
+            "ignoring a typo must NOT dirty the config",
+            ThemePreferences(app).configSourceDirty,
+        )
+        // …and it no longer prompts on a fresh search.
+        vm.onSearch("scholr")
+        assertTrue(
+            "after ignoring, 'scholr' must no longer prompt",
+            vm.searchState.value is SearchState.Navigate,
+        )
+    }
+
+    @Test
+    fun `declining a typo to the threshold auto-ignores it`() {
+        val vm = SearchViewModel(app)
+        scheduler.advanceUntilIdle() // let init load the cached config
+
+        val threshold = ThemePreferences(app).autoIgnoreThreshold // default 3
+
+        // Decline ("Use as search") the same typo `threshold` times. Each decline
+        // bumps the auto-ignore candidate counter (device-local, separate from the
+        // permanent ignore list).
+        repeat(threshold) { i ->
+            vm.onSearch("scholr")
+            assertTrue(
+                "still expected a typo prompt on dismissal ${i + 1} (below threshold)",
+                vm.searchState.value is SearchState.TypoSuggestion,
+            )
+            vm.fallbackSearchAfterTypo()
+        }
+
+        // The candidate count has reached the threshold, so effectiveIgnoreList now
+        // treats 'scholr' as ignored: the next search must not prompt.
+        vm.onSearch("scholr")
+        assertTrue(
+            "after $threshold dismissals 'scholr' must be auto-ignored (no typo prompt)",
+            vm.searchState.value is SearchState.Navigate,
+        )
+    }
+}

--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -493,28 +493,10 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     return true;
   }
   if (message.type === "getIgnoreList") {
+    // The config's BASELINE ignoreList only (normally empty). The user's own
+    // ignore additions live device-local in local-ignore-store and are merged
+    // at parse time — adding one must never write/dirty the config.
     getConfig().then((cfg) => sendResponse(cfg.ignoreList));
-    return true;
-  }
-  if (message.type === "addToIgnoreList") {
-    getConfig().then(async (cfg) => {
-      if (cfg.ignoreList.some((w: string) => w.toLowerCase() === message.value.trim().toLowerCase())) {
-        sendResponse(cfg.ignoreList); return;
-      }
-      const trimmed = message.value.trim().toLowerCase();
-      const next = { ...cfg, ignoreList: [...cfg.ignoreList, trimmed] };
-      await setConfig(next);
-      sendResponse(next.ignoreList);
-    });
-    return true;
-  }
-  if (message.type === "removeFromIgnoreList") {
-    getConfig().then(async (cfg) => {
-      const lower = message.value.trim().toLowerCase();
-      const next = { ...cfg, ignoreList: cfg.ignoreList.filter((w: string) => w.toLowerCase() !== lower) };
-      await setConfig(next);
-      sendResponse(next.ignoreList);
-    });
     return true;
   }
   if (message.type === "addHistory") {

--- a/extension/src/core/effective-ignore-list.ts
+++ b/extension/src/core/effective-ignore-list.ts
@@ -1,22 +1,27 @@
 import type { AutoIgnoreStore } from "./auto-ignore-store.js";
 
 /**
- * Compute the effective ignore list: the union of `permanent` entries (always
- * ignored) and "active" auto-ignore `candidates` — those whose dismissal count
- * has reached `threshold` and that the user has not pinned via
- * `AutoIgnoreCandidate.doNotIgnore`.
+ * Compute the effective ignore list merged from three sources:
+ *  - `permanent`: the config's baseline ignoreList (shared, ships in the config).
+ *  - `local`: the user's device-local ignore additions. Kept OUT of the config
+ *    on purpose so editing it never marks the config dirty / pauses remote
+ *    auto-refresh — it's merged here at parse time instead.
+ *  - `candidates`: "active" auto-ignore entries — those whose dismissal count
+ *    has reached `threshold` and that the user has not pinned via
+ *    `AutoIgnoreCandidate.doNotIgnore`.
  *
  * All output triggers are lowercased and deduplicated while preserving
- * insertion order: permanent entries come first, followed by any candidates
- * not already listed permanently.
+ * insertion order: baseline first, then local additions, then active candidates.
  */
 export function effectiveIgnoreList(
   permanent: string[],
+  local: string[],
   candidates: AutoIgnoreStore,
   threshold: number,
 ): string[] {
   const out = new Set<string>();
   for (const p of permanent) out.add(p.toLowerCase());
+  for (const l of local) out.add(l.toLowerCase());
   for (const [trigger, cand] of Object.entries(candidates)) {
     if (!cand.doNotIgnore && cand.count >= threshold) {
       out.add(trigger.toLowerCase());

--- a/extension/src/core/local-ignore-store.ts
+++ b/extension/src/core/local-ignore-store.ts
@@ -1,0 +1,45 @@
+/**
+ * Device-local list of triggers the user has chosen to permanently ignore for
+ * typo detection.
+ *
+ * Deliberately kept OUT of the config document: the ignore list is a personal,
+ * per-device preference, not shared command config. Storing user ignores here
+ * (instead of in `config.ignoreList`) means adding/removing one never marks the
+ * config dirty and never pauses remote auto-refresh. Entries are merged into the
+ * effective ignore list at parse time by `effectiveIgnoreList`, alongside the
+ * config's baseline ignoreList and the auto-ignore candidates.
+ *
+ * Triggers are stored lowercased; all mutators lowercase input first.
+ */
+
+const STORE_KEY = "fast-travel-local-ignore";
+
+async function readRaw(): Promise<string[]> {
+  const v = await chrome.storage.local.get(STORE_KEY);
+  const list = v[STORE_KEY];
+  return Array.isArray(list)
+    ? (list as unknown[]).filter((x): x is string => typeof x === "string")
+    : [];
+}
+
+/** All locally-ignored triggers (lowercased). */
+export async function loadLocalIgnores(): Promise<string[]> {
+  return await readRaw();
+}
+
+/** Add `trigger` (lowercased). No-op for blank input or an existing entry. */
+export async function addLocalIgnore(trigger: string): Promise<void> {
+  const t = trigger.trim().toLowerCase();
+  if (!t) return;
+  const list = await readRaw();
+  if (list.includes(t)) return;
+  await chrome.storage.local.set({ [STORE_KEY]: [...list, t] });
+}
+
+/** Remove `trigger` if present (case-insensitive). */
+export async function removeLocalIgnore(trigger: string): Promise<void> {
+  const t = trigger.trim().toLowerCase();
+  const list = await readRaw();
+  if (!list.includes(t)) return;
+  await chrome.storage.local.set({ [STORE_KEY]: list.filter((x) => x !== t) });
+}

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -21,6 +21,7 @@ import {
   type AutoIgnoreStore,
 } from "../core/auto-ignore-store.js";
 import { effectiveIgnoreList } from "../core/effective-ignore-list.js";
+import { addLocalIgnore, loadLocalIgnores } from "../core/local-ignore-store.js";
 import { rankByFrecency } from "../core/frecency.js";
 
 interface HistoryEntry {
@@ -89,19 +90,23 @@ let config: FastTravelConfig | null = null;
 // empty-input quick chips.
 let topChipHistory: HistoryEntry[] = [];
 let permanentIgnoreList: string[] = [];
+let localIgnores: string[] = [];
 let candidates: AutoIgnoreStore = {};
 let threshold = 3;
 let currentTypo: TypoResult | null = null;
 const device = detectDevice();
 
 async function refreshIgnoreState(): Promise<void> {
+  // Baseline ignoreList shipped in the config (normally empty) …
   permanentIgnoreList = (await chrome.runtime.sendMessage({ type: "getIgnoreList" })) ?? [];
+  // … plus the user's device-local additions (never written to the config).
+  localIgnores = await loadLocalIgnores();
   candidates = await loadCandidates();
   threshold = await getAutoIgnoreThreshold();
 }
 
 function currentEffectiveIgnoreList(): string[] {
-  return effectiveIgnoreList(permanentIgnoreList, candidates, threshold);
+  return effectiveIgnoreList(permanentIgnoreList, localIgnores, candidates, threshold);
 }
 
 // DOM
@@ -406,7 +411,11 @@ async function defaultSearch(): Promise<void> {
 async function ignoreTypo(): Promise<void> {
   if (!currentTypo) return;
   const trigger = currentTypo.originalQuery.split(/\s+/)[0].toLowerCase();
-  permanentIgnoreList = await chrome.runtime.sendMessage({ type: "addToIgnoreList", value: trigger });
+  // Add to the DEVICE-LOCAL ignore list (not the config) so a permanent ignore
+  // never dirties the config or pauses remote auto-refresh. Drop any auto-ignore
+  // candidate so the manual add wins.
+  await addLocalIgnore(trigger);
+  localIgnores = await loadLocalIgnores();
   await removeCandidate(trigger);
   candidates = await loadCandidates();
   hideTypo();

--- a/extension/src/options/data.ts
+++ b/extension/src/options/data.ts
@@ -21,18 +21,6 @@ export async function setConfig(cfg: FastTravelConfig): Promise<RefreshResult> {
   return result ?? { ok: false, reason: "No response from background" };
 }
 
-export async function getIgnoreList(): Promise<string[]> {
-  return (await chrome.runtime.sendMessage({ type: "getIgnoreList" })) ?? [];
-}
-
-export async function addToIgnoreList(value: string): Promise<string[]> {
-  return await chrome.runtime.sendMessage({ type: "addToIgnoreList", value });
-}
-
-export async function removeFromIgnoreList(value: string): Promise<string[]> {
-  return await chrome.runtime.sendMessage({ type: "removeFromIgnoreList", value });
-}
-
 export interface HistoryEntry {
   query: string;
   commandId: string | null;

--- a/extension/src/options/screens/ignore-list.ts
+++ b/extension/src/options/screens/ignore-list.ts
@@ -1,5 +1,9 @@
 import { el, screenHeader, emptyState } from "../dom.js";
-import { addToIgnoreList, getIgnoreList, removeFromIgnoreList } from "../data.js";
+import {
+  addLocalIgnore,
+  loadLocalIgnores,
+  removeLocalIgnore,
+} from "../../core/local-ignore-store.js";
 import {
   AUTO_IGNORE_THRESHOLD_MAX,
   AUTO_IGNORE_THRESHOLD_MIN,
@@ -145,7 +149,8 @@ export async function renderIgnoreList(main: HTMLElement): Promise<void> {
   async function submitAdd(): Promise<void> {
     const v = newItemInput.value.trim();
     if (!v) return;
-    await addToIgnoreList(v);
+    // Device-local only — adding an ignore never dirties the config.
+    await addLocalIgnore(v);
     // Manual add wins over any red flag / pending count — delete the candidate.
     await removeCandidate(v);
     newItemInput.value = "";
@@ -160,7 +165,10 @@ export async function renderIgnoreList(main: HTMLElement): Promise<void> {
   });
 
   async function refresh(): Promise<void> {
-    const [list, candidates] = await Promise.all([getIgnoreList(), loadCandidates()]);
+    // The "Permanent" section shows ONLY the user's device-local ignore list —
+    // the config baseline and the hidden common-words suppression are not
+    // surfaced here.
+    const [list, candidates] = await Promise.all([loadLocalIgnores(), loadCandidates()]);
 
     // ----- Permanent list -----
     const permanentSorted = [...list].map((s) => s.toLowerCase()).sort();
@@ -176,7 +184,7 @@ export async function renderIgnoreList(main: HTMLElement): Promise<void> {
       for (const trigger of permanentSorted) {
         permanentList.appendChild(
           renderPermanentRow(trigger, async () => {
-            await removeFromIgnoreList(trigger);
+            await removeLocalIgnore(trigger);
             refresh();
           }),
         );
@@ -212,7 +220,7 @@ export async function renderIgnoreList(main: HTMLElement): Promise<void> {
         autoList.appendChild(
           renderCandidateRow(entry, {
             onConfirm: async () => {
-              await addToIgnoreList(entry.trigger);
+              await addLocalIgnore(entry.trigger);
               await removeCandidate(entry.trigger);
               refresh();
             },

--- a/extension/tests/unit/effective-ignore-list.test.ts
+++ b/extension/tests/unit/effective-ignore-list.test.ts
@@ -4,36 +4,42 @@ import { effectiveIgnoreList } from "../../src/core/effective-ignore-list.js";
 const c = (count: number, doNotIgnore = false) => ({ count, doNotIgnore });
 
 describe("effectiveIgnoreList", () => {
-  it("permanent entries are always included", () => {
-    expect(effectiveIgnoreList(["cat", "dog"], {}, 3)).toEqual(["cat", "dog"]);
+  it("permanent (config baseline) entries are always included", () => {
+    expect(effectiveIgnoreList(["cat", "dog"], [], {}, 3)).toEqual(["cat", "dog"]);
+  });
+
+  it("local entries are always included", () => {
+    expect(effectiveIgnoreList([], ["scholr"], {}, 3)).toEqual(["scholr"]);
+  });
+
+  it("baseline, local and active candidates merge in order, deduped lowercase", () => {
+    expect(
+      effectiveIgnoreList(["BASE"], ["Mine", "base"], { auto: c(3), low: c(1) }, 3),
+    ).toEqual(["base", "mine", "auto"]);
   });
 
   it("candidate at or above threshold is included (boundary count == threshold)", () => {
-    expect(effectiveIgnoreList([], { fcb: c(3) }, 3)).toEqual(["fcb"]);
-    expect(effectiveIgnoreList([], { fcb: c(5) }, 3)).toEqual(["fcb"]);
+    expect(effectiveIgnoreList([], [], { fcb: c(3) }, 3)).toEqual(["fcb"]);
+    expect(effectiveIgnoreList([], [], { fcb: c(5) }, 3)).toEqual(["fcb"]);
   });
 
   it("candidate below threshold is excluded", () => {
-    expect(effectiveIgnoreList([], { fcb: c(2) }, 3)).toEqual([]);
+    expect(effectiveIgnoreList([], [], { fcb: c(2) }, 3)).toEqual([]);
   });
 
   it("do-not-ignore candidate is excluded regardless of count", () => {
-    expect(effectiveIgnoreList([], { fcb: c(10, true) }, 3)).toEqual([]);
+    expect(effectiveIgnoreList([], [], { fcb: c(10, true) }, 3)).toEqual([]);
   });
 
-  it("permanent wins even if also flagged DNI as candidate (single entry in output)", () => {
-    expect(
-      effectiveIgnoreList(["fcb"], { fcb: c(0, true) }, 3),
-    ).toEqual(["fcb"]);
+  it("local wins even if also flagged DNI as candidate (single entry in output)", () => {
+    expect(effectiveIgnoreList([], ["fcb"], { fcb: c(0, true) }, 3)).toEqual(["fcb"]);
   });
 
   it("result is lowercase and deduplicated", () => {
-    expect(
-      effectiveIgnoreList(["CAT", "cat"], { cat: c(5) }, 3),
-    ).toEqual(["cat"]);
+    expect(effectiveIgnoreList(["CAT", "cat"], [], { cat: c(5) }, 3)).toEqual(["cat"]);
   });
 
   it("empty inputs return empty array", () => {
-    expect(effectiveIgnoreList([], {}, 3)).toEqual([]);
+    expect(effectiveIgnoreList([], [], {}, 3)).toEqual([]);
   });
 });

--- a/extension/tests/unit/local-ignore-store.test.ts
+++ b/extension/tests/unit/local-ignore-store.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  addLocalIgnore,
+  loadLocalIgnores,
+  removeLocalIgnore,
+} from "../../src/core/local-ignore-store.js";
+
+function mockStorage(initial: Record<string, unknown> = {}) {
+  const backing: Record<string, unknown> = { ...initial };
+  return {
+    get: async (keys: string | string[]) => {
+      const want = Array.isArray(keys) ? keys : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of want) if (k in backing) out[k] = backing[k];
+      return out;
+    },
+    set: async (obj: Record<string, unknown>) => {
+      Object.assign(backing, obj);
+    },
+  };
+}
+
+function install(initial: Record<string, unknown> = {}): void {
+  (globalThis as any).chrome = { storage: { local: mockStorage(initial) } };
+}
+
+describe("local-ignore-store", () => {
+  beforeEach(() => install());
+
+  it("starts empty", async () => {
+    expect(await loadLocalIgnores()).toEqual([]);
+  });
+
+  it("add stores lowercased and persists", async () => {
+    await addLocalIgnore("ScHoLr");
+    expect(await loadLocalIgnores()).toEqual(["scholr"]);
+  });
+
+  it("add is idempotent and ignores blanks", async () => {
+    await addLocalIgnore("dupe");
+    await addLocalIgnore("DUPE");
+    await addLocalIgnore("   ");
+    expect(await loadLocalIgnores()).toEqual(["dupe"]);
+  });
+
+  it("remove deletes case-insensitively", async () => {
+    await addLocalIgnore("one");
+    await addLocalIgnore("two");
+    await removeLocalIgnore("ONE");
+    expect(await loadLocalIgnores()).toEqual(["two"]);
+  });
+});


### PR DESCRIPTION
## Problem
The user's permanent ignore list lived in `config.ignoreList`, so adding an entry — via the typo card's "Add to ignore list" **or** the Settings ignore-list screen — wrote the config, which sets the dirty flag and **pauses remote auto-refresh**. Ignoring one typo shouldn't freeze config sync. (On Android the typo-card path didn't even mark dirty, so the ignore silently never stuck and never showed in Settings.)

## Fix
Move the user's ignore list to a **device-local store**, merged into the effective ignore list at parse time alongside the config baseline and the auto-ignore candidates — so adding/removing an ignore never touches the config or the dirty flag.

- **Android:** `LocalIgnoreStore` (SharedPreferences `fast_travel_local_ignore`)
- **Extension:** `core/local-ignore-store.ts` (`chrome.storage.local`)
- `effectiveIgnoreList(baseline, local, candidates, threshold)` on both platforms
- Settings / options ignore-list shows **only** the device-local list; the common-words typo suppression stays a separate hidden mechanism
- Removed the now-dead `addToIgnoreList` / `removeFromIgnoreList` extension message handlers + data wrappers

## Tests / verification
- **Android:** `LocalIgnoreStoreTest`; `effectiveIgnoreList` gains a `local` source with cases; `SearchViewModelTypoIgnoreTest` asserts local persistence + config **not** dirtied + no re-prompt + auto-ignore tracking. Full unit suite green.
- **Extension:** `local-ignore-store` test; `effectiveIgnoreList` `local` cases. 216 unit tests green; build clean.
- **Live on the emulator:** ignoring a typo writes `fast_travel_local_ignore`, leaves the config clean (no `config_source_dirty`, no `fast_travel_local_config`), and the entry shows in Settings → Ignore List.

🤖 Generated with [Claude Code](https://claude.com/claude-code)