### PR TITLE
Add qq2 → Claude command (mirrors qq → ChatGPT)

### DIFF
--- a/android/app/src/main/assets/default-config.json
+++ b/android/app/src/main/assets/default-config.json
@@ -107,6 +107,22 @@
               "searchUrl": "https://chat.openai.com/?q={query}"
             }
           ]
+        },
+        {
+          "id": "qq2",
+          "triggers": [
+            "qq2"
+          ],
+          "name": "Claude",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=claude.ai&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://claude.ai",
+              "searchUrl": "https://claude.ai/new?q={query}"
+            }
+          ]
         }
       ]
     },

--- a/shared/config/default-config.json
+++ b/shared/config/default-config.json
@@ -107,6 +107,22 @@
               "searchUrl": "https://chat.openai.com/?q={query}"
             }
           ]
+        },
+        {
+          "id": "qq2",
+          "triggers": [
+            "qq2"
+          ],
+          "name": "Claude",
+          "type": "standard",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=claude.ai&sz=128",
+          "routes": [
+            {
+              "devices": "*",
+              "defaultUrl": "https://claude.ai",
+              "searchUrl": "https://claude.ai/new?q={query}"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Adds a `qq2` → **Claude** command, mirroring the existing `qq` → ChatGPT (same AI/chat group + same shape): `defaultUrl https://claude.ai`, `searchUrl https://claude.ai/new?q={query}`.

- Edited the canonical `shared/config/default-config.json`; Android bundled asset re-synced (matches the gradle `syncSharedConfig` copy). The extension imports `shared/config` directly, so it picks this up at build.
- `node tools/validate-config.mjs` passes; extension (216) + Android unit suites green.

Once merged, this reaches existing users via config refresh from the hosted URL — **no app release required** (the bundled copy ships with the next build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)