### PR TITLE
feat: local file search via the `s` command (companion + extension + Android)

### DIFF
--- a/.github/workflows/companion-release.yml
+++ b/.github/workflows/companion-release.yml
@@ -1,0 +1,68 @@
+name: Companion Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 1.0.0)"
+        required: true
+        type: string
+  push:
+    tags:
+      - 'companion-v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish companion binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: '1.24.x'
+
+      # ── Resolve version ────────────────────────────────────────────────────
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Strip the 'companion-v' prefix from the pushed tag name.
+            VERSION="${GITHUB_REF_NAME#companion-v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # ── Build ──────────────────────────────────────────────────────────────
+      - name: Build companion binaries
+        run: companion/scripts/build.sh "${{ steps.version.outputs.version }}"
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd companion/dist
+          sha256sum \
+            fast-travel-companion-linux-amd64 \
+            fast-travel-companion-linux-arm64 \
+            fast-travel-companion-windows-amd64.exe \
+            > SHA256SUMS
+
+      # ── Publish ────────────────────────────────────────────────────────────
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: companion-v${{ steps.version.outputs.version }}
+          name: Companion v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            companion/dist/fast-travel-companion-linux-amd64
+            companion/dist/fast-travel-companion-linux-arm64
+            companion/dist/fast-travel-companion-windows-amd64.exe
+            companion/dist/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ extension/dev-harness/
 # Root-level build output
 build/
 
+# Companion daemon build outputs
+companion/dist/
+
 # Root-level dev/debug test scripts (local-path-dependent, not real tests)
 /test-*.mjs
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ yarn-error.log
 # Environment files
 .env
 .env.*
+
+# Subagent-driven-development scratch
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,17 @@ Releases are fully automated via GitHub Actions. After merging to `main`:
 
 Do NOT manually edit version numbers in source files.
 
+### Companion releases
+
+The companion daemon versions **independently** of the extension/Android app and is **not** included in the main Release workflow. It is built and published by `.github/workflows/companion-release.yml` via two triggers:
+
+- **Manual:** Actions → Companion Release → Run workflow → enter a version (e.g. `1.0.0`).
+- **Tag push:** push a `companion-v*` tag (e.g. `git tag companion-v1.0.0 && git push --tags`); the workflow derives the version from the tag.
+
+Both paths cross-compile all targets on a single `ubuntu-latest` runner (`linux-amd64`, `linux-arm64`, `windows-amd64.exe`), generate a `SHA256SUMS` file, and publish a GitHub Release with all four files attached. Uses only `GITHUB_TOKEN` — no additional secrets required.
+
+Distribution is **GitHub Releases only** (no store submission). AppImage packaging is a future enhancement.
+
 ## CI Secrets (for maintainers)
 
 All secrets live in **GitHub → Settings → Secrets and variables → Actions**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,19 @@ fast-travel-app/
 │       ├── main/       # Application source
 │       ├── test/       # JUnit5 unit tests
 │       └── androidTest/# Compose instrumented tests
+├── companion/          # Go desktop companion daemon (localhost HTTP, OS indexer backends, pairing)
+│   ├── cmd/
+│   │   └── fast-travel-companion/ # main entrypoint
+│   ├── internal/
+│   │   ├── autostart/  # XDG autostart install/uninstall
+│   │   ├── config/     # companion-local JSON config (port, preferred indexer, allowed origins)
+│   │   ├── index/      # Baloo/Tracker/plocate backends + Registry
+│   │   ├── pairing/    # bearer-token security, pairing window
+│   │   ├── protocol/   # wire types (PingResponse, SearchRequest, …)
+│   │   ├── query/      # query parser (simple, glob, regex modes)
+│   │   └── server/     # loopback HTTP server + XDG opener
+│   └── scripts/
+│       └── build.sh    # cross-compile to companion/dist/ (linux-amd64, linux-arm64, windows-amd64)
 ├── shared/
 │   ├── config/         # default-config.json + config.schema.json
 │   └── test-fixtures/  # JSON fixtures shared by extension and Android tests
@@ -43,6 +56,12 @@ cd android && ./gradlew assembleDebug   # Debug APK
 cd android && ./gradlew bundleRelease   # Release AAB (requires signing env vars)
 ```
 
+### Companion (Go daemon)
+```bash
+companion/scripts/build.sh             # Cross-compile → companion/dist/ (linux-amd64, linux-arm64, windows-amd64.exe)
+companion/scripts/build.sh 1.2.3       # Pin a specific version string
+```
+
 ## Running Tests
 
 ### Extension unit tests
@@ -63,6 +82,11 @@ cd android && ./gradlew test
 ### Android instrumented tests (needs device or emulator)
 ```bash
 cd android && ./gradlew connectedAndroidTest
+```
+
+### Companion unit tests
+```bash
+cd companion && go test ./...
 ```
 
 ### Config validation

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,15 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Local file search: media permissions (Android 13+, API 33) -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <!-- Local file search: legacy storage permission (API ≤ 32) -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <!--
         Required on Android 11+ for queryIntentActivities(ACTION_MAIN/LAUNCHER)
         to return the full list of installed launchable apps. Without this,

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -75,6 +75,21 @@
             android:exported="false"
             android:theme="@style/Theme.FastTravel" />
 
+        <!--
+            FileProvider for opening local files (local-search results).
+            Content URIs keep the app from needing MANAGE_EXTERNAL_STORAGE;
+            FLAG_GRANT_READ_URI_PERMISSION is set per-intent at open time.
+        -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
         <!-- Search widget -->
         <receiver
             android:name=".ui.SearchWidgetProvider"

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
@@ -35,6 +35,10 @@ class ThemePreferences(private val prefs: SharedPreferences) {
         private const val KEY_AUTO_IGNORE_THRESHOLD = "auto_ignore_threshold"
         private const val KEY_CONFIG_SOURCE_DIRTY = "config_source_dirty"
         const val KEY_INSTALLED_APPS_ENABLED = "installed_apps_enabled"
+        const val KEY_LOCAL_SEARCH_ENABLED = "local_search_enabled"
+        private const val KEY_LOCAL_SEARCH_QUERY_MODE = "local_search_query_mode"
+        private const val KEY_LOCAL_SEARCH_SORT_FIELD = "local_search_sort_field"
+        private const val KEY_LOCAL_SEARCH_SORT_DIR = "local_search_sort_dir"
         const val DEFAULT_AUTO_IGNORE_THRESHOLD = 3
         const val AUTO_IGNORE_THRESHOLD_MIN = 1
         const val AUTO_IGNORE_THRESHOLD_MAX = 20
@@ -96,6 +100,26 @@ class ThemePreferences(private val prefs: SharedPreferences) {
     var installedAppsEnabled: Boolean
         get() = prefs.getBoolean(KEY_INSTALLED_APPS_ENABLED, true)
         set(value) { prefs.edit().putBoolean(KEY_INSTALLED_APPS_ENABLED, value).apply() }
+
+    /** When on, the 's' keyword intercepts searches for on-device file search. Off by default. */
+    var localSearchEnabled: Boolean
+        get() = prefs.getBoolean(KEY_LOCAL_SEARCH_ENABLED, false)
+        set(value) { prefs.edit().putBoolean(KEY_LOCAL_SEARCH_ENABLED, value).apply() }
+
+    /** Default query mode for local file search. One of "simple", "wildcard", "regex". */
+    var localSearchQueryMode: String
+        get() = prefs.getString(KEY_LOCAL_SEARCH_QUERY_MODE, "simple") ?: "simple"
+        set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_QUERY_MODE, value).apply() }
+
+    /** Default sort field for local file search. Empty string defaults to "relevance" in the pipeline. */
+    var localSearchSortField: String
+        get() = prefs.getString(KEY_LOCAL_SEARCH_SORT_FIELD, "") ?: ""
+        set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_SORT_FIELD, value).apply() }
+
+    /** Default sort direction for local file search. Empty string defaults to "desc" in the pipeline. */
+    var localSearchSortDir: String
+        get() = prefs.getString(KEY_LOCAL_SEARCH_SORT_DIR, "") ?: ""
+        set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_SORT_DIR, value).apply() }
 
     var shortcutRows: Int
         get() = prefs.getInt(KEY_SHORTCUT_ROWS, 2)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
@@ -39,6 +39,11 @@ class ThemePreferences(private val prefs: SharedPreferences) {
         private const val KEY_LOCAL_SEARCH_QUERY_MODE = "local_search_query_mode"
         private const val KEY_LOCAL_SEARCH_SORT_FIELD = "local_search_sort_field"
         private const val KEY_LOCAL_SEARCH_SORT_DIR = "local_search_sort_dir"
+        private const val KEY_LOCAL_SEARCH_VIEW = "local_search_view"
+        private const val KEY_LOCAL_SEARCH_FILTER_TYPES = "local_search_filter_types"
+        private const val KEY_LOCAL_SEARCH_FILTER_DATE_PRESET = "local_search_filter_date_preset"
+        private const val KEY_LOCAL_SEARCH_FILTER_PATH_PREFIX = "local_search_filter_path_prefix"
+        private const val KEY_LOCAL_SEARCH_FILTER_TITLE_ONLY = "local_search_filter_title_only"
         private const val KEY_RECENTLY_OPENED = "local_search_recently_opened"
         private const val RECENTLY_OPENED_MAX = 50
         const val DEFAULT_AUTO_IGNORE_THRESHOLD = 3
@@ -122,6 +127,39 @@ class ThemePreferences(private val prefs: SharedPreferences) {
     var localSearchSortDir: String
         get() = prefs.getString(KEY_LOCAL_SEARCH_SORT_DIR, "") ?: ""
         set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_SORT_DIR, value).apply() }
+
+    /** Preferred results layout: "list" (default) or "grid". View-only — does not trigger re-search. */
+    var localSearchView: String
+        get() = prefs.getString(KEY_LOCAL_SEARCH_VIEW, "list") ?: "list"
+        set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_VIEW, value).apply() }
+
+    /** Active file-type filter strings (e.g. ["image","video"]). Empty means no filter. */
+    var localSearchFilterTypes: List<String>
+        get() {
+            val json = prefs.getString(KEY_LOCAL_SEARCH_FILTER_TYPES, null) ?: return emptyList()
+            return try {
+                val arr = org.json.JSONArray(json)
+                (0 until arr.length()).map { arr.getString(it) }
+            } catch (_: Exception) { emptyList() }
+        }
+        set(value) {
+            prefs.edit().putString(KEY_LOCAL_SEARCH_FILTER_TYPES, org.json.JSONArray(value).toString()).apply()
+        }
+
+    /** Active date preset: "any" (default), "week", "month", or "year". */
+    var localSearchFilterDatePreset: String
+        get() = prefs.getString(KEY_LOCAL_SEARCH_FILTER_DATE_PRESET, "any") ?: "any"
+        set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_FILTER_DATE_PRESET, value).apply() }
+
+    /** Path prefix filter string. Empty string means no filter. */
+    var localSearchFilterPathPrefix: String
+        get() = prefs.getString(KEY_LOCAL_SEARCH_FILTER_PATH_PREFIX, "") ?: ""
+        set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_FILTER_PATH_PREFIX, value).apply() }
+
+    /** When true, only match the file name/title (not path content). Default false. */
+    var localSearchFilterTitleOnly: Boolean
+        get() = prefs.getBoolean(KEY_LOCAL_SEARCH_FILTER_TITLE_ONLY, false)
+        set(value) { prefs.edit().putBoolean(KEY_LOCAL_SEARCH_FILTER_TITLE_ONLY, value).apply() }
 
     /**
      * Ordered list of recently-opened local-file ids (paths), most-recent first.

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
@@ -39,6 +39,8 @@ class ThemePreferences(private val prefs: SharedPreferences) {
         private const val KEY_LOCAL_SEARCH_QUERY_MODE = "local_search_query_mode"
         private const val KEY_LOCAL_SEARCH_SORT_FIELD = "local_search_sort_field"
         private const val KEY_LOCAL_SEARCH_SORT_DIR = "local_search_sort_dir"
+        private const val KEY_RECENTLY_OPENED = "local_search_recently_opened"
+        private const val RECENTLY_OPENED_MAX = 50
         const val DEFAULT_AUTO_IGNORE_THRESHOLD = 3
         const val AUTO_IGNORE_THRESHOLD_MIN = 1
         const val AUTO_IGNORE_THRESHOLD_MAX = 20
@@ -120,6 +122,32 @@ class ThemePreferences(private val prefs: SharedPreferences) {
     var localSearchSortDir: String
         get() = prefs.getString(KEY_LOCAL_SEARCH_SORT_DIR, "") ?: ""
         set(value) { prefs.edit().putString(KEY_LOCAL_SEARCH_SORT_DIR, value).apply() }
+
+    /**
+     * Ordered list of recently-opened local-file ids (paths), most-recent first.
+     * Capped at [RECENTLY_OPENED_MAX]. Used as the `history` param in [SearchRequest]
+     * to boost recently-opened files in scoring.
+     */
+    val recentlyOpened: List<String>
+        get() {
+            val json = prefs.getString(KEY_RECENTLY_OPENED, null) ?: return emptyList()
+            return try {
+                val arr = org.json.JSONArray(json)
+                (0 until arr.length()).map { arr.getString(it) }
+            } catch (_: Exception) { emptyList() }
+        }
+
+    /**
+     * Records [id] as the most-recently-opened file. Deduplicates (moves to front on
+     * re-open) and caps the list at [RECENTLY_OPENED_MAX].
+     */
+    fun addRecentlyOpened(id: String) {
+        val current = recentlyOpened.toMutableList()
+        current.remove(id)
+        current.add(0, id)
+        val trimmed = current.take(RECENTLY_OPENED_MAX)
+        prefs.edit().putString(KEY_RECENTLY_OPENED, org.json.JSONArray(trimmed).toString()).apply()
+    }
 
     var shortcutRows: Int
         get() = prefs.getInt(KEY_SHORTCUT_ROWS, 2)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
@@ -44,6 +44,8 @@ class ThemePreferences(private val prefs: SharedPreferences) {
         private const val KEY_LOCAL_SEARCH_FILTER_DATE_PRESET = "local_search_filter_date_preset"
         private const val KEY_LOCAL_SEARCH_FILTER_PATH_PREFIX = "local_search_filter_path_prefix"
         private const val KEY_LOCAL_SEARCH_FILTER_TITLE_ONLY = "local_search_filter_title_only"
+        private const val KEY_LOCAL_SEARCH_CASE_SENSITIVE = "local_search_case_sensitive"
+        private const val KEY_LOCAL_SEARCH_EXACT_PHRASE = "local_search_exact_phrase"
         private const val KEY_RECENTLY_OPENED = "local_search_recently_opened"
         private const val RECENTLY_OPENED_MAX = 50
         const val DEFAULT_AUTO_IGNORE_THRESHOLD = 3
@@ -160,6 +162,16 @@ class ThemePreferences(private val prefs: SharedPreferences) {
     var localSearchFilterTitleOnly: Boolean
         get() = prefs.getBoolean(KEY_LOCAL_SEARCH_FILTER_TITLE_ONLY, false)
         set(value) { prefs.edit().putBoolean(KEY_LOCAL_SEARCH_FILTER_TITLE_ONLY, value).apply() }
+
+    /** When true, term/phrase comparisons are case-sensitive; regex is unaffected. Default false. */
+    var localSearchCaseSensitive: Boolean
+        get() = prefs.getBoolean(KEY_LOCAL_SEARCH_CASE_SENSITIVE, false)
+        set(value) { prefs.edit().putBoolean(KEY_LOCAL_SEARCH_CASE_SENSITIVE, value).apply() }
+
+    /** When true and queryMode != regex, the whole query is matched as one ordered phrase. Default false. */
+    var localSearchExactPhrase: Boolean
+        get() = prefs.getBoolean(KEY_LOCAL_SEARCH_EXACT_PHRASE, false)
+        set(value) { prefs.edit().putBoolean(KEY_LOCAL_SEARCH_EXACT_PHRASE, value).apply() }
 
     /**
      * Ordered list of recently-opened local-file ids (paths), most-recent first.

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptor.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptor.kt
@@ -1,5 +1,6 @@
 package sh.kavi.fasttravel.localsearch
 
+import sh.kavi.fasttravel.localsearch.index.DateRange
 import sh.kavi.fasttravel.localsearch.index.FileType
 import sh.kavi.fasttravel.localsearch.index.Filters
 import sh.kavi.fasttravel.localsearch.index.SearchRequest
@@ -52,16 +53,66 @@ fun buildLocalSearchRequest(
     sortField: String,
     sortDir: String,
     history: List<String>,
+    types: List<FileType> = emptyList(),
+    modifiedRange: DateRange? = null,
+    pathPrefix: String = "",
+    titleOnly: Boolean = false,
+    page: Int = 0,
     pageSize: Int = 50,
 ): SearchRequest = SearchRequest(
     query = query,
     queryMode = runCatching { QueryMode.fromString(queryMode) }.getOrDefault(QueryMode.SIMPLE),
     sort = Sort(field = sortField, dir = sortDir),
-    filters = Filters(),
-    page = 0,
+    filters = Filters(
+        types = types,
+        modifiedRange = modifiedRange,
+        pathPrefix = pathPrefix,
+        titleOnly = titleOnly,
+    ),
+    page = page,
     pageSize = pageSize,
     history = history,
 )
+
+private const val DAY_MS = 86_400_000L
+
+/**
+ * Converts a named date preset to an epoch-ms open range (from, to=0 meaning open upper bound),
+ * or null for "any" (no filter). Matches the extension's datePresetToRange semantics:
+ *   week  → 7 days
+ *   month → 30 days
+ *   year  → 365 days
+ *
+ * Pure — no android.* imports; JVM-testable.
+ */
+fun datePresetToRange(preset: String, now: Long): DateRange? = when (preset) {
+    "week"  -> DateRange(from = now - 7L   * DAY_MS)
+    "month" -> DateRange(from = now - 30L  * DAY_MS)
+    "year"  -> DateRange(from = now - 365L * DAY_MS)
+    else    -> null  // "any" or unknown → no filter
+}
+
+/**
+ * Toggles [type] in the active [types] list: removes it if already present,
+ * appends it otherwise. Returns a new list — does not mutate the input.
+ * An empty result means "all types" (no filter).
+ *
+ * Matches the extension's toggleType semantics. Pure — JVM-testable.
+ */
+fun toggleType(types: List<String>, type: String): List<String> =
+    if (types.contains(type)) types.filter { it != type } else types + type
+
+/**
+ * Returns true when more pages are available ([loaded] < [total]).
+ * Pure — JVM-testable.
+ */
+fun hasMore(loaded: Int, total: Int): Boolean = loaded < total
+
+/**
+ * Returns the next page index (0-based).
+ * Pure — JVM-testable.
+ */
+fun nextPage(currentPage: Int): Int = currentPage + 1
 
 /**
  * Broad file-type category for icon selection.

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptor.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptor.kt
@@ -1,0 +1,115 @@
+package sh.kavi.fasttravel.localsearch
+
+import sh.kavi.fasttravel.localsearch.index.FileType
+import sh.kavi.fasttravel.localsearch.index.Filters
+import sh.kavi.fasttravel.localsearch.index.SearchRequest
+import sh.kavi.fasttravel.localsearch.index.Sort
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.Calendar
+
+/** Result of [shouldInterceptLocalSearch]. */
+data class InterceptResult(val intercept: Boolean, val query: String)
+
+// Matches "s" (bare) or "s <query>" — anchored so "search", "sm", "so" etc. don't fire.
+private val S_PATTERN = Regex("""^s(\s+(.*))?$""")
+
+/**
+ * Returns true (with the extracted query) when the `s` command intercept should fire.
+ *
+ * Intercepts only when ALL of:
+ *   (a) [enabled] is true (local search feature is on), AND
+ *   (b) [configHasS] is false (the active config does not claim the `s` trigger), AND
+ *   (c) [input] (trimmed) matches `^s(\s+(.*))?$`.
+ *
+ * Pure — no android.* imports; JVM-testable.
+ */
+fun shouldInterceptLocalSearch(
+    input: String,
+    enabled: Boolean,
+    configHasS: Boolean,
+): InterceptResult {
+    if (!enabled || configHasS) return InterceptResult(intercept = false, query = "")
+    val trimmed = input.trim()
+    val match = S_PATTERN.matchEntire(trimmed) ?: return InterceptResult(intercept = false, query = "")
+    val query = match.groupValues[2].trim()
+    return InterceptResult(intercept = true, query = query)
+}
+
+/**
+ * Builds a [SearchRequest] from user preference strings + the extracted query.
+ *
+ * Defaults: page=0, pageSize=[pageSize] (50), empty filters.
+ * Unknown [queryMode] strings fall back to SIMPLE rather than throwing.
+ *
+ * Pure — no android.* imports; JVM-testable.
+ */
+fun buildLocalSearchRequest(
+    query: String,
+    queryMode: String,
+    sortField: String,
+    sortDir: String,
+    history: List<String>,
+    pageSize: Int = 50,
+): SearchRequest = SearchRequest(
+    query = query,
+    queryMode = runCatching { QueryMode.fromString(queryMode) }.getOrDefault(QueryMode.SIMPLE),
+    sort = Sort(field = sortField, dir = sortDir),
+    filters = Filters(),
+    page = 0,
+    pageSize = pageSize,
+    history = history,
+)
+
+/**
+ * Broad file-type category for icon selection.
+ * One entry per [FileType], named identically for easy mapping.
+ */
+enum class LocalFileIcon {
+    FOLDER, IMAGE, VIDEO, AUDIO, ARCHIVE, CODE, DOCUMENT, OTHER
+}
+
+/**
+ * Maps a [FileType] to a [LocalFileIcon] category used by the Compose layer to select
+ * the correct Material icon and tint.
+ *
+ * Pure — no android.* or Compose imports; JVM-testable.
+ */
+fun fileTypeIcon(type: FileType): LocalFileIcon = when (type) {
+    FileType.FOLDER   -> LocalFileIcon.FOLDER
+    FileType.IMAGE    -> LocalFileIcon.IMAGE
+    FileType.VIDEO    -> LocalFileIcon.VIDEO
+    FileType.AUDIO    -> LocalFileIcon.AUDIO
+    FileType.ARCHIVE  -> LocalFileIcon.ARCHIVE
+    FileType.CODE     -> LocalFileIcon.CODE
+    FileType.DOCUMENT -> LocalFileIcon.DOCUMENT
+    FileType.OTHER    -> LocalFileIcon.OTHER
+}
+
+/** Compact human-readable file size (e.g. "1.2 MB"). Pure — JVM-testable. */
+fun formatFileSize(bytes: Long): String = when {
+    bytes <= 0 -> ""
+    bytes < 1_024L -> "$bytes B"
+    bytes < 1_048_576L -> "%.1f KB".format(bytes / 1_024.0)
+    bytes < 1_073_741_824L -> "%.1f MB".format(bytes / 1_048_576.0)
+    else -> "%.1f GB".format(bytes / 1_073_741_824.0)
+}
+
+/**
+ * Compact date representation: "Jun 28" for current-year files, "2023" for older ones.
+ * Returns empty string for epoch 0 (unknown date).
+ * Pure — JVM-testable.
+ */
+fun formatModifiedDate(epochMs: Long): String {
+    if (epochMs == 0L) return ""
+    val fileYear = Calendar.getInstance().also { it.timeInMillis = epochMs }
+        .get(Calendar.YEAR)
+    val thisYear = Calendar.getInstance().get(Calendar.YEAR)
+    return if (fileYear == thisYear) {
+        SimpleDateFormat("MMM d", Locale.getDefault()).format(Date(epochMs))
+    } else {
+        fileYear.toString()
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptor.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptor.kt
@@ -44,6 +44,7 @@ fun shouldInterceptLocalSearch(
  *
  * Defaults: page=0, pageSize=[pageSize] (50), empty filters.
  * Unknown [queryMode] strings fall back to SIMPLE rather than throwing.
+ * [sortField] "created" is remapped to "" (relevance) — Bug B: created sort removed.
  *
  * Pure — no android.* imports; JVM-testable.
  */
@@ -59,10 +60,13 @@ fun buildLocalSearchRequest(
     titleOnly: Boolean = false,
     page: Int = 0,
     pageSize: Int = 50,
+    caseSensitive: Boolean = false,
+    exactPhrase: Boolean = false,
 ): SearchRequest = SearchRequest(
     query = query,
     queryMode = runCatching { QueryMode.fromString(queryMode) }.getOrDefault(QueryMode.SIMPLE),
-    sort = Sort(field = sortField, dir = sortDir),
+    // Bug B: "created" sort is non-functional on Android; remap to "" (relevance).
+    sort = Sort(field = if (sortField == "created") "" else sortField, dir = sortDir),
     filters = Filters(
         types = types,
         modifiedRange = modifiedRange,
@@ -72,6 +76,8 @@ fun buildLocalSearchRequest(
     page = page,
     pageSize = pageSize,
     history = history,
+    caseSensitive = caseSensitive,
+    exactPhrase = exactPhrase,
 )
 
 private const val DAY_MS = 86_400_000L

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Classify.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Classify.kt
@@ -1,0 +1,64 @@
+package sh.kavi.fasttravel.localsearch.index
+
+/**
+ * Maps lowercase file extensions to [FileType] categories.
+ * Mirrors companion/internal/index/classify.go extCategory exactly.
+ */
+private val extCategory: Map<String, FileType> = mapOf(
+    // image
+    "jpg"  to FileType.IMAGE, "jpeg" to FileType.IMAGE,
+    "png"  to FileType.IMAGE, "gif"  to FileType.IMAGE,
+    "webp" to FileType.IMAGE, "bmp"  to FileType.IMAGE,
+    "svg"  to FileType.IMAGE, "heic" to FileType.IMAGE,
+    "tiff" to FileType.IMAGE, "ico"  to FileType.IMAGE,
+
+    // video
+    "mp4"  to FileType.VIDEO, "mkv"  to FileType.VIDEO,
+    "mov"  to FileType.VIDEO, "avi"  to FileType.VIDEO,
+    "webm" to FileType.VIDEO, "flv"  to FileType.VIDEO,
+    "wmv"  to FileType.VIDEO, "m4v"  to FileType.VIDEO,
+
+    // audio
+    "mp3"  to FileType.AUDIO, "flac" to FileType.AUDIO,
+    "wav"  to FileType.AUDIO, "ogg"  to FileType.AUDIO,
+    "m4a"  to FileType.AUDIO, "aac"  to FileType.AUDIO,
+    "opus" to FileType.AUDIO,
+
+    // archive
+    "zip"  to FileType.ARCHIVE, "tar" to FileType.ARCHIVE,
+    "gz"   to FileType.ARCHIVE, "bz2" to FileType.ARCHIVE,
+    "xz"   to FileType.ARCHIVE, "7z"  to FileType.ARCHIVE,
+    "rar"  to FileType.ARCHIVE, "zst" to FileType.ARCHIVE,
+
+    // code
+    "go"   to FileType.CODE, "js"   to FileType.CODE,
+    "ts"   to FileType.CODE, "tsx"  to FileType.CODE,
+    "jsx"  to FileType.CODE, "py"   to FileType.CODE,
+    "rs"   to FileType.CODE, "java" to FileType.CODE,
+    "kt"   to FileType.CODE, "c"    to FileType.CODE,
+    "h"    to FileType.CODE, "cpp"  to FileType.CODE,
+    "hpp"  to FileType.CODE, "cs"   to FileType.CODE,
+    "rb"   to FileType.CODE, "php"  to FileType.CODE,
+    "sh"   to FileType.CODE, "json" to FileType.CODE,
+    "yaml" to FileType.CODE, "yml"  to FileType.CODE,
+    "toml" to FileType.CODE, "xml"  to FileType.CODE,
+    "html" to FileType.CODE, "css"  to FileType.CODE,
+    "sql"  to FileType.CODE,
+
+    // document
+    "pdf"  to FileType.DOCUMENT, "doc"  to FileType.DOCUMENT,
+    "docx" to FileType.DOCUMENT, "xls"  to FileType.DOCUMENT,
+    "xlsx" to FileType.DOCUMENT, "ppt"  to FileType.DOCUMENT,
+    "pptx" to FileType.DOCUMENT, "odt"  to FileType.DOCUMENT,
+    "ods"  to FileType.DOCUMENT, "odp"  to FileType.DOCUMENT,
+    "txt"  to FileType.DOCUMENT, "md"   to FileType.DOCUMENT,
+    "rtf"  to FileType.DOCUMENT, "csv"  to FileType.DOCUMENT,
+    "epub" to FileType.DOCUMENT,
+)
+
+/**
+ * Returns the [FileType] category for a given lowercase extension.
+ * If the extension is unknown, returns [FileType.OTHER].
+ * Mirrors companion/internal/index/classify.go ClassifyType.
+ */
+fun classifyType(ext: String): FileType = extCategory[ext] ?: FileType.OTHER

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Compile.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Compile.kt
@@ -1,0 +1,234 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import sh.kavi.fasttravel.localsearch.query.Node
+
+/**
+ * Compile helpers that drive recall-safe MediaStore candidate narrowing.
+ * Mirrors companion/internal/index/compile.go ORBranches / PositiveSeed / RegexSeeds.
+ *
+ * All functions are pure (no android.* imports) so they can be JVM-unit-tested directly.
+ */
+
+/**
+ * Returns the immediate child nodes when [node] is an "or" node, or a single-element
+ * list containing [node] for any other op.
+ *
+ * Flat-OR invariant: the query grammar emits only a single flat top-level "or" —
+ * branches never contain a nested "or" node. [positiveSeed] relies on this.
+ *
+ * Mirrors companion/internal/index/compile.go ORBranches.
+ */
+fun orBranches(node: Node): List<Node> =
+    if (node.op == "or") node.nodes ?: emptyList() else listOf(node)
+
+/**
+ * Returns the longest contiguous literal fragment from positive (not under a "not")
+ * term and phrase nodes in [branch]. Wildcard characters ('*' and '?') split a term
+ * value into fragments; the longest fragment wins.
+ * Regex nodes are always skipped — their values are not safe as literal seeds.
+ *
+ * Recall safety: using any literal substring as the native query seed means the
+ * index returns a superset of true matches. The pipeline matcher enforces the full
+ * query semantics over that superset.
+ *
+ * Returns ("", false) if no fragment of length ≥ 1 exists.
+ * Mirrors companion/internal/index/compile.go PositiveSeed.
+ */
+fun positiveSeed(branch: Node): Pair<String, Boolean> {
+    var best = ""
+
+    fun walk(n: Node, negated: Boolean) {
+        when (n.op) {
+            "and", "or" -> n.nodes?.forEach { walk(it, negated) }
+            "not"       -> n.node?.let { walk(it, true) }
+            "term", "phrase" -> {
+                if (negated) return
+                for (frag in wildcardFragments(n.value ?: "")) {
+                    if (frag.length > best.length) best = frag
+                }
+                // "regex": intentionally skipped — not safe as literal seed.
+            }
+        }
+    }
+
+    walk(branch, false)
+    return if (best.isEmpty()) Pair("", false) else Pair(best, true)
+}
+
+/**
+ * Splits [s] on '*' and '?' and returns the non-empty pieces.
+ * A value with no wildcards returns a single-element list [s].
+ */
+internal fun wildcardFragments(s: String): List<String> =
+    s.split('*', '?').filter { it.isNotEmpty() }
+
+/**
+ * Derives MediaStore LIKE substring seeds from an RE2 [pattern] that are recall-safe.
+ * Every string the pattern matches contains at least one of the returned seeds.
+ *
+ * Splits the pattern on top-level alternation and extracts the longest required
+ * literal run from each alternative. If any alternative has no usable literal
+ * (length ≥ 2), returns broad=true, signalling the caller to fall back to a
+ * broad (unfiltered-by-name) MediaStore query.
+ *
+ * Seeds are deduplicated before return.
+ *
+ * Mirrors companion/internal/index/compile.go RegexSeeds.
+ */
+fun regexSeeds(pattern: String): Pair<List<String>, Boolean> {
+    val alternatives = splitTopLevelAlternation(pattern)
+    val seen = mutableSetOf<String>()
+    val result = mutableListOf<String>()
+    for (alt in alternatives) {
+        val seed = longestRequiredLiteralRun(alt)
+        if (seed.length < 2) return Pair(emptyList(), true)
+        if (seen.add(seed)) result.add(seed)
+    }
+    return Pair(result, false)
+}
+
+/**
+ * Splits [pattern] on top-level '|' characters — those not escaped (\|), not inside
+ * a char class ([...]), and not inside a group (...). Returns at least one element.
+ * Mirrors companion/internal/index/compile.go splitTopLevelAlternation.
+ */
+internal fun splitTopLevelAlternation(pattern: String): List<String> {
+    val alternatives = mutableListOf<String>()
+    var depth = 0
+    var inClass = false
+    var start = 0
+    var i = 0
+    while (i < pattern.length) {
+        val ch = pattern[i]
+        when {
+            ch == '\\' && i + 1 < pattern.length -> i += 2   // skip escaped char
+            inClass -> {
+                if (ch == ']') inClass = false
+                i++
+            }
+            ch == '[' -> { inClass = true; i++ }
+            ch == '(' -> { depth++; i++ }
+            ch == ')' -> { if (depth > 0) depth--; i++ }
+            ch == '|' && depth == 0 -> {
+                alternatives.add(pattern.substring(start, i))
+                start = i + 1
+                i++
+            }
+            else -> i++
+        }
+    }
+    alternatives.add(pattern.substring(start))
+    return alternatives
+}
+
+/**
+ * Finds the longest contiguous run of characters that MUST appear in every string
+ * matched by the RE2 alternative [alt].
+ *
+ * Rules (left-to-right scan):
+ *   - Ordinary literal chars and escaped non-letter metacharacters (\.  \*  \\  etc.)
+ *     extend the current run.
+ *   - Quantifiers after a run char: '*' or '?' → drop the last char (may be zero),
+ *     break the run; '+' → keep the char (at least one), break the run;
+ *     '{' (any interval) → drop the last char (conservative), skip to '}', break.
+ *   - Run-breakers: '.', '[…]', '(', ')', '^', '$', any '\<letter>' escape (\d \w…).
+ *   - Only depth-0 literals are collected (chars inside groups are never required).
+ *
+ * Mirrors companion/internal/index/compile.go longestRequiredLiteralRun.
+ */
+internal fun longestRequiredLiteralRun(alt: String): String {
+    var best = ""
+    val cur = StringBuilder()
+
+    fun endRun() {
+        if (cur.length > best.length) best = cur.toString()
+        cur.clear()
+    }
+    fun dropLastAndEndRun() {
+        if (cur.isNotEmpty()) cur.deleteCharAt(cur.length - 1)
+        endRun()
+    }
+    fun consumeQuantifier(start: Int): Int {
+        var j = start
+        if (j >= alt.length) return j
+        when (alt[j]) {
+            '*', '?', '+' -> return j + 1
+            '{' -> {
+                j++
+                while (j < alt.length && alt[j] != '}') j++
+                if (j < alt.length) j++ // skip '}'
+            }
+        }
+        return j
+    }
+
+    var depth = 0
+    var i = 0
+    while (i < alt.length) {
+        val ch = alt[i]
+
+        if (ch == '\\' && i + 1 < alt.length) {
+            val next = alt[i + 1]
+            i += 2
+            if ((next in 'a'..'z') || (next in 'A'..'Z')) {
+                // \d \w \s \D \W \S \b \B etc. → class shorthand / zero-width → break run.
+                endRun()
+                i = consumeQuantifier(i)
+            } else if (depth == 0) {
+                // \. \* \( \) \\ \{ \} \+ \? \^ \$ etc. → literal symbol.
+                cur.append(next)
+                if (i < alt.length) {
+                    when (alt[i]) {
+                        '*', '?' -> { dropLastAndEndRun(); i++ }
+                        '+'      -> { endRun(); i++ }
+                        '{'      -> { dropLastAndEndRun(); i = consumeQuantifier(i) }
+                    }
+                }
+            }
+            continue
+        }
+
+        when (ch) {
+            '.' -> { endRun(); i++; i = consumeQuantifier(i) }
+
+            '[' -> {
+                endRun()
+                i++ // skip '['
+                if (i < alt.length && alt[i] == '^') i++      // negation
+                if (i < alt.length && alt[i] == ']') i++      // leading ']' is literal
+                while (i < alt.length && alt[i] != ']') {
+                    if (alt[i] == '\\') i++                    // skip escaped char inside class
+                    i++
+                }
+                if (i < alt.length) i++                        // skip closing ']'
+                i = consumeQuantifier(i)
+            }
+
+            '(' -> { depth++; endRun(); i++ }
+            ')' -> { if (depth > 0) depth--; endRun(); i++ }
+
+            '^', '$' -> { endRun(); i++ }
+
+            // Stray quantifiers (no preceding literal in current run).
+            '*', '?', '+' -> { endRun(); i++ }
+            '{' -> { endRun(); i = consumeQuantifier(i) }
+
+            else -> {
+                // Regular literal — only at depth 0 (chars inside groups are never required).
+                i++
+                if (depth == 0) {
+                    cur.append(ch)
+                    if (i < alt.length) {
+                        when (alt[i]) {
+                            '*', '?' -> { dropLastAndEndRun(); i++ }
+                            '+'      -> { endRun(); i++ }
+                            '{'      -> { dropLastAndEndRun(); i = consumeQuantifier(i) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    endRun()
+    return best
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/FileResult.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/FileResult.kt
@@ -1,0 +1,96 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+
+/**
+ * FileType is a broad file-type category.
+ * Mirrors companion/internal/protocol/types.go FileType constants.
+ */
+enum class FileType(val value: String) {
+    DOCUMENT("document"),
+    IMAGE("image"),
+    VIDEO("video"),
+    AUDIO("audio"),
+    ARCHIVE("archive"),
+    CODE("code"),
+    FOLDER("folder"),
+    OTHER("other");
+
+    companion object {
+        fun fromString(value: String): FileType =
+            entries.firstOrNull { it.value == value } ?: OTHER
+    }
+}
+
+/**
+ * DateRange is an inclusive range in epoch milliseconds.
+ * A bound of 0 means unbounded on that side (matches Go's zero-value semantics).
+ */
+data class DateRange(
+    val from: Long = 0L,
+    val to: Long = 0L,
+)
+
+/**
+ * Filters are optional filters applied before pagination.
+ * Mirrors companion/internal/protocol/types.go Filters.
+ */
+data class Filters(
+    val types: List<FileType> = emptyList(),
+    val createdRange: DateRange? = null,
+    val modifiedRange: DateRange? = null,
+    val pathPrefix: String = "",
+    val titleOnly: Boolean = false,
+)
+
+/**
+ * Sort describes the sort order for search results.
+ * Mirrors companion/internal/protocol/types.go Sort.
+ */
+data class Sort(
+    val field: String = "",  // "" defaults to "relevance" in sortResults
+    val dir: String = "",    // "" defaults to "desc" in sortResults
+)
+
+/**
+ * SearchRequest is the parameter object for [search].
+ * Mirrors the fields of companion/internal/protocol/types.go SearchRequest that the
+ * engine-agnostic pipeline uses (MediaStore wiring and Indexer abstraction are 5b).
+ */
+data class SearchRequest(
+    val query: String,
+    val queryMode: QueryMode = QueryMode.SIMPLE,
+    val sort: Sort = Sort(),
+    val filters: Filters = Filters(),
+    val page: Int = 0,
+    val pageSize: Int = 100,
+    val history: List<String> = emptyList(),
+)
+
+/**
+ * FileResult is a single file match.
+ * Mirrors companion/internal/protocol/types.go FileResult.
+ */
+data class FileResult(
+    val id: String,
+    val name: String,
+    val path: String,
+    val dir: String = "",
+    val ext: String = "",
+    val mime: String = "",
+    val type: FileType = FileType.OTHER,
+    val size: Long = 0L,
+    val createdAt: Long = 0L,
+    val modifiedAt: Long = 0L,
+    val score: Double = 0.0,
+    val iconHint: String = "",
+)
+
+/**
+ * SearchResult is the return type of [search].
+ */
+data class SearchResult(
+    val results: List<FileResult>,
+    val total: Int,
+    val page: Int,
+)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/FileResult.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/FileResult.kt
@@ -65,6 +65,12 @@ data class SearchRequest(
     val page: Int = 0,
     val pageSize: Int = 100,
     val history: List<String> = emptyList(),
+    /** When true, term/phrase comparisons are case-sensitive; regex is unaffected.
+     *  Mirrors companion/internal/protocol/types.go SearchRequest.CaseSensitive. */
+    val caseSensitive: Boolean = false,
+    /** When true and queryMode != REGEX, treat the whole query as one ordered phrase.
+     *  Mirrors companion/internal/protocol/types.go SearchRequest.ExactPhrase. */
+    val exactPhrase: Boolean = false,
 )
 
 /**
@@ -93,4 +99,8 @@ data class SearchResult(
     val results: List<FileResult>,
     val total: Int,
     val page: Int,
+    /** True when the MediaStore candidate query was capped at CANDIDATE_LIMIT, meaning
+     *  actual matches may exceed [total] (lower-bound count).
+     *  Mirrors companion/internal/protocol/types.go SearchResponse.Degraded. */
+    val degraded: Boolean = false,
 )

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Matcher.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Matcher.kt
@@ -2,6 +2,7 @@ package sh.kavi.fasttravel.localsearch.index
 
 import sh.kavi.fasttravel.localsearch.query.Node
 import sh.kavi.fasttravel.localsearch.query.QueryMode
+import java.util.Locale
 
 /**
  * Returns whether [result] satisfies the AST [node].
@@ -24,12 +25,12 @@ fun matches(result: FileResult, node: Node, @Suppress("UNUSED_PARAMETER") mode: 
             if (node.wildcard == true) {
                 globMatch(node.value ?: "", field)
             } else {
-                field.lowercase().contains((node.value ?: "").lowercase())
+                field.lowercase(Locale.ROOT).contains((node.value ?: "").lowercase(Locale.ROOT))
             }
         }
         "phrase" -> {
             val field = resolveField(result, node.field)
-            field.lowercase().contains((node.value ?: "").lowercase())
+            field.lowercase(Locale.ROOT).contains((node.value ?: "").lowercase(Locale.ROOT))
         }
         "regex"  -> {
             val field = resolveField(result, node.field)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Matcher.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Matcher.kt
@@ -1,0 +1,73 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import sh.kavi.fasttravel.localsearch.query.Node
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+
+/**
+ * Returns whether [result] satisfies the AST [node].
+ * Mirrors companion/internal/index/match.go Matches exactly:
+ *   - and  → all children must match
+ *   - or   → at least one child must match
+ *   - not  → negate the single child
+ *   - term (wildcard=false) → case-insensitive substring of name|path
+ *   - term (wildcard=true)  → anchored glob match (see [globMatch])
+ *   - phrase → case-insensitive substring of the exact value
+ *   - regex  → partial regex match (no forced anchoring); compile failure → false
+ */
+fun matches(result: FileResult, node: Node, @Suppress("UNUSED_PARAMETER") mode: QueryMode): Boolean =
+    when (node.op) {
+        "and"    -> node.nodes?.all { matches(result, it, mode) } ?: true
+        "or"     -> node.nodes?.any { matches(result, it, mode) } ?: false
+        "not"    -> if (node.node == null) true else !matches(result, node.node, mode)
+        "term"   -> {
+            val field = resolveField(result, node.field)
+            if (node.wildcard == true) {
+                globMatch(node.value ?: "", field)
+            } else {
+                field.lowercase().contains((node.value ?: "").lowercase())
+            }
+        }
+        "phrase" -> {
+            val field = resolveField(result, node.field)
+            field.lowercase().contains((node.value ?: "").lowercase())
+        }
+        "regex"  -> {
+            val field = resolveField(result, node.field)
+            try {
+                Regex(node.value ?: "").containsMatchIn(field)
+            } catch (_: Exception) {
+                false
+            }
+        }
+        else -> false
+    }
+
+/**
+ * Returns the [FileResult] field value for a given field name.
+ * "path" maps to [FileResult.path]; all other values default to [FileResult.name].
+ */
+private fun resolveField(result: FileResult, field: String?): String =
+    if (field == "path") result.path else result.name
+
+/**
+ * Performs an anchored case-insensitive glob match of [pattern] against [s].
+ * Only `*` (match any sequence) and `?` (match any single character) are wildcards;
+ * all other regex metacharacters in the pattern are escaped.
+ * Mirrors companion/internal/index/match.go globMatch.
+ */
+private fun globMatch(pattern: String, s: String): Boolean {
+    val sb = StringBuilder("(?i)^")
+    for (ch in pattern) {
+        when (ch) {
+            '*'  -> sb.append(".*")
+            '?'  -> sb.append(".")
+            else -> sb.append(Regex.escape(ch.toString()))
+        }
+    }
+    sb.append("$")
+    return try {
+        Regex(sb.toString()).containsMatchIn(s)
+    } catch (_: Exception) {
+        false
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Matcher.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Matcher.kt
@@ -6,42 +6,48 @@ import java.util.Locale
 
 /**
  * Returns whether [result] satisfies the AST [node].
- * Mirrors companion/internal/index/match.go Matches exactly:
- *   - and  → all children must match
- *   - or   → at least one child must match
- *   - not  → negate the single child
- *   - term (wildcard=false) → case-insensitive substring of name|path
- *   - term (wildcard=true)  → anchored glob match (see [globMatch])
- *   - phrase → case-insensitive substring of the exact value
- *   - regex  → partial regex match (no forced anchoring); compile failure → false
+ * [caseSensitive] controls whether term and phrase comparisons are case-sensitive.
+ * Regex nodes are unaffected by [caseSensitive] — the pattern's own flags control case.
+ * Mirrors companion/internal/index/match.go Matches exactly.
  */
-fun matches(result: FileResult, node: Node, @Suppress("UNUSED_PARAMETER") mode: QueryMode): Boolean =
-    when (node.op) {
-        "and"    -> node.nodes?.all { matches(result, it, mode) } ?: true
-        "or"     -> node.nodes?.any { matches(result, it, mode) } ?: false
-        "not"    -> if (node.node == null) true else !matches(result, node.node, mode)
-        "term"   -> {
-            val field = resolveField(result, node.field)
-            if (node.wildcard == true) {
-                globMatch(node.value ?: "", field)
-            } else {
-                field.lowercase(Locale.ROOT).contains((node.value ?: "").lowercase(Locale.ROOT))
-            }
-        }
-        "phrase" -> {
-            val field = resolveField(result, node.field)
+fun matches(
+    result: FileResult,
+    node: Node,
+    @Suppress("UNUSED_PARAMETER") mode: QueryMode,
+    caseSensitive: Boolean = false,
+): Boolean = when (node.op) {
+    "and"    -> node.nodes?.all { matches(result, it, mode, caseSensitive) } ?: true
+    "or"     -> node.nodes?.any { matches(result, it, mode, caseSensitive) } ?: false
+    "not"    -> if (node.node == null) true else !matches(result, node.node, mode, caseSensitive)
+    "term"   -> {
+        val field = resolveField(result, node.field)
+        if (node.wildcard == true) {
+            globMatch(node.value ?: "", field, caseSensitive)
+        } else if (caseSensitive) {
+            field.contains(node.value ?: "")
+        } else {
             field.lowercase(Locale.ROOT).contains((node.value ?: "").lowercase(Locale.ROOT))
         }
-        "regex"  -> {
-            val field = resolveField(result, node.field)
-            try {
-                Regex(node.value ?: "").containsMatchIn(field)
-            } catch (_: Exception) {
-                false
-            }
-        }
-        else -> false
     }
+    "phrase" -> {
+        val field = resolveField(result, node.field)
+        if (caseSensitive) {
+            field.contains(node.value ?: "")
+        } else {
+            field.lowercase(Locale.ROOT).contains((node.value ?: "").lowercase(Locale.ROOT))
+        }
+    }
+    "regex"  -> {
+        // Regex is unaffected by caseSensitive; the pattern controls its own flags.
+        val field = resolveField(result, node.field)
+        try {
+            Regex(node.value ?: "").containsMatchIn(field)
+        } catch (_: Exception) {
+            false
+        }
+    }
+    else -> false
+}
 
 /**
  * Returns the [FileResult] field value for a given field name.
@@ -51,13 +57,14 @@ private fun resolveField(result: FileResult, field: String?): String =
     if (field == "path") result.path else result.name
 
 /**
- * Performs an anchored case-insensitive glob match of [pattern] against [s].
+ * Performs an anchored glob match of [pattern] against [s].
  * Only `*` (match any sequence) and `?` (match any single character) are wildcards;
  * all other regex metacharacters in the pattern are escaped.
+ * When [caseSensitive] is false (default) the match uses the `(?i)` prefix.
  * Mirrors companion/internal/index/match.go globMatch.
  */
-private fun globMatch(pattern: String, s: String): Boolean {
-    val sb = StringBuilder("(?i)^")
+private fun globMatch(pattern: String, s: String, caseSensitive: Boolean = false): Boolean {
+    val sb = StringBuilder(if (caseSensitive) "^" else "(?i)^")
     for (ch in pattern) {
         when (ch) {
             '*'  -> sb.append(".*")

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQuery.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQuery.kt
@@ -98,7 +98,12 @@ fun buildSelection(node: Node, mode: QueryMode): Selection {
         args.add("%$seed%")
         args.add("%$seed%")
     }
-    if (clauses.isEmpty()) return Selection(null, null)
+    // No branch produced a positive seed → all branches are negation-only.
+    // Return a match-nothing selection so MediaStore yields 0 candidates, which
+    // matches the Go companion's 0-result behaviour for all-no-seed queries.
+    // (Contrast: regex broad-case keeps Selection(null,null) because the regex
+    //  matcher provides precision over the full candidate set.)
+    if (clauses.isEmpty()) return Selection("0", emptyArray())
     return Selection(clauses.joinToString(" OR "), args.toTypedArray())
 }
 

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQuery.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQuery.kt
@@ -1,0 +1,204 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import android.content.ContentResolver
+import android.os.Build
+import android.provider.MediaStore
+import sh.kavi.fasttravel.localsearch.query.Node
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+import sh.kavi.fasttravel.localsearch.query.parse
+
+// ── Column name literals ───────────────────────────────────────────────────────
+//
+// These are the actual string values of the MediaStore.MediaColumns constants.
+// Declared here as literals so that [buildSelection] has no android.* dependency at
+// runtime and can be exercised from plain JVM unit tests without Robolectric.
+// The values match the compile-time constants:
+//   DISPLAY_NAME  = MediaStore.MediaColumns.DISPLAY_NAME  = "_display_name"
+//   DATA          = MediaStore.MediaColumns.DATA           = "_data"
+
+private const val COL_DISPLAY_NAME = "_display_name"   // MediaStore.MediaColumns.DISPLAY_NAME
+private const val COL_DATA         = "_data"            // MediaStore.MediaColumns.DATA
+
+private const val CANDIDATE_LIMIT = 1000
+
+// ── Selection ─────────────────────────────────────────────────────────────────
+
+/**
+ * A parameterized SQLite WHERE clause ready for [ContentResolver.query].
+ * [selection] and [selectionArgs] are null when no name filter is applicable
+ * (broad fallback: returns up to [CANDIDATE_LIMIT] rows ordered by recency).
+ */
+data class Selection(
+    val selection: String?,
+    val selectionArgs: Array<String>?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Selection) return false
+        return selection == other.selection &&
+                selectionArgs.contentEquals(other.selectionArgs)
+    }
+
+    override fun hashCode(): Int =
+        31 * (selection?.hashCode() ?: 0) + (selectionArgs?.contentHashCode() ?: 0)
+}
+
+private fun Array<String>?.contentEquals(other: Array<String>?): Boolean {
+    if (this == null && other == null) return true
+    if (this == null || other == null) return false
+    return this.contentEquals(other)
+}
+
+// ── buildSelection ────────────────────────────────────────────────────────────
+
+/**
+ * Builds a recall-safe MediaStore WHERE clause (selection + args) from the query AST.
+ *
+ * Pure — no android.* runtime dependency; testable on the JVM.
+ *
+ * Recall-safety contract: the generated WHERE clause may over-return rows (the 5a
+ * pipeline's [matches] function filters precisely) but must never under-return for
+ * the guaranteed subset.
+ *
+ * Seeds containing '%' or '_' are NOT escaped for LIKE, which broadens (rather
+ * than narrows) recall. This is intentionally recall-safe; the pipeline enforces
+ * exact query semantics over the candidate set.
+ *
+ * Regex mode:
+ *   Uses [regexSeeds] to extract required literal fragments. If any alternative
+ *   has no usable seed (broad=true), no name filter is applied. Otherwise,
+ *   generates: `DISPLAY_NAME LIKE ? [OR DISPLAY_NAME LIKE ?]…`
+ *
+ * Simple / Wildcard mode:
+ *   Iterates [orBranches]; for each branch, [positiveSeed] extracts the longest
+ *   literal fragment. Branches with no seed are skipped (not AND'd away — recall-safe).
+ *   Each seeded branch contributes: `(DISPLAY_NAME LIKE ? OR DATA LIKE ?)`.
+ *   Multiple branches are joined with ` OR `.
+ *
+ * Mirrors the Go seed-narrowing logic in companion/internal/index/compile.go.
+ */
+fun buildSelection(node: Node, mode: QueryMode): Selection {
+    if (mode == QueryMode.REGEX) {
+        val pattern = node.value ?: ""
+        val (seeds, broad) = regexSeeds(pattern)
+        if (broad) return Selection(null, null)
+        val clauses = seeds.map { "$COL_DISPLAY_NAME LIKE ?" }
+        val args    = seeds.map { "%$it%" }.toTypedArray()
+        return Selection(clauses.joinToString(" OR "), args)
+    }
+
+    // Simple / Wildcard mode: one branch per OR clause.
+    val branches     = orBranches(node)
+    val clauses      = mutableListOf<String>()
+    val args         = mutableListOf<String>()
+    for (branch in branches) {
+        val (seed, ok) = positiveSeed(branch)
+        if (!ok) continue  // no positive literal seed; skip branch (recall-safe)
+        clauses.add("($COL_DISPLAY_NAME LIKE ? OR $COL_DATA LIKE ?)")
+        args.add("%$seed%")
+        args.add("%$seed%")
+    }
+    if (clauses.isEmpty()) return Selection(null, null)
+    return Selection(clauses.joinToString(" OR "), args.toTypedArray())
+}
+
+// ── MediaStoreSearcher ────────────────────────────────────────────────────────
+
+/**
+ * Queries [MediaStore.Files] for local-file candidates narrowed by the query AST,
+ * then runs the 5a pipeline ([search]) to produce final [SearchResult].
+ *
+ * Date mapping: MediaStore DATE_MODIFIED / DATE_ADDED are stored in SECONDS;
+ * they are multiplied by 1 000 to yield epoch MILLISECONDS for [FileResult].
+ *
+ * API-level notes:
+ *   - [MediaStore.MediaColumns.RELATIVE_PATH] (API 29+) is included in the
+ *     projection only when available; [MediaStore.MediaColumns.DATA] is always
+ *     projected and used as the canonical path (deprecated on API 29+ but still
+ *     populated on all supported devices in the minSdk-26 target range).
+ *   - LIMIT is appended to the sortOrder string (SQLite extension supported by
+ *     MediaStore on API 26+, matching the app's minSdk).
+ *
+ * Pure-function coverage: [buildSelection] is unit-tested; this class is verified
+ * on-device (ContentResolver is not available in JVM unit tests).
+ */
+class MediaStoreSearcher(private val contentResolver: ContentResolver) {
+
+    fun search(req: SearchRequest): SearchResult {
+        val node = parse(req.query, req.queryMode)
+        val sel  = buildSelection(node, req.queryMode)
+
+        // Build projection; RELATIVE_PATH only available on API 29+.
+        val projection = buildList {
+            add(MediaStore.MediaColumns.DISPLAY_NAME)
+            add(MediaStore.MediaColumns.DATA)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                add(MediaStore.MediaColumns.RELATIVE_PATH)
+            }
+            add(MediaStore.MediaColumns.SIZE)
+            add(MediaStore.MediaColumns.DATE_MODIFIED)
+            add(MediaStore.MediaColumns.DATE_ADDED)
+            add(MediaStore.MediaColumns.MIME_TYPE)
+        }.toTypedArray()
+
+        val uri       = MediaStore.Files.getContentUri("external")
+        val sortOrder = "${MediaStore.MediaColumns.DATE_MODIFIED} DESC LIMIT $CANDIDATE_LIMIT"
+
+        val candidates = mutableListOf<FileResult>()
+
+        contentResolver.query(uri, projection, sel.selection, sel.selectionArgs, sortOrder)
+            ?.use { cursor ->
+                val idxName     = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+                val idxData     = cursor.getColumnIndex(MediaStore.MediaColumns.DATA)
+                val idxRelPath  = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    cursor.getColumnIndex(MediaStore.MediaColumns.RELATIVE_PATH)
+                } else {
+                    -1
+                }
+                val idxSize     = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)
+                val idxModified = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED)
+                val idxAdded    = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_ADDED)
+                val idxMime     = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)
+
+                while (cursor.moveToNext()) {
+                    val name     = cursor.getString(idxName) ?: continue
+                    val dataPath = if (idxData >= 0) cursor.getString(idxData) else null
+                    val relPath  = if (idxRelPath >= 0) cursor.getString(idxRelPath) else null
+
+                    // Build the absolute path: prefer DATA (full path, always available);
+                    // fall back to /storage/emulated/0/<RELATIVE_PATH><DISPLAY_NAME>.
+                    val path: String = when {
+                        !dataPath.isNullOrEmpty() -> dataPath
+                        !relPath.isNullOrEmpty()  -> "/storage/emulated/0/$relPath$name"
+                        else -> continue  // no usable path; skip row
+                    }
+
+                    val dir  = path.substringBeforeLast('/', "")
+                    val ext  = name.substringAfterLast('.', "").lowercase()
+                    val mime = cursor.getString(idxMime) ?: ""
+                    val size = cursor.getLong(idxSize)
+
+                    // MediaStore stores dates in SECONDS; convert to epoch MILLISECONDS.
+                    val modifiedAt = cursor.getLong(idxModified) * 1_000L
+                    val createdAt  = cursor.getLong(idxAdded)    * 1_000L
+
+                    candidates.add(
+                        FileResult(
+                            id         = path,
+                            name       = name,
+                            path       = path,
+                            dir        = dir,
+                            ext        = ext,
+                            mime       = mime,
+                            type       = classifyType(ext),
+                            size       = size,
+                            createdAt  = createdAt,
+                            modifiedAt = modifiedAt,
+                        )
+                    )
+                }
+            }
+
+        return search(candidates, req)
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQuery.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQuery.kt
@@ -204,6 +204,12 @@ class MediaStoreSearcher(private val contentResolver: ContentResolver) {
                 }
             }
 
-        return search(candidates, req)
+        // Degraded when the candidate query was capped: there may be more matches that
+        // the pipeline never saw. Mirrors companion behaviour (Go: idx.Query returns degraded bool).
+        val degraded = candidates.size >= CANDIDATE_LIMIT
+
+        return search(candidates, req).let { result ->
+            if (degraded) result.copy(degraded = true) else result
+        }
     }
 }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Permissions.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Permissions.kt
@@ -1,0 +1,42 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+// Permission string constants declared as literals so [requiredPermissions] has
+// no android.* dependency at runtime (pure, JVM-testable).
+
+private const val PERM_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES"
+private const val PERM_MEDIA_VIDEO  = "android.permission.READ_MEDIA_VIDEO"
+private const val PERM_MEDIA_AUDIO  = "android.permission.READ_MEDIA_AUDIO"
+private const val PERM_STORAGE      = "android.permission.READ_EXTERNAL_STORAGE"
+
+/**
+ * Returns the permissions required for local-file search at the given [sdkInt].
+ *
+ * API 33+ (Android 13): scoped media permissions (READ_MEDIA_IMAGES / VIDEO / AUDIO).
+ * API ≤ 32:            READ_EXTERNAL_STORAGE (with maxSdkVersion="32" in the manifest).
+ *
+ * MANAGE_EXTERNAL_STORAGE is intentionally excluded (violates Play Store policy).
+ *
+ * Pure — no android.* runtime calls; testable on the JVM.
+ */
+fun requiredPermissions(sdkInt: Int): List<String> =
+    if (sdkInt >= 33) {
+        listOf(PERM_MEDIA_IMAGES, PERM_MEDIA_VIDEO, PERM_MEDIA_AUDIO)
+    } else {
+        listOf(PERM_STORAGE)
+    }
+
+/**
+ * Returns true when all permissions required for local-file search are granted
+ * on the current device. Uses [Build.VERSION.SDK_INT] to select the correct set.
+ *
+ * Requires [Context] — not unit-tested (verified on-device).
+ */
+fun hasLocalSearchPermission(context: Context): Boolean =
+    requiredPermissions(Build.VERSION.SDK_INT).all { perm ->
+        ContextCompat.checkSelfPermission(context, perm) == PackageManager.PERMISSION_GRANTED
+    }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Pipeline.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Pipeline.kt
@@ -3,6 +3,7 @@ package sh.kavi.fasttravel.localsearch.index
 import sh.kavi.fasttravel.localsearch.query.Node
 import sh.kavi.fasttravel.localsearch.query.QueryMode
 import sh.kavi.fasttravel.localsearch.query.parse
+import java.util.Locale
 
 /**
  * Runs the full search pipeline against [candidates]:
@@ -156,21 +157,21 @@ internal fun applyFilters(results: List<FileResult>, f: Filters): List<FileResul
  *   recency = modifiedAt / 2e13  (small tiebreaker in [0, 1) for reasonable timestamps).
  */
 internal fun scoreResult(r: FileResult, terms: List<String>, history: List<String>): Double {
-    val nameLower = r.name.lowercase()
-    val pathLower = r.path.lowercase()
+    val nameLower = r.name.lowercase(Locale.ROOT)
+    val pathLower = r.path.lowercase(Locale.ROOT)
 
     var nameBucket = 0
     for (t in terms) {
-        if (nameLower.startsWith(t.lowercase())) { nameBucket = 3; break }
+        if (nameLower.startsWith(t.lowercase(Locale.ROOT))) { nameBucket = 3; break }
     }
     if (nameBucket == 0) {
         for (t in terms) {
-            if (nameLower.contains(t.lowercase())) { nameBucket = 2; break }
+            if (nameLower.contains(t.lowercase(Locale.ROOT))) { nameBucket = 2; break }
         }
     }
     if (nameBucket == 0) {
         for (t in terms) {
-            if (pathLower.contains(t.lowercase())) { nameBucket = 1; break }
+            if (pathLower.contains(t.lowercase(Locale.ROOT))) { nameBucket = 1; break }
         }
     }
 

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Pipeline.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Pipeline.kt
@@ -1,0 +1,207 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import sh.kavi.fasttravel.localsearch.query.Node
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+import sh.kavi.fasttravel.localsearch.query.parse
+
+/**
+ * Runs the full search pipeline against [candidates]:
+ *  1. Parse the query (throws [QueryParseException] on empty input).
+ *  2. Build the match AST:
+ *     - TitleOnly=false → broaden each name-scoped leaf to OR(name, path)
+ *     - TitleOnly=true  → coerce all leaves to name
+ *  3. Post-filter with the matcher.
+ *  4. Apply request filters (types, modifiedRange, createdRange, pathPrefix).
+ *  5. Score each result.
+ *  6. Stable-sort with a deterministic Name-then-Path tiebreak.
+ *  7. Paginate and return (results is always a non-null list).
+ *
+ * Mirrors companion/internal/index/pipeline.go Search.
+ * MediaStore wiring (slice 5b) supplies [candidates]; tests use an in-memory list.
+ */
+fun search(candidates: List<FileResult>, req: SearchRequest): SearchResult {
+    val ast = parse(req.query, req.queryMode)
+
+    val matchAst = if (req.filters.titleOnly) coerceFieldsToName(ast) else broadenToPath(ast)
+
+    // Post-filter: guarantee correctness via the matcher.
+    var filtered = candidates.filter { matches(it, matchAst, req.queryMode) }
+
+    // Apply request filters.
+    filtered = applyFilters(filtered, req.filters)
+
+    // Score each surviving result.
+    val terms = collectTerms(ast)
+    filtered = filtered.map { it.copy(score = scoreResult(it, terms, req.history)) }
+
+    // Stable sort.
+    filtered = sortResults(filtered, req.sort)
+
+    val total = filtered.size
+
+    // Paginate.
+    val page = maxOf(req.page, 0)
+    val size = req.pageSize
+    val pageSlice: List<FileResult> = if (size <= 0) {
+        filtered
+    } else {
+        val lo = page * size
+        if (lo >= total) emptyList()
+        else filtered.subList(lo, minOf(lo + size, total))
+    }
+
+    return SearchResult(results = pageSlice, total = total, page = page)
+}
+
+// ── AST transforms ────────────────────────────────────────────────────────────
+
+/**
+ * Expands every leaf node with field="name" into OR(name-leaf, path-leaf).
+ * Default (TitleOnly=false) behaviour: a plain term like "report" matches
+ * both filenames and directory path components.
+ * Leaves that already carry field="path" are unchanged.
+ * Mirrors companion/internal/index/pipeline.go broadenToPath.
+ */
+internal fun broadenToPath(n: Node): Node = when (n.op) {
+    "and", "or" -> n.copy(nodes = n.nodes?.map { broadenToPath(it) })
+    "not"       -> n.copy(node = n.node?.let { broadenToPath(it) })
+    "term", "phrase", "regex" -> {
+        if (n.field != "name") n
+        else Node(op = "or", nodes = listOf(n, n.copy(field = "path")))
+    }
+    else -> n
+}
+
+/**
+ * Returns a copy of the AST with every leaf's field set to "name".
+ * Used when TitleOnly=true so path-scoped queries also match only filenames.
+ * Mirrors companion/internal/index/pipeline.go coerceFieldsToName.
+ */
+internal fun coerceFieldsToName(n: Node): Node = when (n.op) {
+    "and", "or" -> n.copy(nodes = n.nodes?.map { coerceFieldsToName(it) })
+    "not"       -> n.copy(node = n.node?.let { coerceFieldsToName(it) })
+    "term", "phrase", "regex" -> n.copy(field = "name")
+    else -> n
+}
+
+// ── Term collection ───────────────────────────────────────────────────────────
+
+/**
+ * Recursively collects the Value of every positive term/phrase leaf in [node].
+ * NOT subtrees are skipped (negative terms must not inflate scores).
+ * Regex nodes are excluded (they don't contribute to name-bucket scoring).
+ * Mirrors companion/internal/index/pipeline.go collectTerms.
+ */
+internal fun collectTerms(node: Node): List<String> {
+    val terms = mutableListOf<String>()
+    fun walk(n: Node) {
+        when (n.op) {
+            "and", "or"      -> n.nodes?.forEach { walk(it) }
+            // "not": intentionally skipped — negative terms must not influence scoring.
+            "term", "phrase" -> n.value?.let { terms.add(it) }
+            // "regex": intentionally excluded from scoring.
+        }
+    }
+    walk(node)
+    return terms
+}
+
+// ── Filters ───────────────────────────────────────────────────────────────────
+
+/**
+ * Applies each request filter independently.
+ * CreatedRange: if any bound is set and r.createdAt==0 (birth-time unknown),
+ * the result is excluded — we cannot prove it falls in range.
+ * Mirrors companion/internal/index/pipeline.go applyFilters.
+ */
+internal fun applyFilters(results: List<FileResult>, f: Filters): List<FileResult> =
+    results.filter { r ->
+        // Types filter.
+        if (f.types.isNotEmpty() && r.type !in f.types) return@filter false
+
+        // ModifiedRange filter: a bound of 0 means unbounded on that side.
+        val mr = f.modifiedRange
+        if (mr != null) {
+            if (mr.from != 0L && r.modifiedAt < mr.from) return@filter false
+            if (mr.to != 0L && r.modifiedAt > mr.to) return@filter false
+        }
+
+        // CreatedRange filter: if any bound is set and createdAt is 0 (unknown), exclude.
+        val cr = f.createdRange
+        if (cr != null) {
+            val hasBound = cr.from != 0L || cr.to != 0L
+            if (hasBound && r.createdAt == 0L) return@filter false
+            if (cr.from != 0L && r.createdAt < cr.from) return@filter false
+            if (cr.to != 0L && r.createdAt > cr.to) return@filter false
+        }
+
+        // PathPrefix filter.
+        if (f.pathPrefix.isNotEmpty() && !r.path.startsWith(f.pathPrefix)) return@filter false
+
+        true
+    }
+
+// ── Scoring ───────────────────────────────────────────────────────────────────
+
+/**
+ * Scores a single result.
+ *
+ * Weights (mirrors companion/internal/index/pipeline.go scoreResult):
+ *   nameBucket × 10:
+ *     3 = name-prefix match     → 30
+ *     2 = name-substring match  → 20
+ *     1 = path-only match       → 10
+ *     0 = no literal term match → 0
+ *   historyBoost = 5 when result.id is in history.
+ *   recency = modifiedAt / 2e13  (small tiebreaker in [0, 1) for reasonable timestamps).
+ */
+internal fun scoreResult(r: FileResult, terms: List<String>, history: List<String>): Double {
+    val nameLower = r.name.lowercase()
+    val pathLower = r.path.lowercase()
+
+    var nameBucket = 0
+    for (t in terms) {
+        if (nameLower.startsWith(t.lowercase())) { nameBucket = 3; break }
+    }
+    if (nameBucket == 0) {
+        for (t in terms) {
+            if (nameLower.contains(t.lowercase())) { nameBucket = 2; break }
+        }
+    }
+    if (nameBucket == 0) {
+        for (t in terms) {
+            if (pathLower.contains(t.lowercase())) { nameBucket = 1; break }
+        }
+    }
+
+    val historyBoost = if (r.id in history) 5.0 else 0.0
+    val recency = if (r.modifiedAt != 0L) r.modifiedAt.toDouble() / 2e13 else 0.0
+
+    return nameBucket * 10.0 + historyBoost + recency
+}
+
+// ── Sorting ───────────────────────────────────────────────────────────────────
+
+/**
+ * Stable-sorts results in place according to [s].
+ * Missing field defaults to "relevance"; missing dir defaults to "desc".
+ * Deterministic tiebreak on Name (asc) then Path (asc).
+ * Mirrors companion/internal/index/pipeline.go sortResults (sort.SliceStable).
+ */
+internal fun sortResults(results: List<FileResult>, s: Sort): List<FileResult> {
+    val field = s.field.ifEmpty { "relevance" }
+    val asc = s.dir.ifEmpty { "desc" } == "asc"
+
+    return results.sortedWith(Comparator { a, b ->
+        val primaryCmp = when (field) {
+            "created"  -> if (asc) a.createdAt.compareTo(b.createdAt) else b.createdAt.compareTo(a.createdAt)
+            "modified" -> if (asc) a.modifiedAt.compareTo(b.modifiedAt) else b.modifiedAt.compareTo(a.modifiedAt)
+            else       -> if (asc) a.score.compareTo(b.score) else b.score.compareTo(a.score) // relevance
+        }
+        if (primaryCmp != 0) return@Comparator primaryCmp
+        // Deterministic tiebreak: Name asc, then Path asc.
+        val nameCmp = a.name.compareTo(b.name)
+        if (nameCmp != 0) return@Comparator nameCmp
+        a.path.compareTo(b.path)
+    })
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Pipeline.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/index/Pipeline.kt
@@ -21,12 +21,19 @@ import java.util.Locale
  * MediaStore wiring (slice 5b) supplies [candidates]; tests use an in-memory list.
  */
 fun search(candidates: List<FileResult>, req: SearchRequest): SearchResult {
-    val ast = parse(req.query, req.queryMode)
+    var ast = parse(req.query, req.queryMode)
+
+    // ExactPhrase: treat the whole query as one ordered phrase (non-regex only).
+    // Regex mode ignores ExactPhrase; the pattern is already the entire query.
+    // Mirrors companion/internal/index/pipeline.go Search ExactPhrase block.
+    if (req.exactPhrase && req.queryMode != QueryMode.REGEX) {
+        ast = Node(op = "phrase", field = "name", value = req.query.trim())
+    }
 
     val matchAst = if (req.filters.titleOnly) coerceFieldsToName(ast) else broadenToPath(ast)
 
     // Post-filter: guarantee correctness via the matcher.
-    var filtered = candidates.filter { matches(it, matchAst, req.queryMode) }
+    var filtered = candidates.filter { matches(it, matchAst, req.queryMode, req.caseSensitive) }
 
     // Apply request filters.
     filtered = applyFilters(filtered, req.filters)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/query/Ast.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/query/Ast.kt
@@ -1,0 +1,172 @@
+package sh.kavi.fasttravel.localsearch.query
+
+/**
+ * QueryMode controls how the query string is parsed.
+ * Mirrors companion/internal/query/ast.go Mode constants.
+ */
+enum class QueryMode(val value: String) {
+    SIMPLE("simple"),
+    WILDCARD("wildcard"),
+    REGEX("regex");
+
+    companion object {
+        fun fromString(value: String): QueryMode = when (value.lowercase()) {
+            "simple"   -> SIMPLE
+            "wildcard" -> WILDCARD
+            "regex"    -> REGEX
+            else       -> throw IllegalArgumentException("Unknown query mode: $value")
+        }
+    }
+}
+
+/**
+ * Node is a single AST node. Its shape mirrors companion/internal/query/ast.go Node exactly:
+ *
+ *   op "and"/"or"   → nodes holds the children; node/field/value/wildcard are null.
+ *   op "not"        → node holds the single child; nodes/field/value/wildcard are null.
+ *   op "term"       → field, value, wildcard set; nodes/node are null.
+ *   op "phrase"     → field, value set; wildcard is null; nodes/node are null.
+ *   op "regex"      → field, value set; wildcard is null; nodes/node are null.
+ */
+data class Node(
+    val op: String,
+    val nodes: List<Node>? = null,   // and / or
+    val node: Node? = null,          // not
+    val field: String? = null,       // term / phrase / regex
+    val value: String? = null,       // term / phrase / regex
+    val wildcard: Boolean? = null,   // term only (null = absent for phrase/regex)
+)
+
+/** Thrown by [parse] when the query is empty or blank. */
+class QueryParseException(message: String) : RuntimeException(message)
+
+/**
+ * Parse turns a raw query string and a [QueryMode] into the canonical AST [Node].
+ * Throws [QueryParseException] for empty or whitespace-only input.
+ * Mirrors companion/internal/query/parse.go Parse.
+ */
+fun parse(query: String, mode: QueryMode): Node {
+    if (query.isBlank()) throw QueryParseException("query: empty input")
+
+    if (mode == QueryMode.REGEX) return parseRegex(query)
+
+    val tokens = tokenize(query, mode)
+    return buildAst(tokens)
+}
+
+// ── regex mode ────────────────────────────────────────────────────────────────
+
+private fun parseRegex(query: String): Node {
+    var field = "name"
+    var value = query
+    if (query.startsWith("path:")) {
+        field = "path"
+        value = query.removePrefix("path:")
+    }
+    return Node(op = "regex", field = field, value = value)
+}
+
+// ── tokenizer ─────────────────────────────────────────────────────────────────
+
+/** Internal token produced by [tokenize]. */
+private data class Tok(
+    val isOR: Boolean = false,
+    val negate: Boolean = false,
+    val leaf: Node? = null,       // null when isOR == true
+)
+
+private fun tokenize(query: String, mode: QueryMode): List<Tok> {
+    val toks = mutableListOf<Tok>()
+    var i = 0
+    val n = query.length
+
+    while (i < n) {
+        // skip whitespace
+        if (query[i] == ' ' || query[i] == '\t') { i++; continue }
+
+        // bare pipe → OR separator
+        if (query[i] == '|') { toks.add(Tok(isOR = true)); i++; continue }
+
+        // negation prefix: only when followed by a non-whitespace character
+        var negate = false
+        if (i < n && (query[i] == '-' || query[i] == '!')) {
+            if (i + 1 < n && query[i + 1] != ' ' && query[i + 1] != '\t') {
+                negate = true
+                i++
+            }
+        }
+
+        // path: prefix
+        var field = "name"
+        if (i < n && query.startsWith("path:", i)) {
+            field = "path"
+            i += "path:".length
+        }
+
+        if (i >= n) continue
+
+        // quoted phrase
+        if (query[i] == '"') {
+            i++ // skip opening quote
+            val start = i
+            while (i < n && query[i] != '"') i++
+            val value = query.substring(start, i)
+            if (i < n) i++ // skip closing quote
+            toks.add(Tok(negate = negate, leaf = Node(op = "phrase", field = field, value = value)))
+            continue
+        }
+
+        // regular term: read until whitespace or pipe
+        val start = i
+        while (i < n && query[i] != ' ' && query[i] != '\t' && query[i] != '|') i++
+        val value = query.substring(start, i)
+        if (value.isEmpty()) continue
+
+        // standalone OR keyword (only when no negate and no field scope)
+        if (!negate && field == "name" && value.equals("or", ignoreCase = true)) {
+            toks.add(Tok(isOR = true))
+            continue
+        }
+
+        val wildcard = mode == QueryMode.WILDCARD && (value.contains('*') || value.contains('?'))
+        toks.add(Tok(negate = negate, leaf = Node(op = "term", field = field, value = value, wildcard = wildcard)))
+    }
+
+    return toks
+}
+
+// ── AST builder ───────────────────────────────────────────────────────────────
+
+/**
+ * buildAst turns a flat token list into the canonical AST Node.
+ * Top-level precedence: OR binds looser than AND.
+ */
+private fun buildAst(toks: List<Tok>): Node {
+    val segments = splitByOR(toks)
+    val segNodes = segments.filter { it.isNotEmpty() }.map { buildSegment(it) }
+
+    return when (segNodes.size) {
+        0    -> Node(op = "") // shouldn't reach here after empty-input guard
+        1    -> segNodes[0]
+        else -> Node(op = "or", nodes = segNodes)
+    }
+}
+
+private fun splitByOR(toks: List<Tok>): List<List<Tok>> {
+    val segments = mutableListOf<List<Tok>>()
+    val current = mutableListOf<Tok>()
+    for (t in toks) {
+        if (t.isOR) { segments.add(current.toList()); current.clear() }
+        else current.add(t)
+    }
+    segments.add(current.toList())
+    return segments
+}
+
+private fun buildSegment(toks: List<Tok>): Node {
+    val nodes = toks.map { t ->
+        val leaf = t.leaf!!
+        if (t.negate) Node(op = "not", node = leaf) else leaf
+    }
+    return if (nodes.size == 1) nodes[0] else Node(op = "and", nodes = nodes)
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/query/Ast.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/query/Ast.kt
@@ -71,8 +71,8 @@ private fun parseRegex(query: String): Node {
     }
     try {
         Regex(value)
-    } catch (_: Exception) {
-        throw QueryParseException("invalid regular expression: $value")
+    } catch (e: Exception) {
+        throw QueryParseException("invalid regular expression: ${e.message ?: value}")
     }
     return Node(op = "regex", field = field, value = value)
 }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/query/Ast.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/query/Ast.kt
@@ -56,12 +56,23 @@ fun parse(query: String, mode: QueryMode): Node {
 
 // ── regex mode ────────────────────────────────────────────────────────────────
 
+/**
+ * Builds a regex AST node, validating the pattern compiles.
+ * Throws [QueryParseException] (Bug A) when the pattern is invalid so callers can
+ * surface a useful error to the UI.
+ * Mirrors companion/internal/query/parse.go parseRegex.
+ */
 private fun parseRegex(query: String): Node {
     var field = "name"
     var value = query
     if (query.startsWith("path:")) {
         field = "path"
         value = query.removePrefix("path:")
+    }
+    try {
+        Regex(value)
+    } catch (_: Exception) {
+        throw QueryParseException("invalid regular expression: $value")
     }
     return Node(op = "regex", field = field, value = value)
 }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/settings/LocalSearchSettings.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/localsearch/settings/LocalSearchSettings.kt
@@ -1,0 +1,23 @@
+package sh.kavi.fasttravel.localsearch.settings
+
+import sh.kavi.fasttravel.core.CommandParser
+import sh.kavi.fasttravel.core.FastTravelConfig
+
+/**
+ * Returns true only when both preconditions for enabling Local Search hold:
+ *   (a) all required media permissions are granted, AND
+ *   (b) no command in the active config already claims the 's' trigger.
+ *
+ * Pure — no android.* runtime calls; JVM-testable.
+ */
+fun canEnableLocalSearch(hasPermission: Boolean, configHasS: Boolean): Boolean =
+    hasPermission && !configHasS
+
+/**
+ * Returns true when the active config contains a command whose trigger list
+ * includes "s" (case-insensitive, matching [CommandParser.buildTriggerMap] semantics).
+ *
+ * Pure — no android.* runtime calls; JVM-testable.
+ */
+fun configHasSTrigger(config: FastTravelConfig): Boolean =
+    CommandParser.buildTriggerMap(config).containsKey("s")

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -7,7 +7,10 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.widget.Toast
+import androidx.core.content.FileProvider
+import java.io.File
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -54,14 +57,24 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.ArrowOutward
+import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.VideoCameraBack
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -78,6 +91,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -136,6 +150,11 @@ import sh.kavi.fasttravel.core.Suggestion
 import sh.kavi.fasttravel.core.resolveIconUrl
 import sh.kavi.fasttravel.data.ThemePreferences
 import sh.kavi.fasttravel.deeplink.DeepLinkResolver
+import sh.kavi.fasttravel.localsearch.LocalFileIcon
+import sh.kavi.fasttravel.localsearch.fileTypeIcon
+import sh.kavi.fasttravel.localsearch.formatFileSize
+import sh.kavi.fasttravel.localsearch.formatModifiedDate
+import sh.kavi.fasttravel.localsearch.index.FileResult
 import sh.kavi.fasttravel.ui.appearance.resolveFromPrefs
 import sh.kavi.fasttravel.ui.theme.DividerDark
 import sh.kavi.fasttravel.ui.theme.DividerLight
@@ -439,20 +458,28 @@ fun SearchScreen(
     }
 
     LaunchedEffect(searchState) {
-        if (searchState is SearchState.Navigate) {
-            val url = (searchState as SearchState.Navigate).url
-            val intent = DeepLinkResolver.resolve(context, url)
-            if (intent != null) {
-                context.startActivity(intent)
-            } else {
-                android.widget.Toast.makeText(
-                    context,
-                    "Blocked unsupported URL scheme",
-                    android.widget.Toast.LENGTH_SHORT,
-                ).show()
+        when (searchState) {
+            is SearchState.Navigate -> {
+                val url = (searchState as SearchState.Navigate).url
+                val intent = DeepLinkResolver.resolve(context, url)
+                if (intent != null) {
+                    context.startActivity(intent)
+                } else {
+                    android.widget.Toast.makeText(
+                        context,
+                        "Blocked unsupported URL scheme",
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+                keyboardController?.hide()
+                viewModel.onNavigationHandled()
             }
-            keyboardController?.hide()
-            viewModel.onNavigationHandled()
+            is SearchState.LocalSearchResults -> {
+                // Hide keyboard when the results screen appears.
+                // Focus is naturally cleared as the TextField loses it.
+                keyboardController?.hide()
+            }
+            else -> Unit
         }
     }
 
@@ -471,6 +498,12 @@ fun SearchScreen(
         enabled = searchState is SearchState.TypoSuggestion,
     ) {
         viewModel.dismissTypo()
+    }
+    // BACK from the local-search results screen returns to the launcher.
+    androidx.activity.compose.BackHandler(
+        enabled = searchState is SearchState.LocalSearchResults,
+    ) {
+        viewModel.dismissLocalSearch()
     }
 
     // When a variant provides a surfaceBrush (AMOLED, Glass, gradients), the
@@ -598,46 +631,67 @@ fun SearchScreen(
                 }
             }
 
-            if (imeVisible) {
-                FocusedContent(
-                    viewModel = viewModel,
-                    query = query,
-                    suggestions = suggestions,
-                    installedApps = installedApps,
-                    groupColorMap = groupColorMap,
-                    onSuggestionClick = { s ->
-                        viewModel.onQueryChanged(s.text)
-                        viewModel.onSearch(s.text)
-                    },
-                    onSuggestionPopulate = { s -> viewModel.onQueryChanged(s.text) },
-                    onHistoryRemove = { q -> viewModel.removeHistoryEntry(q) },
-                    onAppLaunch = launchApp,
-                    onCommandAutocompletePick = { cmd ->
-                        val trig = cmd.triggers.firstOrNull() ?: return@FocusedContent
-                        if (cmd.type == CommandType.Redirect) {
-                            viewModel.onSearch(trig)
-                        } else {
-                            viewModel.onQueryChanged("$trig ")
-                        }
-                    },
-                )
-            } else {
-                UnfocusedContent(
-                    chipItems = chipItems,
-                    groupColorMap = groupColorMap,
-                    shortcutRows = shortcutRows,
-                    onCommandClick = { command ->
-                        val trigger = command.triggers.firstOrNull() ?: return@UnfocusedContent
-                        if (command.type == CommandType.Redirect) {
-                            viewModel.onSearch(trigger)
-                        } else {
-                            viewModel.onQueryChanged("$trigger ")
-                            focusRequester.requestFocus()
-                            keyboardController?.show()
-                        }
-                    },
-                    onAppClick = launchApp,
-                )
+            when {
+                searchState is SearchState.LocalSearchResults -> {
+                    LocalSearchResultsScreen(
+                        state = searchState as SearchState.LocalSearchResults,
+                        onOpenFile = { file ->
+                            openFileResult(context, file) { fileId ->
+                                viewModel.recordFileOpen(fileId)
+                            }
+                        },
+                        onRetry = { viewModel.retryLocalSearch() },
+                        onOpenPermissionSettings = {
+                            context.startActivity(
+                                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                    data = android.net.Uri.fromParts("package", context.packageName, null)
+                                }
+                            )
+                        },
+                    )
+                }
+                imeVisible -> {
+                    FocusedContent(
+                        viewModel = viewModel,
+                        query = query,
+                        suggestions = suggestions,
+                        installedApps = installedApps,
+                        groupColorMap = groupColorMap,
+                        onSuggestionClick = { s ->
+                            viewModel.onQueryChanged(s.text)
+                            viewModel.onSearch(s.text)
+                        },
+                        onSuggestionPopulate = { s -> viewModel.onQueryChanged(s.text) },
+                        onHistoryRemove = { q -> viewModel.removeHistoryEntry(q) },
+                        onAppLaunch = launchApp,
+                        onCommandAutocompletePick = { cmd ->
+                            val trig = cmd.triggers.firstOrNull() ?: return@FocusedContent
+                            if (cmd.type == CommandType.Redirect) {
+                                viewModel.onSearch(trig)
+                            } else {
+                                viewModel.onQueryChanged("$trig ")
+                            }
+                        },
+                    )
+                }
+                else -> {
+                    UnfocusedContent(
+                        chipItems = chipItems,
+                        groupColorMap = groupColorMap,
+                        shortcutRows = shortcutRows,
+                        onCommandClick = { command ->
+                            val trigger = command.triggers.firstOrNull() ?: return@UnfocusedContent
+                            if (command.type == CommandType.Redirect) {
+                                viewModel.onSearch(trigger)
+                            } else {
+                                viewModel.onQueryChanged("$trigger ")
+                                focusRequester.requestFocus()
+                                keyboardController?.show()
+                            }
+                        },
+                        onAppClick = launchApp,
+                    )
+                }
             }
         }
     }
@@ -1314,6 +1368,294 @@ private fun CommandChip(
             fontSize = 16.sp,
             color = textColor,
         )
+    }
+}
+
+// ── Local Search Results ──────────────────────────────────────────────────────
+
+/**
+ * Opens [file] via [Intent.ACTION_VIEW] using a [FileProvider] content URI so the
+ * receiving app gets read permission without us needing MANAGE_EXTERNAL_STORAGE.
+ * Catches all failure modes and shows a toast rather than crashing.
+ * On success, [onRecordOpen] is called to record the file id for frecency scoring.
+ */
+private fun openFileResult(
+    context: Context,
+    file: FileResult,
+    onRecordOpen: (String) -> Unit,
+) {
+    try {
+        val f = File(file.path)
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.provider",
+            f,
+        )
+        val mime = file.mime.ifEmpty { "*/*" }
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, mime)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(intent)
+        onRecordOpen(file.id)
+    } catch (_: ActivityNotFoundException) {
+        Toast.makeText(context, "No app found to open this file", Toast.LENGTH_SHORT).show()
+    } catch (e: IllegalArgumentException) {
+        // FileProvider path not covered — fall back to direct file URI.
+        try {
+            val fallbackUri = android.net.Uri.fromFile(File(file.path))
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(fallbackUri, file.mime.ifEmpty { "*/*" })
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(intent)
+            onRecordOpen(file.id)
+        } catch (_: Exception) {
+            Toast.makeText(context, "Cannot open: ${file.name}", Toast.LENGTH_SHORT).show()
+        }
+    } catch (_: Exception) {
+        Toast.makeText(context, "Cannot open: ${file.name}", Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Resolves [LocalFileIcon] to the matching Material icon vector and a theme color.
+ * Called in the Compose layer; [fileTypeIcon] provides the pure category enum.
+ */
+@Composable
+private fun fileTypeIconVector(icon: LocalFileIcon): Pair<ImageVector, Color> = when (icon) {
+    LocalFileIcon.FOLDER   -> Icons.Default.Folder       to Color(0xFF4CAF50)
+    LocalFileIcon.IMAGE    -> Icons.Default.Image         to Color(0xFF9C27B0)
+    LocalFileIcon.VIDEO    -> Icons.Default.VideoCameraBack to Color(0xFFE91E63)
+    LocalFileIcon.AUDIO    -> Icons.Default.MusicNote     to Color(0xFFFF9800)
+    LocalFileIcon.ARCHIVE  -> Icons.Default.Archive       to Color(0xFF795548)
+    LocalFileIcon.CODE     -> Icons.Default.Code          to Color(0xFF009688)
+    LocalFileIcon.DOCUMENT -> Icons.Default.Description   to Color(0xFF2196F3)
+    LocalFileIcon.OTHER    -> Icons.AutoMirrored.Filled.InsertDriveFile to Color(0xFF9E9E9E)
+}
+
+/**
+ * Full-screen results list, loading/empty/error/permission states.
+ * Structured so 5e can add a toolbar + grid view above the [LazyColumn].
+ */
+@Composable
+private fun LocalSearchResultsScreen(
+    state: SearchState.LocalSearchResults,
+    onOpenFile: (FileResult) -> Unit,
+    onRetry: () -> Unit,
+    onOpenPermissionSettings: () -> Unit,
+) {
+    val dividerColor = MaterialTheme.colorScheme.outlineVariant
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // ── Toolbar placeholder — 5e will add query-mode control, sort, filter chips ──
+        // Count + source line (shown when results are available).
+        if (!state.isLoading && state.error == null && !state.needsPermission && state.query.isNotBlank()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp, bottom = 4.dp, start = 4.dp, end = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = if (state.total == 1) "1 file" else "${state.total} files",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = "On-device files",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                )
+            }
+            HorizontalDivider(color = dividerColor)
+        }
+
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.needsPermission -> {
+                LocalSearchPermissionNeeded(onOpenSettings = onOpenPermissionSettings)
+            }
+            state.error != null -> {
+                LocalSearchError(message = state.error, onRetry = onRetry)
+            }
+            state.query.isBlank() -> {
+                // Bare "s" with no query — prompt the user.
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Type a search term after 's' to search your files",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+            state.results.isEmpty() -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "No files match \"${state.query}\"",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+            else -> {
+                // ── Results list — 5e adds a grid variant beside this ──
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(state.results) { file ->
+                        FileResultRow(file = file, onClick = { onOpenFile(file) })
+                        HorizontalDivider(color = dividerColor)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocalSearchPermissionNeeded(onOpenSettings: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Storage permission needed",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Grant media access in Settings → Local Search to search your files.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onOpenSettings) {
+            Text("Open Settings")
+        }
+    }
+}
+
+@Composable
+private fun LocalSearchError(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "Search failed",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        OutlinedButton(onClick = onRetry) {
+            Text("Retry")
+        }
+    }
+}
+
+@Composable
+private fun FileResultRow(file: FileResult, onClick: () -> Unit) {
+    val iconInfo = fileTypeIcon(file.type)
+    val (iconVector, iconColor) = fileTypeIconVector(iconInfo)
+    val sizeText = formatFileSize(file.size)
+    val dateText = formatModifiedDate(file.modifiedAt)
+    val meta = listOfNotNull(dateText.takeIf { it.isNotEmpty() }, sizeText.takeIf { it.isNotEmpty() })
+        .joinToString(" · ")
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 10.dp)
+            .semantics {
+                contentDescription = "File: ${file.name}"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Per-type icon in a tinted circle, matching CommandFavicon visual weight.
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(iconColor.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = iconVector,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = iconColor,
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = file.name,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (file.dir.isNotEmpty()) {
+                TailText(
+                    text = file.dir,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            if (meta.isNotEmpty()) {
+                Text(
+                    text = meta,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                )
+            }
+        }
     }
 }
 

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -52,6 +52,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.rememberScrollState
@@ -86,7 +87,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -1586,7 +1586,7 @@ private fun LocalSearchResultsScreen(
                         FileResultGridCard(file = file, onClick = { onOpenFile(file) })
                     }
                     if (hasMore(state.results.size, state.total)) {
-                        item {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
                             LoadMoreFooter(isLoadingMore = state.isLoadingMore, onLoadMore = onLoadMore)
                         }
                     }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -676,6 +676,8 @@ fun SearchScreen(
                         onTitleOnlyChange = { viewModel.setLocalSearchFilterTitleOnly(it) },
                         onClearFilters = { viewModel.clearLocalSearchFilters() },
                         onLoadMore = { viewModel.loadMoreLocalSearch() },
+                        onCaseSensitiveChange = { viewModel.setLocalSearchCaseSensitive(it) },
+                        onExactPhraseChange = { viewModel.setLocalSearchExactPhrase(it) },
                     )
                 }
                 imeVisible -> {
@@ -1490,6 +1492,8 @@ private fun LocalSearchResultsScreen(
     onTitleOnlyChange: (Boolean) -> Unit,
     onClearFilters: () -> Unit,
     onLoadMore: () -> Unit,
+    onCaseSensitiveChange: (Boolean) -> Unit,
+    onExactPhraseChange: (Boolean) -> Unit,
 ) {
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
 
@@ -1507,6 +1511,8 @@ private fun LocalSearchResultsScreen(
                 onPathPrefixChange = onPathPrefixChange,
                 onTitleOnlyChange = onTitleOnlyChange,
                 onClearFilters = onClearFilters,
+                onCaseSensitiveChange = onCaseSensitiveChange,
+                onExactPhraseChange = onExactPhraseChange,
             )
             HorizontalDivider(color = dividerColor)
         }
@@ -1520,7 +1526,12 @@ private fun LocalSearchResultsScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = if (state.total == 1) "1 file" else "${state.total} files",
+                    text = when {
+                        state.degraded && state.total == 1 -> "1+ file"
+                        state.degraded -> "${state.total}+ files"
+                        state.total == 1 -> "1 file"
+                        else -> "${state.total} files"
+                    },
                     style = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1612,8 +1623,8 @@ private fun LocalSearchResultsScreen(
 
 /**
  * Drive-style toolbar: query-mode segmented control, sort (field + direction),
- * list/grid toggle, type-filter chips, date preset, title-only switch, path field,
- * and a clear affordance.
+ * list/grid toggle, type-filter chips, date preset, title-only switch,
+ * exact-phrase + match-case toggles, path field, and a clear affordance.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -1628,6 +1639,8 @@ private fun LocalSearchToolbar(
     onPathPrefixChange: (String) -> Unit,
     onTitleOnlyChange: (Boolean) -> Unit,
     onClearFilters: () -> Unit,
+    onCaseSensitiveChange: (Boolean) -> Unit,
+    onExactPhraseChange: (Boolean) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -1671,7 +1684,8 @@ private fun LocalSearchToolbar(
 
             // Sort field dropdown
             var sortExpanded by remember { mutableStateOf(false) }
-            val sortFieldOptions = listOf("" to "Relevance", "modified" to "Modified", "created" to "Created")
+            // Bug B: "Date created" sort removed — unreliable via MediaStore on Android.
+            val sortFieldOptions = listOf("" to "Relevance", "modified" to "Modified")
             val currentSortLabel = sortFieldOptions.firstOrNull { it.first == toolbarState.sortField }?.second ?: "Relevance"
             ExposedDropdownMenuBox(
                 expanded = sortExpanded,
@@ -1812,11 +1826,58 @@ private fun LocalSearchToolbar(
 
             Spacer(modifier = Modifier.width(4.dp))
 
+            // Match case toggle
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable { onCaseSensitiveChange(!toolbarState.caseSensitive) },
+            ) {
+                Switch(
+                    checked = toolbarState.caseSensitive,
+                    onCheckedChange = onCaseSensitiveChange,
+                    modifier = Modifier.height(24.dp),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Match case",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            // Exact phrase toggle (disabled in regex mode — pattern already is the full query)
+            val isRegexMode = toolbarState.queryMode == "regex"
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable(enabled = !isRegexMode) {
+                    if (!isRegexMode) onExactPhraseChange(!toolbarState.exactPhrase)
+                },
+            ) {
+                Switch(
+                    checked = toolbarState.exactPhrase,
+                    onCheckedChange = { if (!isRegexMode) onExactPhraseChange(it) },
+                    enabled = !isRegexMode,
+                    modifier = Modifier.height(24.dp),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Exact phrase",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (isRegexMode) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            else MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
             // Clear filters
             val hasActiveFilters = toolbarState.filterTypes.isNotEmpty() ||
                 toolbarState.filterDatePreset != "any" ||
                 toolbarState.filterPathPrefix.isNotEmpty() ||
-                toolbarState.filterTitleOnly
+                toolbarState.filterTitleOnly ||
+                toolbarState.caseSensitive ||
+                toolbarState.exactPhrase
             if (hasActiveFilters) {
                 TextButton(
                     onClick = onClearFilters,

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ime
@@ -50,6 +51,9 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -58,29 +62,40 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Archive
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowOutward
-import androidx.compose.material.icons.filled.AudioFile
+import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.VideoCameraBack
+import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -154,6 +169,7 @@ import sh.kavi.fasttravel.localsearch.LocalFileIcon
 import sh.kavi.fasttravel.localsearch.fileTypeIcon
 import sh.kavi.fasttravel.localsearch.formatFileSize
 import sh.kavi.fasttravel.localsearch.formatModifiedDate
+import sh.kavi.fasttravel.localsearch.hasMore
 import sh.kavi.fasttravel.localsearch.index.FileResult
 import sh.kavi.fasttravel.ui.appearance.resolveFromPrefs
 import sh.kavi.fasttravel.ui.theme.DividerDark
@@ -633,8 +649,10 @@ fun SearchScreen(
 
             when {
                 searchState is SearchState.LocalSearchResults -> {
+                    val toolbarState by viewModel.localSearchToolbarState.collectAsState()
                     LocalSearchResultsScreen(
                         state = searchState as SearchState.LocalSearchResults,
+                        toolbarState = toolbarState,
                         onOpenFile = { file ->
                             openFileResult(context, file) { fileId ->
                                 viewModel.recordFileOpen(fileId)
@@ -648,6 +666,16 @@ fun SearchScreen(
                                 }
                             )
                         },
+                        onQueryModeChange = { viewModel.setLocalSearchQueryMode(it) },
+                        onSortFieldChange = { viewModel.setLocalSearchSortField(it) },
+                        onSortDirToggle = { viewModel.toggleLocalSearchSortDir() },
+                        onViewToggle = { viewModel.setLocalSearchView(it) },
+                        onTypeToggle = { viewModel.toggleLocalSearchFilterType(it) },
+                        onDatePresetChange = { viewModel.setLocalSearchFilterDatePreset(it) },
+                        onPathPrefixChange = { viewModel.setLocalSearchFilterPathPrefix(it) },
+                        onTitleOnlyChange = { viewModel.setLocalSearchFilterTitleOnly(it) },
+                        onClearFilters = { viewModel.clearLocalSearchFilters() },
+                        onLoadMore = { viewModel.loadMoreLocalSearch() },
                     )
                 }
                 imeVisible -> {
@@ -1401,12 +1429,13 @@ private fun openFileResult(
     } catch (_: ActivityNotFoundException) {
         Toast.makeText(context, "No app found to open this file", Toast.LENGTH_SHORT).show()
     } catch (e: IllegalArgumentException) {
-        // FileProvider path not covered — fall back to direct file URI.
+        // FileProvider path not covered — fall back to a direct file:// URI.
+        // Note: FLAG_GRANT_READ_URI_PERMISSION is a no-op for file:// URIs (only
+        // applies to content:// URIs from FileProvider), so it is intentionally omitted.
         try {
             val fallbackUri = android.net.Uri.fromFile(File(file.path))
             val intent = Intent(Intent.ACTION_VIEW).apply {
                 setDataAndType(fallbackUri, file.mime.ifEmpty { "*/*" })
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
             context.startActivity(intent)
             onRecordOpen(file.id)
@@ -1419,42 +1448,75 @@ private fun openFileResult(
 }
 
 /**
- * Resolves [LocalFileIcon] to the matching Material icon vector and a theme color.
+ * Resolves [LocalFileIcon] to the matching Material icon vector and a theme-aware color.
+ * Colors are sourced from [MaterialTheme.colorScheme] so they adapt to light/dark/AMOLED/
+ * Material You and custom theme variants — no hardcoded hex values.
  * Called in the Compose layer; [fileTypeIcon] provides the pure category enum.
  */
 @Composable
-private fun fileTypeIconVector(icon: LocalFileIcon): Pair<ImageVector, Color> = when (icon) {
-    LocalFileIcon.FOLDER   -> Icons.Default.Folder       to Color(0xFF4CAF50)
-    LocalFileIcon.IMAGE    -> Icons.Default.Image         to Color(0xFF9C27B0)
-    LocalFileIcon.VIDEO    -> Icons.Default.VideoCameraBack to Color(0xFFE91E63)
-    LocalFileIcon.AUDIO    -> Icons.Default.MusicNote     to Color(0xFFFF9800)
-    LocalFileIcon.ARCHIVE  -> Icons.Default.Archive       to Color(0xFF795548)
-    LocalFileIcon.CODE     -> Icons.Default.Code          to Color(0xFF009688)
-    LocalFileIcon.DOCUMENT -> Icons.Default.Description   to Color(0xFF2196F3)
-    LocalFileIcon.OTHER    -> Icons.AutoMirrored.Filled.InsertDriveFile to Color(0xFF9E9E9E)
+private fun fileTypeIconVector(icon: LocalFileIcon): Pair<ImageVector, Color> {
+    val cs = MaterialTheme.colorScheme
+    return when (icon) {
+        LocalFileIcon.FOLDER   -> Icons.Default.Folder                       to cs.secondary
+        LocalFileIcon.IMAGE    -> Icons.Default.Image                         to cs.primary
+        LocalFileIcon.VIDEO    -> Icons.Default.VideoCameraBack               to cs.error
+        LocalFileIcon.AUDIO    -> Icons.Default.MusicNote                     to cs.onSurfaceVariant
+        LocalFileIcon.ARCHIVE  -> Icons.Default.Archive                       to cs.outline
+        LocalFileIcon.CODE     -> Icons.Default.Code                          to cs.secondary
+        LocalFileIcon.DOCUMENT -> Icons.Default.Description                   to cs.primary
+        LocalFileIcon.OTHER    -> Icons.AutoMirrored.Filled.InsertDriveFile   to cs.outline
+    }
 }
 
 /**
- * Full-screen results list, loading/empty/error/permission states.
- * Structured so 5e can add a toolbar + grid view above the [LazyColumn].
+ * Full-screen results screen with Drive-style toolbar (query mode, sort, filters),
+ * list/grid toggle, paginated results, and all loading/empty/error/permission states.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LocalSearchResultsScreen(
     state: SearchState.LocalSearchResults,
+    toolbarState: LocalSearchToolbarState,
     onOpenFile: (FileResult) -> Unit,
     onRetry: () -> Unit,
     onOpenPermissionSettings: () -> Unit,
+    onQueryModeChange: (String) -> Unit,
+    onSortFieldChange: (String) -> Unit,
+    onSortDirToggle: () -> Unit,
+    onViewToggle: (String) -> Unit,
+    onTypeToggle: (String) -> Unit,
+    onDatePresetChange: (String) -> Unit,
+    onPathPrefixChange: (String) -> Unit,
+    onTitleOnlyChange: (Boolean) -> Unit,
+    onClearFilters: () -> Unit,
+    onLoadMore: () -> Unit,
 ) {
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
 
     Column(modifier = Modifier.fillMaxSize()) {
-        // ── Toolbar placeholder — 5e will add query-mode control, sort, filter chips ──
-        // Count + source line (shown when results are available).
+        // ── Toolbar (shown once we're past the gating states) ──────────────────
+        if (!state.needsPermission && state.error == null && state.query.isNotBlank()) {
+            LocalSearchToolbar(
+                toolbarState = toolbarState,
+                onQueryModeChange = onQueryModeChange,
+                onSortFieldChange = onSortFieldChange,
+                onSortDirToggle = onSortDirToggle,
+                onViewToggle = onViewToggle,
+                onTypeToggle = onTypeToggle,
+                onDatePresetChange = onDatePresetChange,
+                onPathPrefixChange = onPathPrefixChange,
+                onTitleOnlyChange = onTitleOnlyChange,
+                onClearFilters = onClearFilters,
+            )
+            HorizontalDivider(color = dividerColor)
+        }
+
+        // ── Count + source line ────────────────────────────────────────────────
         if (!state.isLoading && state.error == null && !state.needsPermission && state.query.isNotBlank()) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 10.dp, bottom = 4.dp, start = 4.dp, end = 4.dp),
+                    .padding(top = 6.dp, bottom = 2.dp, start = 4.dp, end = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
@@ -1465,7 +1527,7 @@ private fun LocalSearchResultsScreen(
                     modifier = Modifier.weight(1f),
                 )
                 Text(
-                    text = "On-device files",
+                    text = "On-device",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                 )
@@ -1475,10 +1537,7 @@ private fun LocalSearchResultsScreen(
 
         when {
             state.isLoading -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
             }
@@ -1489,11 +1548,8 @@ private fun LocalSearchResultsScreen(
                 LocalSearchError(message = state.error, onRetry = onRetry)
             }
             state.query.isBlank() -> {
-                // Bare "s" with no query — prompt the user.
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(32.dp),
+                    modifier = Modifier.fillMaxSize().padding(32.dp),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
@@ -1506,9 +1562,7 @@ private fun LocalSearchResultsScreen(
             }
             state.results.isEmpty() -> {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(32.dp),
+                    modifier = Modifier.fillMaxSize().padding(32.dp),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
@@ -1519,14 +1573,361 @@ private fun LocalSearchResultsScreen(
                     )
                 }
             }
+            toolbarState.view == "grid" -> {
+                // ── Grid view ──────────────────────────────────────────────────
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    gridItems(state.results) { file ->
+                        FileResultGridCard(file = file, onClick = { onOpenFile(file) })
+                    }
+                    if (hasMore(state.results.size, state.total)) {
+                        item {
+                            LoadMoreFooter(isLoadingMore = state.isLoadingMore, onLoadMore = onLoadMore)
+                        }
+                    }
+                }
+            }
             else -> {
-                // ── Results list — 5e adds a grid variant beside this ──
+                // ── List view ──────────────────────────────────────────────────
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     items(state.results) { file ->
                         FileResultRow(file = file, onClick = { onOpenFile(file) })
                         HorizontalDivider(color = dividerColor)
                     }
+                    if (hasMore(state.results.size, state.total)) {
+                        item {
+                            LoadMoreFooter(isLoadingMore = state.isLoadingMore, onLoadMore = onLoadMore)
+                        }
+                    }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Drive-style toolbar: query-mode segmented control, sort (field + direction),
+ * list/grid toggle, type-filter chips, date preset, title-only switch, path field,
+ * and a clear affordance.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LocalSearchToolbar(
+    toolbarState: LocalSearchToolbarState,
+    onQueryModeChange: (String) -> Unit,
+    onSortFieldChange: (String) -> Unit,
+    onSortDirToggle: () -> Unit,
+    onViewToggle: (String) -> Unit,
+    onTypeToggle: (String) -> Unit,
+    onDatePresetChange: (String) -> Unit,
+    onPathPrefixChange: (String) -> Unit,
+    onTitleOnlyChange: (Boolean) -> Unit,
+    onClearFilters: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        // ── Row 1: query mode | sort + dir | view toggle ───────────────────────
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            // Query-mode segmented buttons
+            val modes = listOf("simple" to "Simple", "wildcard" to "Wildcard", "regex" to "Regex*")
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                for ((value, label) in modes) {
+                    val selected = toolbarState.queryMode == value
+                    if (selected) {
+                        Button(
+                            onClick = {},
+                            modifier = Modifier.weight(1f).height(32.dp),
+                            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp),
+                        ) {
+                            Text(label, fontSize = 11.sp, maxLines = 1)
+                        }
+                    } else {
+                        OutlinedButton(
+                            onClick = { onQueryModeChange(value) },
+                            modifier = Modifier.weight(1f).height(32.dp),
+                            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp),
+                        ) {
+                            Text(label, fontSize = 11.sp, maxLines = 1)
+                        }
+                    }
+                }
+            }
+
+            // Sort field dropdown
+            var sortExpanded by remember { mutableStateOf(false) }
+            val sortFieldOptions = listOf("" to "Relevance", "modified" to "Modified", "created" to "Created")
+            val currentSortLabel = sortFieldOptions.firstOrNull { it.first == toolbarState.sortField }?.second ?: "Relevance"
+            ExposedDropdownMenuBox(
+                expanded = sortExpanded,
+                onExpandedChange = { sortExpanded = it },
+            ) {
+                OutlinedButton(
+                    onClick = { sortExpanded = true },
+                    modifier = Modifier
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                        .height(32.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                ) {
+                    Text(currentSortLabel, fontSize = 11.sp, maxLines = 1)
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(14.dp))
+                }
+                ExposedDropdownMenu(expanded = sortExpanded, onDismissRequest = { sortExpanded = false }) {
+                    sortFieldOptions.forEach { (value, label) ->
+                        DropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = { onSortFieldChange(value); sortExpanded = false },
+                        )
+                    }
+                }
+            }
+
+            // Sort direction toggle
+            val isAsc = toolbarState.sortDir == "asc"
+            IconButton(
+                onClick = onSortDirToggle,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    imageVector = if (isAsc) Icons.Default.ArrowUpward else Icons.Default.ArrowDownward,
+                    contentDescription = if (isAsc) "Sort ascending" else "Sort descending",
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // List / Grid view toggle
+            Row {
+                IconButton(onClick = { onViewToggle("list") }, modifier = Modifier.size(32.dp)) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ViewList,
+                        contentDescription = "List view",
+                        modifier = Modifier.size(18.dp),
+                        tint = if (toolbarState.view == "list") MaterialTheme.colorScheme.primary
+                               else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = { onViewToggle("grid") }, modifier = Modifier.size(32.dp)) {
+                    Icon(
+                        imageVector = Icons.Default.GridView,
+                        contentDescription = "Grid view",
+                        modifier = Modifier.size(18.dp),
+                        tint = if (toolbarState.view == "grid") MaterialTheme.colorScheme.primary
+                               else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        // ── Row 2: type chips + date preset + title-only + clear (scrollable) ──
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val fileTypeChips = listOf(
+                "document" to "Doc",
+                "image" to "Image",
+                "video" to "Video",
+                "audio" to "Audio",
+                "archive" to "Archive",
+                "code" to "Code",
+                "folder" to "Folder",
+                "other" to "Other",
+            )
+            for ((value, label) in fileTypeChips) {
+                FilterChip(
+                    selected = toolbarState.filterTypes.contains(value),
+                    onClick = { onTypeToggle(value) },
+                    label = { Text(label, fontSize = 11.sp) },
+                    modifier = Modifier.height(28.dp),
+                )
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            // Date preset dropdown
+            var dateExpanded by remember { mutableStateOf(false) }
+            val dateOptions = listOf("any" to "Any time", "week" to "Past week", "month" to "Past month", "year" to "Past year")
+            val currentDateLabel = dateOptions.firstOrNull { it.first == toolbarState.filterDatePreset }?.second ?: "Any time"
+            ExposedDropdownMenuBox(
+                expanded = dateExpanded,
+                onExpandedChange = { dateExpanded = it },
+            ) {
+                FilterChip(
+                    selected = toolbarState.filterDatePreset != "any",
+                    onClick = { dateExpanded = true },
+                    label = {
+                        Text(currentDateLabel, fontSize = 11.sp)
+                        Icon(Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(12.dp))
+                    },
+                    modifier = Modifier
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                        .height(28.dp),
+                )
+                ExposedDropdownMenu(expanded = dateExpanded, onDismissRequest = { dateExpanded = false }) {
+                    dateOptions.forEach { (value, label) ->
+                        DropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = { onDatePresetChange(value); dateExpanded = false },
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            // Title-only toggle
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable { onTitleOnlyChange(!toolbarState.filterTitleOnly) },
+            ) {
+                Switch(
+                    checked = toolbarState.filterTitleOnly,
+                    onCheckedChange = onTitleOnlyChange,
+                    modifier = Modifier.height(24.dp),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Title only",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            // Clear filters
+            val hasActiveFilters = toolbarState.filterTypes.isNotEmpty() ||
+                toolbarState.filterDatePreset != "any" ||
+                toolbarState.filterPathPrefix.isNotEmpty() ||
+                toolbarState.filterTitleOnly
+            if (hasActiveFilters) {
+                TextButton(
+                    onClick = onClearFilters,
+                    modifier = Modifier.height(28.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                ) {
+                    Text("Clear", fontSize = 11.sp, color = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
+
+        // ── Row 3: path prefix (full-width, debounced) ──────────────────────────
+        // Local mutable state for debouncing; syncs to toolbarState.filterPathPrefix externally.
+        var localPath by remember { mutableStateOf(toolbarState.filterPathPrefix) }
+        LaunchedEffect(toolbarState.filterPathPrefix) {
+            if (localPath != toolbarState.filterPathPrefix) localPath = toolbarState.filterPathPrefix
+        }
+        LaunchedEffect(localPath) {
+            if (localPath != toolbarState.filterPathPrefix) {
+                kotlinx.coroutines.delay(400L)
+                onPathPrefixChange(localPath)
+            }
+        }
+        OutlinedTextFieldS(
+            value = localPath,
+            onValueChange = { localPath = it },
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            placeholder = { Text("Path prefix…", style = MaterialTheme.typography.bodySmall) },
+        )
+    }
+}
+
+/**
+ * Grid card for a single file result (used in grid view).
+ */
+@Composable
+private fun FileResultGridCard(file: FileResult, onClick: () -> Unit) {
+    val iconInfo = fileTypeIcon(file.type)
+    val (iconVector, iconColor) = fileTypeIconVector(iconInfo)
+    val meta = buildString {
+        val date = formatModifiedDate(file.modifiedAt)
+        if (date.isNotEmpty()) append(date)
+        val size = formatFileSize(file.size)
+        if (size.isNotEmpty()) { if (isNotEmpty()) append(" · "); append(size) }
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = "File: ${file.name}" },
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(iconColor.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = iconVector,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = iconColor,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = file.name,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+            )
+            if (meta.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = meta,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Load-more footer shown at the bottom of list/grid when more results are available.
+ */
+@Composable
+private fun LoadMoreFooter(isLoadingMore: Boolean, onLoadMore: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isLoadingMore) {
+            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+        } else {
+            OutlinedButton(onClick = onLoadMore) {
+                Text("Load more")
             }
         }
     }

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -28,8 +28,14 @@ import sh.kavi.fasttravel.data.SearchHistory
 import sh.kavi.fasttravel.data.ThemePreferences
 import sh.kavi.fasttravel.data.withIgnoreAdded
 import sh.kavi.fasttravel.localsearch.buildLocalSearchRequest
+import sh.kavi.fasttravel.localsearch.datePresetToRange
+import sh.kavi.fasttravel.localsearch.hasMore
+import sh.kavi.fasttravel.localsearch.nextPage
 import sh.kavi.fasttravel.localsearch.shouldInterceptLocalSearch
+import sh.kavi.fasttravel.localsearch.toggleType
+import sh.kavi.fasttravel.localsearch.index.DateRange
 import sh.kavi.fasttravel.localsearch.index.FileResult
+import sh.kavi.fasttravel.localsearch.index.FileType
 import sh.kavi.fasttravel.localsearch.index.MediaStoreSearcher
 import sh.kavi.fasttravel.localsearch.index.hasLocalSearchPermission
 import sh.kavi.fasttravel.localsearch.settings.configHasSTrigger
@@ -52,10 +58,28 @@ sealed class SearchState {
         val results: List<FileResult> = emptyList(),
         val total: Int = 0,
         val isLoading: Boolean = true,
+        val isLoadingMore: Boolean = false,
+        val currentPage: Int = 0,
         val error: String? = null,
         val needsPermission: Boolean = false,
     ) : SearchState()
 }
+
+/**
+ * Immutable snapshot of all toolbar control states for the local-search results screen.
+ * Kept separate from [SearchState.LocalSearchResults] so the view toggle can update without
+ * triggering a re-search (re-renders current results in the chosen layout only).
+ */
+data class LocalSearchToolbarState(
+    val queryMode: String = "simple",
+    val sortField: String = "",
+    val sortDir: String = "",
+    val view: String = "list",
+    val filterTypes: List<String> = emptyList(),
+    val filterDatePreset: String = "any",
+    val filterPathPrefix: String = "",
+    val filterTitleOnly: Boolean = false,
+)
 
 class SearchViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -71,6 +95,9 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
 
     private val _searchState = MutableStateFlow<SearchState>(SearchState.Idle)
     val searchState: StateFlow<SearchState> = _searchState.asStateFlow()
+
+    private val _localSearchToolbarState = MutableStateFlow(LocalSearchToolbarState())
+    val localSearchToolbarState: StateFlow<LocalSearchToolbarState> = _localSearchToolbarState.asStateFlow()
 
     private var config: FastTravelConfig? = null
     private var suggestionJob: Job? = null
@@ -111,6 +138,18 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     private val autoIgnoreStore = AutoIgnoreStore(application)
 
     init {
+        // Load persisted toolbar state so controls reflect saved prefs on open.
+        _localSearchToolbarState.value = LocalSearchToolbarState(
+            queryMode = themePrefs.localSearchQueryMode,
+            sortField = themePrefs.localSearchSortField,
+            sortDir = themePrefs.localSearchSortDir,
+            view = themePrefs.localSearchView,
+            filterTypes = themePrefs.localSearchFilterTypes,
+            filterDatePreset = themePrefs.localSearchFilterDatePreset,
+            filterPathPrefix = themePrefs.localSearchFilterPathPrefix,
+            filterTitleOnly = themePrefs.localSearchFilterTitleOnly,
+        )
+
         loadCommonWords(application)
         themePrefs.registerListener(prefsListener)
 
@@ -444,10 +483,13 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     /**
      * Runs a local-file search for [query] and emits [SearchState.LocalSearchResults].
      *
+     * When [page] is 0 the results list resets (new search / filter change).
+     * When [page] > 0 the new results are appended to the existing list (load-more).
+     *
      * Permission is checked independently here — [themePrefs.localSearchEnabled] is
      * necessary but not sufficient (the pref is not cleared on permission revocation).
      */
-    private fun handleLocalSearch(query: String) {
+    private fun handleLocalSearch(query: String, page: Int = 0) {
         lastLocalSearchQuery = query
 
         // Blank query (bare "s") — show the results screen without running a search.
@@ -469,33 +511,65 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
             return
         }
 
-        _searchState.value = SearchState.LocalSearchResults(query = query, isLoading = true)
+        // Capture existing results before the coroutine (for append in load-more).
+        val existingResults = if (page > 0) {
+            (_searchState.value as? SearchState.LocalSearchResults)?.results ?: emptyList()
+        } else {
+            emptyList()
+        }
+
+        if (page == 0) {
+            _searchState.value = SearchState.LocalSearchResults(query = query, isLoading = true)
+        } else {
+            _searchState.value = (_searchState.value as? SearchState.LocalSearchResults)
+                ?.copy(isLoadingMore = true)
+                ?: SearchState.LocalSearchResults(query = query, isLoading = true)
+        }
 
         localSearchJob?.cancel()
         localSearchJob = viewModelScope.launch {
             try {
+                val types = themePrefs.localSearchFilterTypes.mapNotNull { s ->
+                    runCatching { FileType.fromString(s) }.getOrNull()
+                }
+                val modifiedRange: DateRange? = datePresetToRange(
+                    themePrefs.localSearchFilterDatePreset,
+                    System.currentTimeMillis(),
+                )
                 val req = buildLocalSearchRequest(
                     query = query,
                     queryMode = themePrefs.localSearchQueryMode,
                     sortField = themePrefs.localSearchSortField,
                     sortDir = themePrefs.localSearchSortDir,
                     history = themePrefs.recentlyOpened,
+                    types = types,
+                    modifiedRange = modifiedRange,
+                    pathPrefix = themePrefs.localSearchFilterPathPrefix,
+                    titleOnly = themePrefs.localSearchFilterTitleOnly,
+                    page = page,
                 )
                 val result = withContext(Dispatchers.IO) {
                     MediaStoreSearcher(getApplication<Application>().contentResolver).search(req)
                 }
                 _searchState.value = SearchState.LocalSearchResults(
                     query = query,
-                    results = result.results,
+                    results = existingResults + result.results,
                     total = result.total,
                     isLoading = false,
+                    isLoadingMore = false,
+                    currentPage = page,
                 )
             } catch (e: Exception) {
-                _searchState.value = SearchState.LocalSearchResults(
-                    query = query,
-                    isLoading = false,
-                    error = e.message ?: "Search failed",
-                )
+                val prev = _searchState.value as? SearchState.LocalSearchResults
+                _searchState.value = if (prev != null) {
+                    prev.copy(isLoading = false, isLoadingMore = false, error = e.message ?: "Search failed")
+                } else {
+                    SearchState.LocalSearchResults(
+                        query = query,
+                        isLoading = false,
+                        error = e.message ?: "Search failed",
+                    )
+                }
             }
         }
     }
@@ -511,6 +585,94 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     /** Re-run the last local search (e.g. after a permission grant). */
     fun retryLocalSearch() {
         handleLocalSearch(lastLocalSearchQuery)
+    }
+
+    /**
+     * Fetches the next page of results for the current query and appends them.
+     * No-op when already loading or when all results are loaded.
+     */
+    fun loadMoreLocalSearch() {
+        val state = _searchState.value as? SearchState.LocalSearchResults ?: return
+        if (state.isLoading || state.isLoadingMore) return
+        if (!hasMore(state.results.size, state.total)) return
+        handleLocalSearch(lastLocalSearchQuery, page = nextPage(state.currentPage))
+    }
+
+    // ── Toolbar control functions ────────────────────────────────────────────
+
+    /** Changes query mode, persists the pref, and re-runs the search from page 0. */
+    fun setLocalSearchQueryMode(mode: String) {
+        themePrefs.localSearchQueryMode = mode
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(queryMode = mode)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /** Changes sort field, persists the pref, and re-runs the search from page 0. */
+    fun setLocalSearchSortField(field: String) {
+        themePrefs.localSearchSortField = field
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(sortField = field)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /** Toggles sort direction (asc ↔ desc), persists the pref, and re-runs the search from page 0. */
+    fun toggleLocalSearchSortDir() {
+        val next = if (themePrefs.localSearchSortDir == "asc") "" else "asc"
+        themePrefs.localSearchSortDir = next
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(sortDir = next)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /**
+     * Changes the view layout (list/grid), persists the pref.
+     * Does NOT re-run the search — re-renders current results in the new layout only.
+     */
+    fun setLocalSearchView(view: String) {
+        themePrefs.localSearchView = view
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(view = view)
+    }
+
+    /** Toggles a file-type filter string, persists, and re-runs the search from page 0. */
+    fun toggleLocalSearchFilterType(type: String) {
+        val new = toggleType(themePrefs.localSearchFilterTypes, type)
+        themePrefs.localSearchFilterTypes = new
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(filterTypes = new)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /** Sets the date-modified preset filter, persists, and re-runs the search from page 0. */
+    fun setLocalSearchFilterDatePreset(preset: String) {
+        themePrefs.localSearchFilterDatePreset = preset
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(filterDatePreset = preset)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /** Sets the path-prefix filter, persists, and re-runs the search from page 0. */
+    fun setLocalSearchFilterPathPrefix(prefix: String) {
+        themePrefs.localSearchFilterPathPrefix = prefix
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(filterPathPrefix = prefix)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /** Toggles the title-only filter, persists, and re-runs the search from page 0. */
+    fun setLocalSearchFilterTitleOnly(titleOnly: Boolean) {
+        themePrefs.localSearchFilterTitleOnly = titleOnly
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(filterTitleOnly = titleOnly)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /** Clears all filter prefs, resets toolbar filter state, and re-runs the search from page 0. */
+    fun clearLocalSearchFilters() {
+        themePrefs.localSearchFilterTypes = emptyList()
+        themePrefs.localSearchFilterDatePreset = "any"
+        themePrefs.localSearchFilterPathPrefix = ""
+        themePrefs.localSearchFilterTitleOnly = false
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(
+            filterTypes = emptyList(),
+            filterDatePreset = "any",
+            filterPathPrefix = "",
+            filterTitleOnly = false,
+        )
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
     }
 
     /**

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -62,6 +62,8 @@ sealed class SearchState {
         val currentPage: Int = 0,
         val error: String? = null,
         val needsPermission: Boolean = false,
+        /** True when the MediaStore candidate set was capped — total is a lower bound. */
+        val degraded: Boolean = false,
     ) : SearchState()
 }
 
@@ -79,6 +81,8 @@ data class LocalSearchToolbarState(
     val filterDatePreset: String = "any",
     val filterPathPrefix: String = "",
     val filterTitleOnly: Boolean = false,
+    val caseSensitive: Boolean = false,
+    val exactPhrase: Boolean = false,
 )
 
 class SearchViewModel(application: Application) : AndroidViewModel(application) {
@@ -139,15 +143,19 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
 
     init {
         // Load persisted toolbar state so controls reflect saved prefs on open.
+        // Bug B: remap stored "created" sort to "" (relevance) — created sort is removed.
+        val storedSortField = themePrefs.localSearchSortField.let { if (it == "created") "" else it }
         _localSearchToolbarState.value = LocalSearchToolbarState(
             queryMode = themePrefs.localSearchQueryMode,
-            sortField = themePrefs.localSearchSortField,
+            sortField = storedSortField,
             sortDir = themePrefs.localSearchSortDir,
             view = themePrefs.localSearchView,
             filterTypes = themePrefs.localSearchFilterTypes,
             filterDatePreset = themePrefs.localSearchFilterDatePreset,
             filterPathPrefix = themePrefs.localSearchFilterPathPrefix,
             filterTitleOnly = themePrefs.localSearchFilterTitleOnly,
+            caseSensitive = themePrefs.localSearchCaseSensitive,
+            exactPhrase = themePrefs.localSearchExactPhrase,
         )
 
         loadCommonWords(application)
@@ -547,6 +555,8 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
                     pathPrefix = themePrefs.localSearchFilterPathPrefix,
                     titleOnly = themePrefs.localSearchFilterTitleOnly,
                     page = page,
+                    caseSensitive = themePrefs.localSearchCaseSensitive,
+                    exactPhrase = themePrefs.localSearchExactPhrase,
                 )
                 val result = withContext(Dispatchers.IO) {
                     MediaStoreSearcher(getApplication<Application>().contentResolver).search(req)
@@ -558,6 +568,7 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
                     isLoading = false,
                     isLoadingMore = false,
                     currentPage = page,
+                    degraded = result.degraded,
                 )
             } catch (e: Exception) {
                 val prev = _searchState.value as? SearchState.LocalSearchResults
@@ -666,12 +677,33 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         themePrefs.localSearchFilterDatePreset = "any"
         themePrefs.localSearchFilterPathPrefix = ""
         themePrefs.localSearchFilterTitleOnly = false
+        themePrefs.localSearchCaseSensitive = false
+        themePrefs.localSearchExactPhrase = false
         _localSearchToolbarState.value = _localSearchToolbarState.value.copy(
             filterTypes = emptyList(),
             filterDatePreset = "any",
             filterPathPrefix = "",
             filterTitleOnly = false,
+            caseSensitive = false,
+            exactPhrase = false,
         )
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /** Toggles case-sensitive matching, persists the pref, and re-runs the search from page 0. */
+    fun setLocalSearchCaseSensitive(value: Boolean) {
+        themePrefs.localSearchCaseSensitive = value
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(caseSensitive = value)
+        handleLocalSearch(lastLocalSearchQuery, page = 0)
+    }
+
+    /**
+     * Toggles exact-phrase matching, persists the pref, and re-runs the search from page 0.
+     * Has no effect in regex mode (the pipeline ignores exactPhrase for regex queries).
+     */
+    fun setLocalSearchExactPhrase(value: Boolean) {
+        themePrefs.localSearchExactPhrase = value
+        _localSearchToolbarState.value = _localSearchToolbarState.value.copy(exactPhrase = value)
         handleLocalSearch(lastLocalSearchQuery, page = 0)
     }
 

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -27,6 +27,12 @@ import sh.kavi.fasttravel.data.ConfigRepository
 import sh.kavi.fasttravel.data.SearchHistory
 import sh.kavi.fasttravel.data.ThemePreferences
 import sh.kavi.fasttravel.data.withIgnoreAdded
+import sh.kavi.fasttravel.localsearch.buildLocalSearchRequest
+import sh.kavi.fasttravel.localsearch.shouldInterceptLocalSearch
+import sh.kavi.fasttravel.localsearch.index.FileResult
+import sh.kavi.fasttravel.localsearch.index.MediaStoreSearcher
+import sh.kavi.fasttravel.localsearch.index.hasLocalSearchPermission
+import sh.kavi.fasttravel.localsearch.settings.configHasSTrigger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -41,6 +47,14 @@ sealed class SearchState {
     data object Idle : SearchState()
     data class TypoSuggestion(val typo: ParseOutput.TypoResult) : SearchState()
     data class Navigate(val url: String) : SearchState()
+    data class LocalSearchResults(
+        val query: String,
+        val results: List<FileResult> = emptyList(),
+        val total: Int = 0,
+        val isLoading: Boolean = true,
+        val error: String? = null,
+        val needsPermission: Boolean = false,
+    ) : SearchState()
 }
 
 class SearchViewModel(application: Application) : AndroidViewModel(application) {
@@ -62,6 +76,8 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     private var suggestionJob: Job? = null
     private var installedAppsJob: Job? = null
     private var chipJob: Job? = null
+    private var localSearchJob: Job? = null
+    private var lastLocalSearchQuery: String = ""
 
     private val _chipItems = MutableStateFlow<List<ChipItem>>(emptyList())
     val chipItems: StateFlow<List<ChipItem>> = _chipItems.asStateFlow()
@@ -287,6 +303,7 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     fun onQueryChanged(newQuery: String) {
         _query.value = newQuery
         _searchState.value = SearchState.Idle
+        localSearchJob?.cancel()
 
         val cfg = config
         // When user commits to a command ("trigger "), stale Google suggestions from
@@ -391,6 +408,20 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         val cfg = config ?: return
         _suggestions.value = emptyList()
 
+        // ── Local search intercept ────────────────────────────────────────────
+        // Must run BEFORE CommandParser so "s <query>" never reaches typo-detection.
+        // configHasSTrigger is checked here (independent of localSearchEnabled) so
+        // the guard is correct even when the pref was set before a config collision.
+        val intercept = shouldInterceptLocalSearch(
+            input = searchQuery,
+            enabled = themePrefs.localSearchEnabled,
+            configHasS = configHasSTrigger(cfg),
+        )
+        if (intercept.intercept) {
+            handleLocalSearch(intercept.query)
+            return
+        }
+
         val input = ParseInput(
             rawQuery = searchQuery,
             device = DeviceType.Android,
@@ -408,6 +439,86 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
                 _searchState.value = SearchState.TypoSuggestion(result)
             }
         }
+    }
+
+    /**
+     * Runs a local-file search for [query] and emits [SearchState.LocalSearchResults].
+     *
+     * Permission is checked independently here — [themePrefs.localSearchEnabled] is
+     * necessary but not sufficient (the pref is not cleared on permission revocation).
+     */
+    private fun handleLocalSearch(query: String) {
+        lastLocalSearchQuery = query
+
+        // Blank query (bare "s") — show the results screen without running a search.
+        if (query.isBlank()) {
+            _searchState.value = SearchState.LocalSearchResults(
+                query = query,
+                isLoading = false,
+            )
+            return
+        }
+
+        // Independent permission check — do NOT attempt the search without it.
+        if (!hasLocalSearchPermission(getApplication())) {
+            _searchState.value = SearchState.LocalSearchResults(
+                query = query,
+                isLoading = false,
+                needsPermission = true,
+            )
+            return
+        }
+
+        _searchState.value = SearchState.LocalSearchResults(query = query, isLoading = true)
+
+        localSearchJob?.cancel()
+        localSearchJob = viewModelScope.launch {
+            try {
+                val req = buildLocalSearchRequest(
+                    query = query,
+                    queryMode = themePrefs.localSearchQueryMode,
+                    sortField = themePrefs.localSearchSortField,
+                    sortDir = themePrefs.localSearchSortDir,
+                    history = themePrefs.recentlyOpened,
+                )
+                val result = withContext(Dispatchers.IO) {
+                    MediaStoreSearcher(getApplication<Application>().contentResolver).search(req)
+                }
+                _searchState.value = SearchState.LocalSearchResults(
+                    query = query,
+                    results = result.results,
+                    total = result.total,
+                    isLoading = false,
+                )
+            } catch (e: Exception) {
+                _searchState.value = SearchState.LocalSearchResults(
+                    query = query,
+                    isLoading = false,
+                    error = e.message ?: "Search failed",
+                )
+            }
+        }
+    }
+
+    /** Dismiss the local-search results screen and return to [SearchState.Idle]. */
+    fun dismissLocalSearch() {
+        localSearchJob?.cancel()
+        if (_searchState.value is SearchState.LocalSearchResults) {
+            _searchState.value = SearchState.Idle
+        }
+    }
+
+    /** Re-run the last local search (e.g. after a permission grant). */
+    fun retryLocalSearch() {
+        handleLocalSearch(lastLocalSearchQuery)
+    }
+
+    /**
+     * Records a file open so it scores higher on subsequent local searches.
+     * Called from the UI after a successful [Intent.ACTION_VIEW] launch.
+     */
+    fun recordFileOpen(fileId: String) {
+        themePrefs.addRecentlyOpened(fileId)
     }
 
     fun acceptTypo() {

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -6,8 +6,10 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -147,6 +149,10 @@ import sh.kavi.fasttravel.ui.appearance.ResolvedAppearance
 import sh.kavi.fasttravel.ui.appearance.resolveAppearance
 import sh.kavi.fasttravel.ui.appearance.forSettings
 import sh.kavi.fasttravel.ui.appearance.resolveFromPrefs
+import sh.kavi.fasttravel.localsearch.index.hasLocalSearchPermission
+import sh.kavi.fasttravel.localsearch.index.requiredPermissions
+import sh.kavi.fasttravel.localsearch.settings.canEnableLocalSearch
+import sh.kavi.fasttravel.localsearch.settings.configHasSTrigger
 import sh.kavi.fasttravel.ui.theme.FastTravelTheme
 import sh.kavi.fasttravel.ui.theme.LocalAppearance
 import kotlinx.coroutines.Dispatchers
@@ -444,6 +450,7 @@ fun SettingsNavHost(
             LocalSearchScreen(
                 navController = navController,
                 themePrefs = themePrefs,
+                config = config,
             )
         }
         composable(SettingsRoute.About.route) {
@@ -611,8 +618,65 @@ fun SettingsHomeScreen(
 fun LocalSearchScreen(
     navController: NavHostController,
     themePrefs: ThemePreferences,
+    config: FastTravelConfig?,
 ) {
+    val context = LocalContext.current
+
     var installedAppsEnabled by remember { mutableStateOf(themePrefs.installedAppsEnabled) }
+    var localSearchEnabled by remember { mutableStateOf(themePrefs.localSearchEnabled) }
+    var queryMode by remember { mutableStateOf(themePrefs.localSearchQueryMode) }
+    var sortField by remember { mutableStateOf(themePrefs.localSearchSortField) }
+    var sortDir by remember { mutableStateOf(themePrefs.localSearchSortDir) }
+    var sortFieldExpanded by remember { mutableStateOf(false) }
+
+    // Derive permission state; refreshed by the permission launcher callback.
+    var hasPermission by remember { mutableStateOf(hasLocalSearchPermission(context)) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        val allGranted = grants.values.all { it }
+        hasPermission = allGranted
+        if (allGranted) {
+            // Permission just granted — enable only if the collision guard still passes.
+            val hasS = config?.let { configHasSTrigger(it) } ?: false
+            if (!hasS) {
+                localSearchEnabled = true
+                themePrefs.localSearchEnabled = true
+            }
+        }
+    }
+
+    // Collision check: does any command in the active config claim the 's' trigger?
+    val configHasS = remember(config) { config?.let { configHasSTrigger(it) } ?: false }
+
+    // If a collision now exists and local search was on, force it off in storage too.
+    LaunchedEffect(configHasS) {
+        if (configHasS && localSearchEnabled) {
+            localSearchEnabled = false
+            themePrefs.localSearchEnabled = false
+        }
+    }
+
+    val canEnable = canEnableLocalSearch(hasPermission, configHasS)
+
+    // Helper to handle the toggle action: permission-gate or direct enable/disable.
+    fun handleToggle(wantOn: Boolean) {
+        if (configHasS) return  // Collision — never allow enabling.
+        if (wantOn) {
+            if (!hasPermission) {
+                permissionLauncher.launch(
+                    requiredPermissions(Build.VERSION.SDK_INT).toTypedArray()
+                )
+            } else {
+                localSearchEnabled = true
+                themePrefs.localSearchEnabled = true
+            }
+        } else {
+            localSearchEnabled = false
+            themePrefs.localSearchEnabled = false
+        }
+    }
 
     Scaffold(
         topBar = { SettingsTopBar(title = "Local search", onBack = { navController.popBackStack() }) },
@@ -625,6 +689,8 @@ fun LocalSearchScreen(
                 .verticalScroll(rememberScrollState()),
         ) {
             Spacer(modifier = Modifier.height(16.dp))
+
+            // ── Installed apps ────────────────────────────────────────────────
             SettingsCard {
                 SettingsSwitchItem(
                     headlineText = "Show installed apps",
@@ -636,8 +702,261 @@ fun LocalSearchScreen(
                     },
                 )
             }
-            // Future on-device, non-web options (e.g. the `s` local file-search command,
-            // issue #25) will live on this screen.
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // ── Local file search ─────────────────────────────────────────────
+            SettingsCategoryHeader(title = "Local file search")
+            SettingsCard {
+                // Explainer
+                ListItem(
+                    headlineContent = {
+                        Text(
+                            "Search on-device media and documents using the 's' keyword. " +
+                                "Results are drawn from your device's files via MediaStore.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                )
+
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                )
+
+                // Enable toggle (disabled when collision exists)
+                ListItem(
+                    headlineContent = {
+                        Text(
+                            text = "Enable local file search",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = if (!configHasS) MaterialTheme.colorScheme.onSurface
+                                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    supportingContent = {
+                        Text(
+                            text = "Search on-device files with the 's' keyword.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = localSearchEnabled && canEnable,
+                            onCheckedChange = { handleToggle(it) },
+                            enabled = !configHasS,
+                        )
+                    },
+                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    modifier = Modifier
+                        .alpha(if (!configHasS) 1f else 0.5f)
+                        .clickable(enabled = !configHasS) {
+                            handleToggle(!(localSearchEnabled && canEnable))
+                        },
+                )
+
+                // Permission status row
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                )
+                if (!hasPermission && !configHasS) {
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text = "Permission needed",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        supportingContent = {
+                            Text(
+                                text = "Storage access is required to search on-device files.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        trailingContent = {
+                            OutlinedButton(
+                                onClick = {
+                                    permissionLauncher.launch(
+                                        requiredPermissions(Build.VERSION.SDK_INT).toTypedArray()
+                                    )
+                                },
+                                shape = RoundedCornerShape(8.dp),
+                            ) { Text("Grant") }
+                        },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    )
+                } else if (hasPermission && !configHasS) {
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text = "Storage permission granted",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        leadingContent = {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    )
+                }
+
+                // Collision guard error
+                if (configHasS) {
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text = "The 's' keyword is already used by a command in your config — " +
+                                    "rename or remove it to use Local Search.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    )
+                }
+            }
+
+            // ── Defaults (shown only when local search is enabled and no collision) ──
+            if (localSearchEnabled && !configHasS) {
+                Spacer(modifier = Modifier.height(16.dp))
+                SettingsCategoryHeader(title = "Defaults")
+                SettingsCard {
+                    // Query mode
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                        Text(
+                            "Default query mode",
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        val queryModeOptions = listOf(
+                            "simple"   to "Simple",
+                            "wildcard" to "Wildcard",
+                            "regex"    to "Regex*",
+                        )
+                        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                            queryModeOptions.forEachIndexed { index, (value, label) ->
+                                SegmentedButton(
+                                    selected = queryMode == value,
+                                    onClick = {
+                                        queryMode = value
+                                        themePrefs.localSearchQueryMode = value
+                                    },
+                                    shape = SegmentedButtonDefaults.itemShape(
+                                        index = index,
+                                        count = queryModeOptions.size,
+                                    ),
+                                ) { Text(label) }
+                            }
+                        }
+                        if (queryMode == "regex") {
+                            Spacer(Modifier.height(6.dp))
+                            Text(
+                                "* Regex on Android is best-effort — MediaStore has no native regex " +
+                                    "support, so results may be broader than expected.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                    )
+
+                    // Sort
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                        Text(
+                            "Default sort",
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                        Spacer(Modifier.height(8.dp))
+
+                        // Sort field dropdown
+                        val sortFieldOptions = listOf(
+                            ""         to "Relevance",
+                            "name"     to "Name",
+                            "modified" to "Modified date",
+                            "created"  to "Created date",
+                            "size"     to "Size",
+                        )
+                        ExposedDropdownMenuBox(
+                            expanded = sortFieldExpanded,
+                            onExpandedChange = { sortFieldExpanded = it },
+                        ) {
+                            OutlinedTextField(
+                                value = sortFieldOptions.firstOrNull { it.first == sortField }?.second
+                                    ?: "Relevance",
+                                onValueChange = {},
+                                readOnly = true,
+                                label = { Text("Sort by") },
+                                trailingIcon = {
+                                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = sortFieldExpanded)
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                                shape = RoundedCornerShape(8.dp),
+                            )
+                            ExposedDropdownMenu(
+                                expanded = sortFieldExpanded,
+                                onDismissRequest = { sortFieldExpanded = false },
+                            ) {
+                                sortFieldOptions.forEach { (value, label) ->
+                                    DropdownMenuItem(
+                                        text = { Text(label) },
+                                        onClick = {
+                                            sortField = value
+                                            themePrefs.localSearchSortField = value
+                                            sortFieldExpanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+
+                        Spacer(Modifier.height(8.dp))
+
+                        // Sort direction segmented control
+                        // "" and "desc" are equivalent in the pipeline (both mean descending).
+                        Text(
+                            "Direction",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                            val dirOptions = listOf("" to "Descending", "asc" to "Ascending")
+                            dirOptions.forEachIndexed { index, (value, label) ->
+                                SegmentedButton(
+                                    selected = if (value == "asc") sortDir == "asc" else sortDir != "asc",
+                                    onClick = {
+                                        sortDir = value
+                                        themePrefs.localSearchSortDir = value
+                                    },
+                                    shape = SegmentedButtonDefaults.itemShape(
+                                        index = index,
+                                        count = dirOptions.size,
+                                    ),
+                                ) { Text(label) }
+                            }
+                        }
+                    }
+                }
+            }
+
             Spacer(modifier = Modifier.height(32.dp))
         }
     }

--- a/android/app/src/main/res/xml/file_provider_paths.xml
+++ b/android/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    FileProvider path configuration for local-search file opens.
+
+    MediaStore returns absolute paths under /storage/emulated/0/ (primary external
+    storage). <external-path path="." /> covers all subdirectories there.
+
+    <external-cache-path> and <files-path> are included for completeness;
+    they are unlikely to be needed for file-search results but are harmless.
+
+    If FileProvider.getUriForFile throws IllegalArgumentException (path not covered),
+    the Compose layer catches it and falls back to a toast.
+-->
+<paths>
+    <!-- Primary external storage: /storage/emulated/0/... -->
+    <external-path name="external" path="." />
+    <!-- App-private external files: /sdcard/Android/data/<pkg>/files/... -->
+    <external-files-path name="external_files" path="." />
+    <!-- App-private external cache: /sdcard/Android/data/<pkg>/cache/... -->
+    <external-cache-path name="external_cache" path="." />
+    <!-- App-private internal files: /data/data/<pkg>/files/... -->
+    <files-path name="internal_files" path="." />
+</paths>

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
@@ -1,6 +1,7 @@
 package sh.kavi.fasttravel.data
 
 import android.content.SharedPreferences
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -24,6 +25,58 @@ class ThemePreferencesTest {
 
         prefs.installedAppsEnabled = true
         assertTrue(prefs.installedAppsEnabled)
+    }
+
+    // ── localSearchEnabled ────────────────────────────────────────────────────
+
+    @Test
+    fun `localSearchEnabled defaults to false`() {
+        // Must start OFF so no user gains an unrequested s-intercept on upgrade.
+        assertFalse(newPrefs().localSearchEnabled)
+    }
+
+    @Test
+    fun `localSearchEnabled persists when toggled`() {
+        val prefs = newPrefs()
+        prefs.localSearchEnabled = true
+        assertTrue(prefs.localSearchEnabled)
+        prefs.localSearchEnabled = false
+        assertFalse(prefs.localSearchEnabled)
+    }
+
+    // ── localSearchQueryMode ──────────────────────────────────────────────────
+
+    @Test
+    fun `localSearchQueryMode defaults to simple`() {
+        assertEquals("simple", newPrefs().localSearchQueryMode)
+    }
+
+    @Test
+    fun `localSearchQueryMode persists custom value`() {
+        val prefs = newPrefs()
+        prefs.localSearchQueryMode = "wildcard"
+        assertEquals("wildcard", prefs.localSearchQueryMode)
+    }
+
+    // ── localSearchSortField / localSearchSortDir ─────────────────────────────
+
+    @Test
+    fun `localSearchSortField defaults to empty string (relevance)`() {
+        assertEquals("", newPrefs().localSearchSortField)
+    }
+
+    @Test
+    fun `localSearchSortDir defaults to empty string (desc)`() {
+        assertEquals("", newPrefs().localSearchSortDir)
+    }
+
+    @Test
+    fun `localSearchSortField and SortDir persist custom values`() {
+        val prefs = newPrefs()
+        prefs.localSearchSortField = "name"
+        prefs.localSearchSortDir = "asc"
+        assertEquals("name", prefs.localSearchSortField)
+        assertEquals("asc", prefs.localSearchSortDir)
     }
 }
 

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
@@ -78,6 +78,109 @@ class ThemePreferencesTest {
         assertEquals("name", prefs.localSearchSortField)
         assertEquals("asc", prefs.localSearchSortDir)
     }
+
+    // ── localSearchView ──────────────────────────────────────────────────────
+
+    @Test
+    fun `localSearchView defaults to list`() {
+        assertEquals("list", newPrefs().localSearchView)
+    }
+
+    @Test
+    fun `localSearchView persists grid`() {
+        val prefs = newPrefs()
+        prefs.localSearchView = "grid"
+        assertEquals("grid", prefs.localSearchView)
+    }
+
+    @Test
+    fun `localSearchView round-trips back to list`() {
+        val prefs = newPrefs()
+        prefs.localSearchView = "grid"
+        prefs.localSearchView = "list"
+        assertEquals("list", prefs.localSearchView)
+    }
+
+    // ── localSearchFilterTypes ───────────────────────────────────────────────
+
+    @Test
+    fun `localSearchFilterTypes defaults to empty list`() {
+        assertTrue(newPrefs().localSearchFilterTypes.isEmpty())
+    }
+
+    @Test
+    fun `localSearchFilterTypes persists a list of type strings`() {
+        val prefs = newPrefs()
+        prefs.localSearchFilterTypes = listOf("image", "video")
+        assertEquals(listOf("image", "video"), prefs.localSearchFilterTypes)
+    }
+
+    @Test
+    fun `localSearchFilterTypes persists empty list after clear`() {
+        val prefs = newPrefs()
+        prefs.localSearchFilterTypes = listOf("image")
+        prefs.localSearchFilterTypes = emptyList()
+        assertTrue(prefs.localSearchFilterTypes.isEmpty())
+    }
+
+    // ── localSearchFilterDatePreset ──────────────────────────────────────────
+
+    @Test
+    fun `localSearchFilterDatePreset defaults to any`() {
+        assertEquals("any", newPrefs().localSearchFilterDatePreset)
+    }
+
+    @Test
+    fun `localSearchFilterDatePreset persists week`() {
+        val prefs = newPrefs()
+        prefs.localSearchFilterDatePreset = "week"
+        assertEquals("week", prefs.localSearchFilterDatePreset)
+    }
+
+    @Test
+    fun `localSearchFilterDatePreset persists month and year`() {
+        val prefs = newPrefs()
+        prefs.localSearchFilterDatePreset = "month"
+        assertEquals("month", prefs.localSearchFilterDatePreset)
+        prefs.localSearchFilterDatePreset = "year"
+        assertEquals("year", prefs.localSearchFilterDatePreset)
+    }
+
+    // ── localSearchFilterPathPrefix ──────────────────────────────────────────
+
+    @Test
+    fun `localSearchFilterPathPrefix defaults to empty string`() {
+        assertEquals("", newPrefs().localSearchFilterPathPrefix)
+    }
+
+    @Test
+    fun `localSearchFilterPathPrefix persists a path`() {
+        val prefs = newPrefs()
+        prefs.localSearchFilterPathPrefix = "/sdcard/Music"
+        assertEquals("/sdcard/Music", prefs.localSearchFilterPathPrefix)
+    }
+
+    // ── localSearchFilterTitleOnly ───────────────────────────────────────────
+
+    @Test
+    fun `localSearchFilterTitleOnly defaults to false`() {
+        assertFalse(newPrefs().localSearchFilterTitleOnly)
+    }
+
+    @Test
+    fun `localSearchFilterTitleOnly persists true`() {
+        val prefs = newPrefs()
+        prefs.localSearchFilterTitleOnly = true
+        assertTrue(prefs.localSearchFilterTitleOnly)
+    }
+
+    @Test
+    fun `localSearchFilterTitleOnly round-trips false`() {
+        val prefs = newPrefs()
+        prefs.localSearchFilterTitleOnly = true
+        prefs.localSearchFilterTitleOnly = false
+        assertFalse(prefs.localSearchFilterTitleOnly)
+    }
 }
 
 private class TPFakePrefs : SharedPreferences {

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptorTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchInterceptorTest.kt
@@ -1,0 +1,226 @@
+package sh.kavi.fasttravel.localsearch
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import sh.kavi.fasttravel.localsearch.index.FileType
+
+/**
+ * JUnit5 unit tests for the pure local-search intercept helpers.
+ * All tests run on the JVM — no android.* dependencies.
+ */
+class LocalSearchInterceptorTest {
+
+    // ── shouldInterceptLocalSearch ────────────────────────────────────────────
+
+    @Test
+    fun `no intercept when local search is disabled`() {
+        val r = shouldInterceptLocalSearch("s cats", enabled = false, configHasS = false)
+        assertFalse(r.intercept)
+        assertEquals("", r.query)
+    }
+
+    @Test
+    fun `no intercept when config has s trigger`() {
+        val r = shouldInterceptLocalSearch("s cats", enabled = true, configHasS = true)
+        assertFalse(r.intercept)
+        assertEquals("", r.query)
+    }
+
+    @Test
+    fun `no intercept when both disabled and config has s`() {
+        val r = shouldInterceptLocalSearch("s cats", enabled = false, configHasS = true)
+        assertFalse(r.intercept)
+    }
+
+    @Test
+    fun `no intercept for non-s input`() {
+        assertFalse(shouldInterceptLocalSearch("g cats", enabled = true, configHasS = false).intercept)
+        assertFalse(shouldInterceptLocalSearch("search cats", enabled = true, configHasS = false).intercept)
+        assertFalse(shouldInterceptLocalSearch("sm cats", enabled = true, configHasS = false).intercept)
+        assertFalse(shouldInterceptLocalSearch("so cats", enabled = true, configHasS = false).intercept)
+        assertFalse(shouldInterceptLocalSearch("stack cats", enabled = true, configHasS = false).intercept)
+        assertFalse(shouldInterceptLocalSearch("ss", enabled = true, configHasS = false).intercept)
+    }
+
+    @Test
+    fun `intercepts bare s with empty query`() {
+        val r = shouldInterceptLocalSearch("s", enabled = true, configHasS = false)
+        assertTrue(r.intercept)
+        assertEquals("", r.query)
+    }
+
+    @Test
+    fun `intercepts s with single-word query`() {
+        val r = shouldInterceptLocalSearch("s cats", enabled = true, configHasS = false)
+        assertTrue(r.intercept)
+        assertEquals("cats", r.query)
+    }
+
+    @Test
+    fun `intercepts s with multi-word query`() {
+        val r = shouldInterceptLocalSearch("s hello world", enabled = true, configHasS = false)
+        assertTrue(r.intercept)
+        assertEquals("hello world", r.query)
+    }
+
+    @Test
+    fun `intercepts s with leading and trailing whitespace in input`() {
+        val r = shouldInterceptLocalSearch("  s cats  ", enabled = true, configHasS = false)
+        assertTrue(r.intercept)
+        assertEquals("cats", r.query)
+    }
+
+    @Test
+    fun `no intercept for empty input even when enabled`() {
+        val r = shouldInterceptLocalSearch("", enabled = true, configHasS = false)
+        assertFalse(r.intercept)
+    }
+
+    @Test
+    fun `intercept is strict no-op for all non-matching inputs`() {
+        listOf("", "g", "search", "sm", "ss", "sa").forEach { input ->
+            val r = shouldInterceptLocalSearch(input, enabled = true, configHasS = false)
+            assertFalse(r.intercept, "expected no intercept for: '$input'")
+        }
+    }
+
+    // ── buildLocalSearchRequest ───────────────────────────────────────────────
+
+    @Test
+    fun `builds request with correct query`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertEquals("cats", req.query)
+    }
+
+    @Test
+    fun `builds request with simple query mode`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertEquals(sh.kavi.fasttravel.localsearch.query.QueryMode.SIMPLE, req.queryMode)
+    }
+
+    @Test
+    fun `builds request with wildcard query mode`() {
+        val req = buildLocalSearchRequest("cats", "wildcard", "", "", emptyList())
+        assertEquals(sh.kavi.fasttravel.localsearch.query.QueryMode.WILDCARD, req.queryMode)
+    }
+
+    @Test
+    fun `builds request with regex query mode`() {
+        val req = buildLocalSearchRequest("cats", "regex", "", "", emptyList())
+        assertEquals(sh.kavi.fasttravel.localsearch.query.QueryMode.REGEX, req.queryMode)
+    }
+
+    @Test
+    fun `builds request with unknown query mode defaults to simple`() {
+        val req = buildLocalSearchRequest("cats", "unknown", "", "", emptyList())
+        assertEquals(sh.kavi.fasttravel.localsearch.query.QueryMode.SIMPLE, req.queryMode)
+    }
+
+    @Test
+    fun `builds request with correct sort field`() {
+        val req = buildLocalSearchRequest("cats", "simple", "name", "asc", emptyList())
+        assertEquals("name", req.sort.field)
+    }
+
+    @Test
+    fun `builds request with correct sort direction`() {
+        val req = buildLocalSearchRequest("cats", "simple", "modified", "desc", emptyList())
+        assertEquals("desc", req.sort.dir)
+    }
+
+    @Test
+    fun `builds request with empty sort falls back to pipeline defaults`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertEquals("", req.sort.field)
+        assertEquals("", req.sort.dir)
+    }
+
+    @Test
+    fun `builds request with correct history list`() {
+        val history = listOf("/storage/emulated/0/report.pdf", "/storage/emulated/0/notes.txt")
+        val req = buildLocalSearchRequest("cats", "simple", "", "", history)
+        assertEquals(history, req.history)
+    }
+
+    @Test
+    fun `builds request with page 0`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertEquals(0, req.page)
+    }
+
+    @Test
+    fun `builds request with default pageSize of 50`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertEquals(50, req.pageSize)
+    }
+
+    @Test
+    fun `builds request with custom pageSize`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList(), pageSize = 25)
+        assertEquals(25, req.pageSize)
+    }
+
+    @Test
+    fun `builds request with empty filters`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertTrue(req.filters.types.isEmpty())
+        assertEquals("", req.filters.pathPrefix)
+        assertFalse(req.filters.titleOnly)
+    }
+
+    // ── fileTypeIcon ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `fileTypeIcon maps FOLDER to FOLDER`() {
+        assertEquals(LocalFileIcon.FOLDER, fileTypeIcon(FileType.FOLDER))
+    }
+
+    @Test
+    fun `fileTypeIcon maps IMAGE to IMAGE`() {
+        assertEquals(LocalFileIcon.IMAGE, fileTypeIcon(FileType.IMAGE))
+    }
+
+    @Test
+    fun `fileTypeIcon maps VIDEO to VIDEO`() {
+        assertEquals(LocalFileIcon.VIDEO, fileTypeIcon(FileType.VIDEO))
+    }
+
+    @Test
+    fun `fileTypeIcon maps AUDIO to AUDIO`() {
+        assertEquals(LocalFileIcon.AUDIO, fileTypeIcon(FileType.AUDIO))
+    }
+
+    @Test
+    fun `fileTypeIcon maps ARCHIVE to ARCHIVE`() {
+        assertEquals(LocalFileIcon.ARCHIVE, fileTypeIcon(FileType.ARCHIVE))
+    }
+
+    @Test
+    fun `fileTypeIcon maps CODE to CODE`() {
+        assertEquals(LocalFileIcon.CODE, fileTypeIcon(FileType.CODE))
+    }
+
+    @Test
+    fun `fileTypeIcon maps DOCUMENT to DOCUMENT`() {
+        assertEquals(LocalFileIcon.DOCUMENT, fileTypeIcon(FileType.DOCUMENT))
+    }
+
+    @Test
+    fun `fileTypeIcon maps OTHER to OTHER`() {
+        assertEquals(LocalFileIcon.OTHER, fileTypeIcon(FileType.OTHER))
+    }
+
+    @Test
+    fun `fileTypeIcon covers every FileType variant`() {
+        // Regression guard: if a new FileType is added without updating fileTypeIcon, this
+        // exhaustiveness check detects it.
+        for (type in FileType.entries) {
+            val icon = fileTypeIcon(type)
+            // Just verifying it returns a non-null value without throwing.
+            @Suppress("SENSELESS_COMPARISON")
+            assertTrue(icon != null, "fileTypeIcon returned null for $type")
+        }
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchToolbarTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchToolbarTest.kt
@@ -245,4 +245,51 @@ class LocalSearchToolbarTest {
         )
         assertEquals(25, req.pageSize)
     }
+
+    // ── caseSensitive / exactPhrase ────────────────────────────────────────────
+
+    @Test
+    fun `buildLocalSearchRequest carries caseSensitive flag`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            caseSensitive = true,
+        )
+        assertTrue(req.caseSensitive)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest carries exactPhrase flag`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            exactPhrase = true,
+        )
+        assertTrue(req.exactPhrase)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest defaults caseSensitive and exactPhrase to false`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertFalse(req.caseSensitive)
+        assertFalse(req.exactPhrase)
+    }
+
+    // ── Bug B: created sort remapped to relevance ──────────────────────────────
+
+    @Test
+    fun `buildLocalSearchRequest remaps created sort field to relevance (empty string)`() {
+        val req = buildLocalSearchRequest("cats", "simple", "created", "", emptyList())
+        assertEquals("", req.sort.field, "stored 'created' sort must be remapped to '' (relevance)")
+    }
+
+    @Test
+    fun `buildLocalSearchRequest leaves modified sort field unchanged`() {
+        val req = buildLocalSearchRequest("cats", "simple", "modified", "asc", emptyList())
+        assertEquals("modified", req.sort.field)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest leaves relevance sort field unchanged`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "desc", emptyList())
+        assertEquals("", req.sort.field)
+    }
 }

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchToolbarTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/LocalSearchToolbarTest.kt
@@ -1,0 +1,248 @@
+package sh.kavi.fasttravel.localsearch
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import sh.kavi.fasttravel.localsearch.index.DateRange
+import sh.kavi.fasttravel.localsearch.index.FileType
+
+/**
+ * JUnit5 unit tests for the pure toolbar logic: datePresetToRange, toggleType,
+ * hasMore/nextPage, and extended buildLocalSearchRequest.
+ * All tests run on the JVM — no android.* dependencies.
+ */
+class LocalSearchToolbarTest {
+
+    private val BASE_NOW = 1_750_000_000_000L // arbitrary fixed epoch ms
+
+    // ── datePresetToRange ──────────────────────────────────────────────────────
+
+    @Test
+    fun `datePresetToRange any returns null`() {
+        assertNull(datePresetToRange("any", BASE_NOW))
+    }
+
+    @Test
+    fun `datePresetToRange week returns from = now minus 7 days in ms`() {
+        val range = datePresetToRange("week", BASE_NOW)
+        assertNotNull(range)
+        assertEquals(BASE_NOW - 7L * 86_400_000L, range!!.from)
+    }
+
+    @Test
+    fun `datePresetToRange month returns from = now minus 30 days in ms`() {
+        val range = datePresetToRange("month", BASE_NOW)
+        assertNotNull(range)
+        assertEquals(BASE_NOW - 30L * 86_400_000L, range!!.from)
+    }
+
+    @Test
+    fun `datePresetToRange year returns from = now minus 365 days in ms`() {
+        val range = datePresetToRange("year", BASE_NOW)
+        assertNotNull(range)
+        assertEquals(BASE_NOW - 365L * 86_400_000L, range!!.from)
+    }
+
+    @Test
+    fun `datePresetToRange unknown preset returns null`() {
+        assertNull(datePresetToRange("decade", BASE_NOW))
+    }
+
+    @Test
+    fun `datePresetToRange to is 0 meaning open upper bound`() {
+        val range = datePresetToRange("week", BASE_NOW)
+        assertNotNull(range)
+        assertEquals(0L, range!!.to)
+    }
+
+    @Test
+    fun `datePresetToRange week matches extension constant 7 DAY_MS`() {
+        val DAY_MS = 86_400_000L
+        val now = 2_000_000_000_000L
+        assertEquals(now - 7L * DAY_MS, datePresetToRange("week", now)!!.from)
+    }
+
+    @Test
+    fun `datePresetToRange month matches extension constant 30 DAY_MS`() {
+        val DAY_MS = 86_400_000L
+        val now = 2_000_000_000_000L
+        assertEquals(now - 30L * DAY_MS, datePresetToRange("month", now)!!.from)
+    }
+
+    @Test
+    fun `datePresetToRange year matches extension constant 365 DAY_MS`() {
+        val DAY_MS = 86_400_000L
+        val now = 2_000_000_000_000L
+        assertEquals(now - 365L * DAY_MS, datePresetToRange("year", now)!!.from)
+    }
+
+    // ── toggleType ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `toggleType adds type when absent from empty list`() {
+        assertEquals(listOf("image"), toggleType(emptyList(), "image"))
+    }
+
+    @Test
+    fun `toggleType adds type when absent from non-empty list`() {
+        assertEquals(listOf("image", "video"), toggleType(listOf("image"), "video"))
+    }
+
+    @Test
+    fun `toggleType removes type when present`() {
+        assertEquals(listOf("video"), toggleType(listOf("image", "video"), "image"))
+    }
+
+    @Test
+    fun `toggleType removes last type yielding empty list`() {
+        assertTrue(toggleType(listOf("audio"), "audio").isEmpty())
+    }
+
+    @Test
+    fun `toggleType does not mutate the input list`() {
+        val original = listOf("image")
+        val result = toggleType(original, "video")
+        assertEquals(listOf("image"), original) // original unchanged
+        assertEquals(listOf("image", "video"), result)
+    }
+
+    @Test
+    fun `toggleType removing middle element preserves order`() {
+        val result = toggleType(listOf("doc", "image", "video"), "image")
+        assertEquals(listOf("doc", "video"), result)
+    }
+
+    // ── hasMore ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `hasMore returns true when loaded is less than total`() {
+        assertTrue(hasMore(10, 20))
+    }
+
+    @Test
+    fun `hasMore returns false when loaded equals total`() {
+        assertFalse(hasMore(20, 20))
+    }
+
+    @Test
+    fun `hasMore returns false when loaded exceeds total`() {
+        assertFalse(hasMore(25, 20))
+    }
+
+    @Test
+    fun `hasMore returns false for zero total`() {
+        assertFalse(hasMore(0, 0))
+    }
+
+    @Test
+    fun `hasMore returns false when loaded is 1 and total is 1`() {
+        assertFalse(hasMore(1, 1))
+    }
+
+    // ── nextPage ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `nextPage returns 1 for page 0`() {
+        assertEquals(1, nextPage(0))
+    }
+
+    @Test
+    fun `nextPage increments by one`() {
+        assertEquals(5, nextPage(4))
+        assertEquals(3, nextPage(2))
+    }
+
+    // ── extended buildLocalSearchRequest ───────────────────────────────────────
+
+    @Test
+    fun `buildLocalSearchRequest with types filter`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            types = listOf(FileType.IMAGE, FileType.VIDEO),
+        )
+        assertEquals(listOf(FileType.IMAGE, FileType.VIDEO), req.filters.types)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest with modifiedRange filter`() {
+        val range = DateRange(from = 1_000_000L, to = 0L)
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            modifiedRange = range,
+        )
+        assertEquals(range, req.filters.modifiedRange)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest with null modifiedRange leaves it null`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            modifiedRange = null,
+        )
+        assertNull(req.filters.modifiedRange)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest with pathPrefix filter`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            pathPrefix = "/storage/emulated/0",
+        )
+        assertEquals("/storage/emulated/0", req.filters.pathPrefix)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest with titleOnly filter`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            titleOnly = true,
+        )
+        assertTrue(req.filters.titleOnly)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest with page parameter`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            page = 2,
+        )
+        assertEquals(2, req.page)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest defaults have empty filters and page 0`() {
+        val req = buildLocalSearchRequest("cats", "simple", "", "", emptyList())
+        assertTrue(req.filters.types.isEmpty())
+        assertNull(req.filters.modifiedRange)
+        assertEquals("", req.filters.pathPrefix)
+        assertFalse(req.filters.titleOnly)
+        assertEquals(0, req.page)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest backward compat positional call without filter args`() {
+        // Existing call-sites: buildLocalSearchRequest(q, mode, field, dir, history)
+        val req = buildLocalSearchRequest("cats", "wildcard", "name", "asc", listOf("/path/a"))
+        assertEquals("cats", req.query)
+        assertEquals(sh.kavi.fasttravel.localsearch.query.QueryMode.WILDCARD, req.queryMode)
+        assertEquals("name", req.sort.field)
+        assertEquals("asc", req.sort.dir)
+        assertEquals(listOf("/path/a"), req.history)
+        // Defaults
+        assertTrue(req.filters.types.isEmpty())
+        assertEquals(0, req.page)
+        assertEquals(50, req.pageSize)
+    }
+
+    @Test
+    fun `buildLocalSearchRequest with custom pageSize still works`() {
+        val req = buildLocalSearchRequest(
+            "cats", "simple", "", "", emptyList(),
+            pageSize = 25,
+        )
+        assertEquals(25, req.pageSize)
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/CompileTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/CompileTest.kt
@@ -1,0 +1,216 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+import sh.kavi.fasttravel.localsearch.query.parse
+
+/**
+ * Mirrors companion/internal/index/compile_test.go for the Kotlin ports of
+ * ORBranches / PositiveSeed / RegexSeeds.
+ */
+class CompileTest {
+
+    // ── orBranches ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `orBranches SingleTerm`() {
+        val n = parse("hello", QueryMode.SIMPLE)
+        val branches = orBranches(n)
+        assertEquals(1, branches.size)
+        assertEquals("term", branches[0].op)
+    }
+
+    @Test
+    fun `orBranches ORTwoBranches`() {
+        val n = parse("hello | world", QueryMode.SIMPLE)
+        val branches = orBranches(n)
+        assertEquals(2, branches.size)
+    }
+
+    @Test
+    fun `orBranches ORThreeBranches`() {
+        val n = parse("a | b | c", QueryMode.SIMPLE)
+        val branches = orBranches(n)
+        assertEquals(3, branches.size)
+    }
+
+    @Test
+    fun `orBranches ANDIsNotOR`() {
+        // "hello world" parses to an AND node — not split into branches.
+        val n = parse("hello world", QueryMode.SIMPLE)
+        val branches = orBranches(n)
+        assertEquals(1, branches.size)
+        assertEquals("and", branches[0].op)
+    }
+
+    // ── positiveSeed ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `positiveSeed PlainTerm`() {
+        val n = parse("invoice", QueryMode.SIMPLE)
+        val (seed, ok) = positiveSeed(n)
+        assertTrue(ok)
+        assertEquals("invoice", seed)
+    }
+
+    @Test
+    fun `positiveSeed MultiTermPicksLongest`() {
+        // "ab cdef" → AND{term:ab, term:cdef}; longest fragment is "cdef" (4 > 2).
+        val n = parse("ab cdef", QueryMode.SIMPLE)
+        val (seed, ok) = positiveSeed(n)
+        assertTrue(ok)
+        assertEquals("cdef", seed)
+    }
+
+    @Test
+    fun `positiveSeed WildcardTermSplitsOnStar`() {
+        // "inv*.pdf" splits on '*' → ["inv", ".pdf"]; longest is ".pdf" (4 > 3).
+        val n = parse("inv*.pdf", QueryMode.WILDCARD)
+        val (seed, ok) = positiveSeed(n)
+        assertTrue(ok)
+        assertEquals(".pdf", seed)
+    }
+
+    @Test
+    fun `positiveSeed WildcardTermSplitsOnQuestion`() {
+        // "inv?oice" splits on '?' → ["inv", "oice"]; longest is "oice" (4 > 3).
+        val n = parse("inv?oice", QueryMode.WILDCARD)
+        val (seed, ok) = positiveSeed(n)
+        assertTrue(ok)
+        assertEquals("oice", seed)
+    }
+
+    @Test
+    fun `positiveSeed Phrase`() {
+        // Phrases have no wildcards; the whole value is the fragment.
+        val n = parse("\"hello world\"", QueryMode.SIMPLE)
+        val (seed, ok) = positiveSeed(n)
+        assertTrue(ok)
+        assertEquals("hello world", seed)
+    }
+
+    @Test
+    fun `positiveSeed NegatedTermIgnored`() {
+        // "-foo bar" → AND{not{term:foo}, term:bar}; "foo" is negated, "bar" is positive.
+        val n = parse("-foo bar", QueryMode.SIMPLE)
+        val (seed, ok) = positiveSeed(n)
+        assertTrue(ok)
+        assertEquals("bar", seed)
+    }
+
+    @Test
+    fun `positiveSeed PureNegation NoSeed`() {
+        // "-foo" → not{term:foo}; no positive terms → no seed.
+        val n = parse("-foo", QueryMode.SIMPLE)
+        val (_, ok) = positiveSeed(n)
+        assertFalse(ok, "expected ok=false for pure negation")
+    }
+
+    @Test
+    fun `positiveSeed RegexNodeSkipped`() {
+        // Regex-mode input → regex node; positiveSeed must not use the regex as a literal seed.
+        val n = parse("foo", QueryMode.REGEX)
+        val (_, ok) = positiveSeed(n)
+        assertFalse(ok, "expected ok=false for regex node")
+    }
+
+    // ── regexSeeds ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `regexSeeds PlainLiteral`() {
+        val (seeds, broad) = regexSeeds("report")
+        assertFalse(broad)
+        assertEquals(listOf("report"), seeds)
+    }
+
+    @Test
+    fun `regexSeeds BudgetPattern`() {
+        // ^budget_\d{4}\.xlsx$ — longest required run is "budget_" (breaks at \d)
+        val (seeds, broad) = regexSeeds("""^budget_\d{4}\.xlsx$""")
+        assertFalse(broad)
+        assertEquals(listOf("budget_"), seeds)
+    }
+
+    @Test
+    fun `regexSeeds Alternation`() {
+        // foo|bar — two seeds
+        val (seeds, broad) = regexSeeds("foo|bar")
+        assertFalse(broad)
+        assertEquals(2, seeds.size)
+        assertTrue(seeds.contains("foo"), "seeds must contain foo; got $seeds")
+        assertTrue(seeds.contains("bar"), "seeds must contain bar; got $seeds")
+    }
+
+    @Test
+    fun `regexSeeds SingleCharAlternation Broad`() {
+        // a|.* — "a" is len 1 (< 2), so broad=true
+        val (_, broad) = regexSeeds("""a|.*""")
+        assertTrue(broad, "expected broad=true (one alternative has no usable literal)")
+    }
+
+    @Test
+    fun `regexSeeds WildcardOnly Broad`() {
+        val (_, broad) = regexSeeds("""^.*$""")
+        assertTrue(broad, "expected broad=true for ^.*\$")
+    }
+
+    @Test
+    fun `regexSeeds QuantifiedGroupSeedsOutsideGroup`() {
+        // (foo)*bar — "foo" is inside an optional group, so the only required
+        // literal is "bar". Seeding on "foo" would drop matches like "bar".
+        val (seeds, broad) = regexSeeds("(foo)*bar")
+        assertFalse(broad, "expected broad=false; seeds=$seeds")
+        assertEquals(listOf("bar"), seeds)
+    }
+
+    @Test
+    fun `regexSeeds GroupLiteralsIgnored`() {
+        // (budget)_2024 — literals inside the group are not used as a required
+        // seed; the required top-level run is "_2024".
+        val (seeds, broad) = regexSeeds("(budget)_2024")
+        assertFalse(broad, "expected broad=false; seeds=$seeds")
+        assertEquals(listOf("_2024"), seeds)
+    }
+
+    @Test
+    fun `regexSeeds OnlyShortTopLevelLiterals Broad`() {
+        // a(bc)*d — the only top-level literals are "a" and "d" (each len 1).
+        val (_, broad) = regexSeeds("a(bc)*d")
+        assertTrue(broad, "expected broad=true for a(bc)*d")
+    }
+
+    @Test
+    fun `regexSeeds EscapedDotPattern`() {
+        // inv\.pdf — \. is a literal dot; longest run is "inv.pdf"
+        val (seeds, broad) = regexSeeds("""inv\.pdf""")
+        assertFalse(broad, "expected broad=false; seeds=$seeds")
+        assertEquals(1, seeds.size)
+        assertEquals("inv.pdf", seeds[0])
+    }
+
+    @Test
+    fun `regexSeeds CharClassPrefix`() {
+        // [ab]cdef — char class breaks run, "cdef" is the longest required run
+        val (seeds, broad) = regexSeeds("[ab]cdef")
+        assertFalse(broad)
+        assertEquals(listOf("cdef"), seeds)
+    }
+
+    @Test
+    fun `regexSeeds Deduplication`() {
+        // same seed from two branches → deduplicated
+        val (seeds, broad) = regexSeeds("foo|foo")
+        assertFalse(broad)
+        assertEquals(listOf("foo"), seeds)
+    }
+
+    @Test
+    fun `regexSeeds FlatOR ThreeBranches Broad`() {
+        // a | b | c — each branch is len 1 → broad=true
+        val (_, broad) = regexSeeds("a|b|c")
+        assertTrue(broad, "expected broad=true for single-char alternation branches")
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MatcherTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MatcherTest.kt
@@ -1,0 +1,87 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+import sh.kavi.fasttravel.localsearch.query.parse
+import java.util.stream.Stream
+
+/**
+ * Mirrors companion/internal/index/match_test.go – covers substring, wildcard-glob,
+ * phrase, regex, path:, AND, OR, NOT with the real parser.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MatcherTest {
+
+    data class TC(
+        val name: String,
+        val queryString: String,
+        val mode: QueryMode,
+        val result: FileResult,
+        val want: Boolean,
+    ) {
+        override fun toString(): String = name
+    }
+
+    private fun makeResult(name: String, path: String) = FileResult(
+        id = path,
+        name = name,
+        path = path,
+        dir = "/home/alice/docs",
+        ext = "pdf",
+        type = FileType.DOCUMENT,
+    )
+
+    private fun cases(): Stream<TC> = listOf(
+        TC("substring term hit", "report", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), true),
+        TC("substring term miss", "budget", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), false),
+        TC("prefix substring hit", "ann", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), true),
+        TC("wildcard glob hit", "inv*.pdf", QueryMode.WILDCARD,
+            makeResult("invoice_2024.pdf", "/home/bob/Invoices/invoice_2024.pdf"), true),
+        TC("wildcard glob near-miss", "inv*.pdf", QueryMode.WILDCARD,
+            makeResult("invoice_2024.txt", "/home/bob/Invoices/invoice_2024.txt"), false),
+        TC("phrase with space hit", "\"annual report\"", QueryMode.SIMPLE,
+            makeResult("annual report 2024.pdf", "/home/alice/docs/annual report 2024.pdf"), true),
+        TC("phrase with space miss", "\"annual report\"", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), false),
+        TC("regex on name hit", """^budget_\d{4}\.xlsx$""", QueryMode.REGEX,
+            makeResult("budget_2024.xlsx", "/home/bob/Finance/budget_2024.xlsx"), true),
+        TC("regex on name miss", """^budget_\d{4}\.xlsx$""", QueryMode.REGEX,
+            makeResult("budget_summary.xlsx", "/home/bob/Finance/budget_summary.xlsx"), false),
+        TC("path term matches path not name", "path:Finance", QueryMode.SIMPLE,
+            makeResult("report.pdf", "/home/bob/Finance/report.pdf"), true),
+        TC("path term does not match when not in path", "path:Finance", QueryMode.SIMPLE,
+            makeResult("report.pdf", "/home/alice/Documents/report.pdf"), false),
+        TC("AND both match", "annual report", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), true),
+        TC("AND one missing", "annual budget", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), false),
+        TC("OR first matches", "annual | budget", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), true),
+        TC("OR second matches", "invoice | report", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), true),
+        TC("OR neither matches", "invoice | budget", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), false),
+        TC("NOT excludes", "-budget", QueryMode.SIMPLE,
+            makeResult("budget_2024.xlsx", "/home/bob/Finance/budget_2024.xlsx"), false),
+        TC("NOT passes when term absent", "-budget", QueryMode.SIMPLE,
+            makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"), true),
+        TC("wildcard infix glob hit", "*report*", QueryMode.WILDCARD,
+            makeResult("annual_report.pdf", "/home/alice/docs/annual_report.pdf"), true),
+    ).stream()
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cases")
+    @DisplayName("matcher cases")
+    fun `matcher cases`(tc: TC) {
+        val node = parse(tc.queryString, tc.mode)
+        val got = matches(tc.result, node, tc.mode)
+        assertEquals(tc.want, got, "matches(\"${tc.queryString}\", name=\"${tc.result.name}\")")
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MatcherTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MatcherTest.kt
@@ -1,7 +1,10 @@
 package sh.kavi.fasttravel.localsearch.index
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -83,5 +86,63 @@ class MatcherTest {
         val node = parse(tc.queryString, tc.mode)
         val got = matches(tc.result, node, tc.mode)
         assertEquals(tc.want, got, "matches(\"${tc.queryString}\", name=\"${tc.result.name}\")")
+    }
+
+    // ── caseSensitive tests ────────────────────────────────────────────────────
+
+    @Test
+    fun `caseSensitive false (default) matches term case-insensitively`() {
+        val node = parse("REPORT", QueryMode.SIMPLE)
+        val result = makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf")
+        assertTrue(matches(result, node, QueryMode.SIMPLE, caseSensitive = false))
+    }
+
+    @Test
+    fun `caseSensitive true misses term when case differs`() {
+        val node = parse("REPORT", QueryMode.SIMPLE)
+        val result = makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf")
+        assertFalse(matches(result, node, QueryMode.SIMPLE, caseSensitive = true))
+    }
+
+    @Test
+    fun `caseSensitive true hits term when case matches`() {
+        val node = parse("report", QueryMode.SIMPLE)
+        val result = makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf")
+        assertTrue(matches(result, node, QueryMode.SIMPLE, caseSensitive = true))
+    }
+
+    @Test
+    fun `caseSensitive true misses phrase when case differs`() {
+        // Quoted phrase node
+        val node = parse("\"Annual Report\"", QueryMode.SIMPLE)
+        val result = makeResult("annual report 2024.pdf", "/home/alice/docs/annual report 2024.pdf")
+        // caseSensitive=true: field.contains("Annual Report") → false (file has lowercase)
+        assertFalse(matches(result, node, QueryMode.SIMPLE, caseSensitive = true))
+    }
+
+    @Test
+    fun `caseSensitive false hits phrase when case differs`() {
+        val node = parse("\"Annual Report\"", QueryMode.SIMPLE)
+        val result = makeResult("annual report 2024.pdf", "/home/alice/docs/annual report 2024.pdf")
+        assertTrue(matches(result, node, QueryMode.SIMPLE, caseSensitive = false))
+    }
+
+    @Test
+    fun `caseSensitive true with wildcard glob – case mismatch fails`() {
+        val node = parse("Rep*.pdf", QueryMode.WILDCARD)
+        val result = makeResult("report_2024.pdf", "/home/bob/report_2024.pdf")
+        // caseSensitive=false uses (?i) prefix → matches; caseSensitive=true does not
+        assertTrue(matches(result, node, QueryMode.WILDCARD, caseSensitive = false))
+        assertFalse(matches(result, node, QueryMode.WILDCARD, caseSensitive = true))
+    }
+
+    @Test
+    fun `caseSensitive does not affect regex nodes`() {
+        // regex "report" should not match "REPORT.pdf" regardless of caseSensitive
+        // (the pattern's own flags control case, caseSensitive is irrelevant)
+        val node = parse("report", QueryMode.REGEX)
+        val result = makeResult("REPORT.pdf", "/home/alice/REPORT.pdf")
+        assertFalse(matches(result, node, QueryMode.REGEX, caseSensitive = false))
+        assertFalse(matches(result, node, QueryMode.REGEX, caseSensitive = true))
     }
 }

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQueryTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQueryTest.kt
@@ -117,12 +117,46 @@ class MediaStoreQueryTest {
     }
 
     @Test
-    fun `buildSelection pureNegation returns null selection`() {
-        // "-foo" → NOT{term:foo} → positiveSeed=false → no branches → null
+    fun `buildSelection pureNegation returns match-nothing selection`() {
+        // "-foo" → NOT{term:foo} → positiveSeed=false for every branch → no seeds.
+        // Must return a match-nothing selection (not null/broad), matching the Go
+        // companion's 0-result behaviour for all-no-seed queries.
         val node = parse("-foo", QueryMode.SIMPLE)
         val sel = buildSelection(node, QueryMode.SIMPLE)
-        assertNull(sel.selection, "pure negation should produce null selection")
-        assertNull(sel.selectionArgs, "pure negation should produce null selectionArgs")
+        assertEquals("0", sel.selection, "all-no-seed simple query must produce match-nothing selection")
+        assertArrayEquals(emptyArray<String>(), sel.selectionArgs)
+    }
+
+    @Test
+    fun `buildSelection allNoSeed single negation dash-draft`() {
+        // "-draft" → single NOT branch, no positive literal → match-nothing (not broad)
+        val node = parse("-draft", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertEquals("0", sel.selection, "all-no-seed query must not fall back to broad scan")
+        assertArrayEquals(emptyArray<String>(), sel.selectionArgs)
+    }
+
+    @Test
+    fun `buildSelection allNoSeed multiple negations`() {
+        // "-a -b" → AND of two negations → no positive seed on any branch → match-nothing
+        val node = parse("-a -b", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertEquals("0", sel.selection, "multi-negation query must produce match-nothing selection")
+        assertArrayEquals(emptyArray<String>(), sel.selectionArgs)
+    }
+
+    @Test
+    fun `buildSelection mixedOR seededBranchKept`() {
+        // "invoice | -pdf" → OR{invoice, NOT{pdf}} → invoice branch seeded, -pdf branch skipped.
+        // Must produce a WHERE for the invoice branch only, not a broad or null scan.
+        val node = parse("invoice | -pdf", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertEquals(
+            "(_display_name LIKE ? OR _data LIKE ?)",
+            sel.selection,
+            "mixed OR with one seeded branch must produce seeded WHERE for that branch only",
+        )
+        assertArrayEquals(arrayOf("%invoice%", "%invoice%"), sel.selectionArgs)
     }
 
     // ── requiredPermissions ──────────────────────────────────────────────────────

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQueryTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/MediaStoreQueryTest.kt
@@ -1,0 +1,152 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+import sh.kavi.fasttravel.localsearch.query.parse
+
+/**
+ * Tests for [buildSelection] (pure, no android.* runtime calls) and
+ * [requiredPermissions] (pure).
+ *
+ * Column names in assertions are the literal string values of MediaStore.MediaColumns
+ * constants (e.g. "_display_name", "_data") — inlined at compile time.
+ */
+class MediaStoreQueryTest {
+
+    // ── buildSelection ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `buildSelection simpleTerm`() {
+        val node = parse("invoice", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertEquals(
+            "(_display_name LIKE ? OR _data LIKE ?)",
+            sel.selection,
+        )
+        assertArrayEquals(
+            arrayOf("%invoice%", "%invoice%"),
+            sel.selectionArgs,
+        )
+    }
+
+    @Test
+    fun `buildSelection multiTermAND picks longest seed`() {
+        // "invoice pdf" → AND{invoice(7), pdf(3)}; seed = "invoice"
+        val node = parse("invoice pdf", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertEquals(
+            "(_display_name LIKE ? OR _data LIKE ?)",
+            sel.selection,
+        )
+        assertArrayEquals(
+            arrayOf("%invoice%", "%invoice%"),
+            sel.selectionArgs,
+        )
+    }
+
+    @Test
+    fun `buildSelection OR two branches`() {
+        val node = parse("invoice | receipt", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertEquals(
+            "(_display_name LIKE ? OR _data LIKE ?) OR (_display_name LIKE ? OR _data LIKE ?)",
+            sel.selection,
+        )
+        assertArrayEquals(
+            arrayOf("%invoice%", "%invoice%", "%receipt%", "%receipt%"),
+            sel.selectionArgs,
+        )
+    }
+
+    @Test
+    fun `buildSelection wildcard splits on star`() {
+        // "inv*.pdf" → positiveSeed splits on '*' → [inv, .pdf] → longest=".pdf"
+        val node = parse("inv*.pdf", QueryMode.WILDCARD)
+        val sel = buildSelection(node, QueryMode.WILDCARD)
+        assertEquals(
+            "(_display_name LIKE ? OR _data LIKE ?)",
+            sel.selection,
+        )
+        assertArrayEquals(
+            arrayOf("%.pdf%", "%.pdf%"),
+            sel.selectionArgs,
+        )
+    }
+
+    @Test
+    fun `buildSelection pathScope uses same recall-safe selection`() {
+        // "path:Finance" — seed "Finance" is extracted from the path-scoped term.
+        // Both columns are OR'd; the pipeline's matcher enforces path-only precision.
+        val node = parse("path:Finance", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertEquals(
+            "(_display_name LIKE ? OR _data LIKE ?)",
+            sel.selection,
+        )
+        assertArrayEquals(
+            arrayOf("%Finance%", "%Finance%"),
+            sel.selectionArgs,
+        )
+    }
+
+    @Test
+    fun `buildSelection regex seedBased`() {
+        // regex mode: seeds from regexSeeds("foo|bar") = ["foo", "bar"] → DISPLAY_NAME only
+        val node = parse("foo|bar", QueryMode.REGEX)
+        val sel = buildSelection(node, QueryMode.REGEX)
+        assertEquals(
+            "_display_name LIKE ? OR _display_name LIKE ?",
+            sel.selection,
+        )
+        assertArrayEquals(
+            arrayOf("%foo%", "%bar%"),
+            sel.selectionArgs,
+        )
+    }
+
+    @Test
+    fun `buildSelection regex broad returns null selection`() {
+        // ^.*$ → regexSeeds → broad=true → no filter (null selection)
+        val node = parse("^.*\$", QueryMode.REGEX)
+        val sel = buildSelection(node, QueryMode.REGEX)
+        assertNull(sel.selection, "broad regex should produce null selection")
+        assertNull(sel.selectionArgs, "broad regex should produce null selectionArgs")
+    }
+
+    @Test
+    fun `buildSelection pureNegation returns null selection`() {
+        // "-foo" → NOT{term:foo} → positiveSeed=false → no branches → null
+        val node = parse("-foo", QueryMode.SIMPLE)
+        val sel = buildSelection(node, QueryMode.SIMPLE)
+        assertNull(sel.selection, "pure negation should produce null selection")
+        assertNull(sel.selectionArgs, "pure negation should produce null selectionArgs")
+    }
+
+    // ── requiredPermissions ──────────────────────────────────────────────────────
+
+    @Test
+    fun `requiredPermissions api33 returns scoped media perms`() {
+        val perms = requiredPermissions(33)
+        assertEquals(3, perms.size)
+        assertEquals("android.permission.READ_MEDIA_IMAGES", perms[0])
+        assertEquals("android.permission.READ_MEDIA_VIDEO", perms[1])
+        assertEquals("android.permission.READ_MEDIA_AUDIO", perms[2])
+    }
+
+    @Test
+    fun `requiredPermissions api30 returns legacy storage perm`() {
+        val perms = requiredPermissions(30)
+        assertEquals(1, perms.size)
+        assertEquals("android.permission.READ_EXTERNAL_STORAGE", perms[0])
+    }
+
+    @Test
+    fun `requiredPermissions api32 boundary returns legacy storage perm`() {
+        val perms = requiredPermissions(32)
+        assertEquals(1, perms.size)
+        assertEquals("android.permission.READ_EXTERNAL_STORAGE", perms[0])
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/PipelineTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/PipelineTest.kt
@@ -1,0 +1,271 @@
+package sh.kavi.fasttravel.localsearch.index
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import sh.kavi.fasttravel.localsearch.query.QueryMode
+import sh.kavi.fasttravel.localsearch.query.QueryParseException
+
+/**
+ * Mirrors companion/internal/index/pipeline_test.go.
+ * All tests use in-memory candidates (no device/MediaStore required).
+ */
+class PipelineTest {
+
+    // Fixed timestamps in ascending order (milliseconds since epoch).
+    private val ts0 = 1000000000000L // ~Sep 2001
+    private val ts1 = 1100000000000L // ~Sep 2004
+    private val ts2 = 1200000000000L // ~Jan 2008
+    private val ts3 = 1300000000000L // ~Mar 2011
+
+    /**
+     * testCorpus:
+     *   a  – "report" prefix in Name, document, /docs/, created ts0
+     *   b  – "report" substring in Name, document, /docs/, created ts1
+     *   c  – "report" only in Path (not Name), document, createdAt=0
+     *   d  – no "report" anywhere, video
+     *   e  – "report" prefix in Name, code, /code/
+     *   f1 – "report" substring in Name, other, ModifiedAt=ts1 (tiebreak pair)
+     *   f2 – "report" substring in Name, other, ModifiedAt=ts1 (tiebreak pair)
+     */
+    private val testCorpus = listOf(
+        FileResult(id = "a", name = "report_q1.pdf", path = "/docs/report_q1.pdf", dir = "/docs", ext = "pdf", type = FileType.DOCUMENT, modifiedAt = ts1, createdAt = ts0),
+        FileResult(id = "b", name = "annual_report.pdf", path = "/docs/annual_report.pdf", dir = "/docs", ext = "pdf", type = FileType.DOCUMENT, modifiedAt = ts2, createdAt = ts1),
+        FileResult(id = "c", name = "summary.txt", path = "/reports/summary.txt", dir = "/reports", ext = "txt", type = FileType.DOCUMENT, modifiedAt = ts3, createdAt = 0),
+        FileResult(id = "d", name = "vacation.mp4", path = "/videos/vacation.mp4", dir = "/videos", ext = "mp4", type = FileType.VIDEO, modifiedAt = ts0, createdAt = ts0),
+        FileResult(id = "e", name = "report_gen.py", path = "/code/report_gen.py", dir = "/code", ext = "py", type = FileType.CODE, modifiedAt = ts2, createdAt = ts2),
+        FileResult(id = "f1", name = "b_report.log", path = "/logs/b_report.log", dir = "/logs", ext = "log", type = FileType.OTHER, modifiedAt = ts1, createdAt = ts1),
+        FileResult(id = "f2", name = "a_report.log", path = "/logs/a_report.log", dir = "/logs", ext = "log", type = FileType.OTHER, modifiedAt = ts1, createdAt = ts1),
+    )
+
+    private fun newSearch(q: String) = SearchRequest(
+        query = q,
+        queryMode = QueryMode.SIMPLE,
+        sort = Sort(field = "relevance", dir = "desc"),
+        pageSize = 100,
+    )
+
+    private fun resultIds(results: List<FileResult>) = results.map { it.id }
+
+    @Test
+    fun `basic match – report matches 6 of 7`() {
+        val resp = search(testCorpus, newSearch("report"))
+        assertEquals(6, resp.total, "Total; results: ${resultIds(resp.results)}")
+        assertFalse(resp.results.any { it.id == "d" }, "result 'd' (vacation.mp4) should not match 'report'")
+    }
+
+    @Test
+    fun `type filter – document only returns a, b, c`() {
+        val req = newSearch("report").copy(filters = Filters(types = listOf(FileType.DOCUMENT)))
+        val resp = search(testCorpus, req)
+        val wantIds = setOf("a", "b", "c")
+        assertEquals(3, resp.total, "Total; results: ${resultIds(resp.results)}")
+        for (r in resp.results) {
+            assertTrue(r.id in wantIds, "unexpected result '${r.id}' (type=${r.type}) with Types filter=[document]")
+        }
+    }
+
+    @Test
+    fun `modified range filter – from ts2 excludes ts1 results`() {
+        val req = newSearch("report").copy(filters = Filters(modifiedRange = DateRange(from = ts2)))
+        val resp = search(testCorpus, req)
+        val wantIds = setOf("b", "c", "e")
+        assertEquals(3, resp.total, "Total; results: ${resultIds(resp.results)}")
+        for (r in resp.results) {
+            assertTrue(r.id in wantIds, "unexpected result '${r.id}' (modifiedAt=${r.modifiedAt}) with modifiedRange.from=$ts2")
+        }
+    }
+
+    @Test
+    fun `created range filter – excludes unknown createdAt==0`() {
+        val req = newSearch("report").copy(filters = Filters(createdRange = DateRange(from = ts0)))
+        val resp = search(testCorpus, req)
+        // c has createdAt=0 → excluded; a(ts0), b(ts1), e(ts2), f1(ts1), f2(ts1) pass.
+        assertEquals(5, resp.total, "Total (c excluded due to unknown createdAt); results: ${resultIds(resp.results)}")
+        assertFalse(resp.results.any { it.id == "c" }, "result 'c' (createdAt=0) should be excluded when a createdRange bound is set")
+    }
+
+    @Test
+    fun `path prefix filter – docs only returns a and b`() {
+        val req = newSearch("report").copy(filters = Filters(pathPrefix = "/docs/"))
+        val resp = search(testCorpus, req)
+        val wantIds = setOf("a", "b")
+        assertEquals(2, resp.total, "Total; results: ${resultIds(resp.results)}")
+        for (r in resp.results) {
+            assertTrue(r.id in wantIds, "unexpected result '${r.id}' (path=${r.path}) with pathPrefix=/docs/")
+        }
+    }
+
+    @Test
+    fun `titleOnly false includes path-only match c`() {
+        val req = newSearch("report").copy(filters = Filters(titleOnly = false))
+        val resp = search(testCorpus, req)
+        assertTrue(resp.results.any { it.id == "c" }, "TitleOnly=false: expected 'c' (path-only match) to be included")
+    }
+
+    @Test
+    fun `titleOnly true excludes path-only match c`() {
+        val req = newSearch("report").copy(filters = Filters(titleOnly = true))
+        val resp = search(testCorpus, req)
+        assertFalse(resp.results.any { it.id == "c" }, "TitleOnly=true: 'c' (path-only match) should be excluded")
+    }
+
+    @Test
+    fun `sort modified asc – monotone increasing`() {
+        val req = newSearch("report").copy(sort = Sort(field = "modified", dir = "asc"))
+        val resp = search(testCorpus, req)
+        var prev = 0L
+        for (r in resp.results) {
+            assertTrue(r.modifiedAt >= prev, "modified asc: out of order – '${r.id}' has modifiedAt=${r.modifiedAt} after prev=$prev")
+            prev = r.modifiedAt
+        }
+    }
+
+    @Test
+    fun `sort modified desc – monotone decreasing`() {
+        val req = newSearch("report").copy(sort = Sort(field = "modified", dir = "desc"))
+        val resp = search(testCorpus, req)
+        var prev = Long.MAX_VALUE
+        for (r in resp.results) {
+            assertTrue(r.modifiedAt <= prev, "modified desc: out of order – '${r.id}' has modifiedAt=${r.modifiedAt} after prev=$prev")
+            prev = r.modifiedAt
+        }
+    }
+
+    @Test
+    fun `relevance order – prefix above substring above path-only`() {
+        val resp = search(testCorpus, newSearch("report"))
+        val posOf = { id: String -> resp.results.indexOfFirst { it.id == id } }
+        val iA = posOf("a"); val iB = posOf("b"); val iC = posOf("c"); val iE = posOf("e")
+        assertTrue(iA >= 0 && iB >= 0 && iC >= 0 && iE >= 0, "missing results: a=$iA b=$iB c=$iC e=$iE; all: ${resultIds(resp.results)}")
+        assertTrue(iA < iB, "prefix match 'a' (pos $iA) should rank before substring 'b' (pos $iB)")
+        assertTrue(iE < iB, "prefix match 'e' (pos $iE) should rank before substring 'b' (pos $iB)")
+        assertTrue(iB < iC, "substring 'b' (pos $iB) should rank before path-only 'c' (pos $iC)")
+    }
+
+    @Test
+    fun `tiebreak – f2 (a_report) before f1 (b_report) by name asc`() {
+        val resp = search(testCorpus, newSearch("report"))
+        val iF1 = resp.results.indexOfFirst { it.id == "f1" }
+        val iF2 = resp.results.indexOfFirst { it.id == "f2" }
+        assertTrue(iF1 >= 0 && iF2 >= 0, "f1=$iF1 f2=$iF2: both should be present; results: ${resultIds(resp.results)}")
+        assertTrue(iF2 < iF1, "tiebreak: f2 (Name 'a_report.log', pos $iF2) should appear before f1 (Name 'b_report.log', pos $iF1)")
+    }
+
+    @Test
+    fun `history boost – history item ranks first despite lower recency`() {
+        val items = listOf(
+            FileResult(id = "h", name = "annual_report_h.txt", path = "/h/annual_report_h.txt", type = FileType.DOCUMENT, modifiedAt = ts1, createdAt = ts1),
+            FileResult(id = "i", name = "annual_report_i.txt", path = "/i/annual_report_i.txt", type = FileType.DOCUMENT, modifiedAt = ts2, createdAt = ts2),
+        )
+        val req = newSearch("report").copy(history = listOf("h"))
+        val resp = search(items, req)
+        assertEquals(2, resp.results.size, "want 2 results, got ${resp.results.size}")
+        assertEquals("h", resp.results[0].id, "history boost: 'h' should rank first; got '${resp.results[0].id}' first")
+    }
+
+    @Test
+    fun `pagination – page 0 of pageSize 2 returns 2 of 6`() {
+        val req = newSearch("report").copy(pageSize = 2, page = 0)
+        val resp = search(testCorpus, req)
+        assertEquals(6, resp.total, "page 0: Total")
+        assertEquals(2, resp.results.size, "page 0: result count")
+        assertEquals(0, resp.page, "page 0: page field")
+    }
+
+    @Test
+    fun `pagination – page 1 returns different results than page 0`() {
+        val req = newSearch("report").copy(pageSize = 2)
+        val resp0 = search(testCorpus, req.copy(page = 0))
+        val resp1 = search(testCorpus, req.copy(page = 1))
+        assertEquals(6, resp1.total, "page 1: Total")
+        assertEquals(2, resp1.results.size, "page 1: result count")
+        val ids0 = resultIds(resp0.results).toSet()
+        for (id in resultIds(resp1.results)) {
+            assertFalse(id in ids0, "page 0 and page 1 share result '$id'")
+        }
+    }
+
+    @Test
+    fun `pagination – out-of-range page returns empty results with correct total`() {
+        val req = newSearch("report").copy(pageSize = 2, page = 100)
+        val resp = search(testCorpus, req)
+        assertEquals(6, resp.total, "page 100: Total")
+        assertEquals(0, resp.results.size, "page 100: result count should be 0")
+    }
+
+    @Test
+    fun `non-nil empty results when nothing matches`() {
+        val resp = search(testCorpus, newSearch("zzz_no_match_ever_zzz"))
+        assertNotNull(resp.results, "Results must be a non-null empty list when nothing matches")
+        assertEquals(0, resp.results.size, "Results should be empty")
+        assertEquals(0, resp.total, "Total = 0")
+    }
+
+    @Test
+    fun `empty query throws`() {
+        val req = SearchRequest(query = "", pageSize = 10)
+        assertThrows(QueryParseException::class.java) { search(testCorpus, req) }
+    }
+
+    // --- financeCorpus for path-scope and regex-broadening tests ---
+
+    /**
+     * financeCorpus:
+     *   g1 – "Finance" in path dir only (name is neutral)
+     *   g2 – "Finance" in name only (path dir is neutral)
+     *   g3 – "Finance" in both name and path
+     *   g4 – "Finance" nowhere
+     */
+    private val financeCorpus = listOf(
+        FileResult(id = "g1", name = "quarterly.pdf", path = "/Finance/quarterly.pdf", dir = "/Finance", ext = "pdf", type = FileType.DOCUMENT, modifiedAt = ts1, createdAt = ts1),
+        FileResult(id = "g2", name = "Finance_plan.xlsx", path = "/accounting/budget.xlsx", dir = "/accounting", ext = "xlsx", type = FileType.DOCUMENT, modifiedAt = ts1, createdAt = ts1),
+        FileResult(id = "g3", name = "Finance_summary.pdf", path = "/Finance/Finance_summary.pdf", dir = "/Finance", ext = "pdf", type = FileType.DOCUMENT, modifiedAt = ts1, createdAt = ts1),
+        FileResult(id = "g4", name = "budget.csv", path = "/other/budget.csv", dir = "/other", ext = "csv", type = FileType.DOCUMENT, modifiedAt = ts1, createdAt = ts1),
+    )
+
+    @Test
+    fun `explicit path scope – TitleOnly=false only matches path`() {
+        val req = newSearch("path:Finance").copy(filters = Filters(titleOnly = false))
+        val resp = search(financeCorpus, req)
+        // g1 and g3 have Finance in their path → must match
+        // g2 has Finance only in its name, not path → must NOT match (path: leaf not broadened)
+        // g4 has Finance nowhere → must NOT match
+        assertTrue(resp.results.any { it.id == "g1" }, "TitleOnly=false: g1 (Finance in path dir) must match path:Finance")
+        assertTrue(resp.results.any { it.id == "g3" }, "TitleOnly=false: g3 (Finance in both) must match path:Finance")
+        assertFalse(resp.results.any { it.id == "g2" }, "TitleOnly=false: g2 (Finance only in name) must NOT match path:Finance — path: leaf must not be broadened")
+        assertFalse(resp.results.any { it.id == "g4" }, "TitleOnly=false: g4 (Finance nowhere) must NOT match")
+    }
+
+    @Test
+    fun `explicit path scope – TitleOnly=true coerces to name check`() {
+        val req = newSearch("path:Finance").copy(filters = Filters(titleOnly = true))
+        val resp = search(financeCorpus, req)
+        // coerceFieldsToName forces path: leaf to evaluate against name field
+        // g2 (Finance in name) and g3 (Finance in both) now match
+        // g1 (Finance only in path, not name) no longer does
+        assertFalse(resp.results.any { it.id == "g1" }, "TitleOnly=true: g1 (Finance only in path) must NOT match after coerce-to-name")
+        assertTrue(resp.results.any { it.id == "g2" }, "TitleOnly=true: g2 (Finance in name) must match — path: coerced to name-check")
+        assertTrue(resp.results.any { it.id == "g3" }, "TitleOnly=true: g3 (Finance in both) must match")
+        assertFalse(resp.results.any { it.id == "g4" }, "TitleOnly=true: g4 (Finance nowhere) must NOT match")
+    }
+
+    @Test
+    fun `regex broadening – name-only regex leaf is broadened to name-OR-path`() {
+        val req = SearchRequest(
+            query = "Finance",
+            queryMode = QueryMode.REGEX,
+            sort = Sort(field = "relevance", dir = "desc"),
+            pageSize = 100,
+            filters = Filters(titleOnly = false),
+        )
+        val resp = search(financeCorpus, req)
+        // g1 matches via path, g2 via name, g3 via both; g4 matches neither.
+        assertTrue(resp.results.any { it.id == "g1" }, "regex TitleOnly=false: g1 (Finance in path only) must match — regex leaves broadened to name-OR-path")
+        assertFalse(resp.results.any { it.id == "g4" }, "regex TitleOnly=false: g4 (Finance nowhere) must NOT match")
+        assertEquals(3, resp.total, "regex TitleOnly=false: want 3 results (g1, g2, g3), got ${resp.total}: ${resultIds(resp.results)}")
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/PipelineTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/index/PipelineTest.kt
@@ -253,6 +253,59 @@ class PipelineTest {
         assertFalse(resp.results.any { it.id == "g4" }, "TitleOnly=true: g4 (Finance nowhere) must NOT match")
     }
 
+    // ── exactPhrase tests ──────────────────────────────────────────────────────
+
+    /**
+     * exactPhrase=true: the 2-word query "annual report" becomes a single phrase node,
+     * so only files containing "annual report" as a contiguous substring match.
+     * Mirrors companion/internal/index/pipeline.go ExactPhrase handling.
+     */
+    @Test
+    fun `exactPhrase true – matches only contiguous phrase, not AND of terms`() {
+        val corpus = listOf(
+            FileResult(id = "j1", name = "annual-report.pdf", path = "/docs/annual-report.pdf", type = FileType.DOCUMENT),
+            FileResult(id = "j2", name = "annual report.pdf", path = "/docs/annual report.pdf", type = FileType.DOCUMENT),
+        )
+        val req = SearchRequest(query = "annual report", queryMode = QueryMode.SIMPLE, exactPhrase = true, pageSize = 100)
+        val resp = search(corpus, req)
+        assertTrue(resp.results.any { it.id == "j2" }, "exactPhrase: 'annual report.pdf' (with space) must match")
+        assertFalse(resp.results.any { it.id == "j1" }, "exactPhrase: 'annual-report.pdf' (dash) must NOT match phrase")
+    }
+
+    @Test
+    fun `exactPhrase false (default) AND-matches both results`() {
+        val corpus = listOf(
+            FileResult(id = "j1", name = "annual-report.pdf", path = "/docs/annual-report.pdf", type = FileType.DOCUMENT),
+            FileResult(id = "j2", name = "annual report.pdf", path = "/docs/annual report.pdf", type = FileType.DOCUMENT),
+        )
+        val req = SearchRequest(query = "annual report", queryMode = QueryMode.SIMPLE, exactPhrase = false, pageSize = 100)
+        val resp = search(corpus, req)
+        assertTrue(resp.results.any { it.id == "j1" }, "exactPhrase=false: AND-match hits 'annual-report.pdf'")
+        assertTrue(resp.results.any { it.id == "j2" }, "exactPhrase=false: AND-match hits 'annual report.pdf'")
+    }
+
+    @Test
+    fun `exactPhrase true is ignored in regex mode`() {
+        val corpus = listOf(
+            FileResult(id = "k1", name = "annual-report.pdf", path = "/docs/annual-report.pdf", type = FileType.DOCUMENT),
+        )
+        // regex mode: exactPhrase must be ignored; pattern "annual" matches name
+        val req = SearchRequest(query = "annual", queryMode = QueryMode.REGEX, exactPhrase = true, pageSize = 100)
+        val resp = search(corpus, req)
+        assertTrue(resp.results.any { it.id == "k1" }, "exactPhrase in regex mode is ignored; pattern 'annual' must match")
+    }
+
+    // ── Bug A: invalid regex → QueryParseException ─────────────────────────────
+
+    @Test
+    fun `invalid regex throws QueryParseException`() {
+        val corpus = listOf(
+            FileResult(id = "r1", name = "report.pdf", path = "/docs/report.pdf", type = FileType.DOCUMENT),
+        )
+        val req = SearchRequest(query = "[invalid", queryMode = QueryMode.REGEX, pageSize = 100)
+        assertThrows(QueryParseException::class.java) { search(corpus, req) }
+    }
+
     @Test
     fun `regex broadening – name-only regex leaf is broadened to name-OR-path`() {
         val req = SearchRequest(

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/query/ParserParityTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/query/ParserParityTest.kt
@@ -1,0 +1,76 @@
+package sh.kavi.fasttravel.localsearch.query
+
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+import java.util.stream.Stream
+
+/**
+ * Parity gate: drives all 15 cases in shared/companion-protocol/fixtures/query-parsing.json.
+ * Every case must produce the exact AST listed in the fixture.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ParserParityTest {
+
+    data class ParserCase(
+        val name: String,
+        val query: String,
+        val queryMode: QueryMode,
+        val expectedAst: Node,
+    ) {
+        override fun toString(): String = name
+    }
+
+    private fun resolveSharedFile(relativePath: String): File {
+        val candidates = listOf(
+            File("../shared/$relativePath"),
+            File("../../shared/$relativePath"),
+            File("shared/$relativePath"),
+        )
+        return candidates.firstOrNull { it.exists() }
+            ?: throw IllegalStateException(
+                "Cannot find shared/$relativePath. Tried: ${candidates.map { it.absolutePath }}"
+            )
+    }
+
+    private fun nodeFromJson(obj: JSONObject): Node {
+        val op = obj.getString("op")
+        val nodes = if (obj.has("nodes")) {
+            val arr = obj.getJSONArray("nodes")
+            (0 until arr.length()).map { nodeFromJson(arr.getJSONObject(it)) }
+        } else null
+        val node = if (obj.has("node")) nodeFromJson(obj.getJSONObject("node")) else null
+        val field = if (obj.has("field")) obj.getString("field") else null
+        val value = if (obj.has("value")) obj.getString("value") else null
+        val wildcard = if (obj.has("wildcard")) obj.getBoolean("wildcard") else null
+        return Node(op = op, nodes = nodes, node = node, field = field, value = value, wildcard = wildcard)
+    }
+
+    private fun loadCases(): Stream<ParserCase> {
+        val json = resolveSharedFile("companion-protocol/fixtures/query-parsing.json").readText()
+        val root = JSONObject(json)
+        val arr = root.getJSONArray("cases")
+        val cases = (0 until arr.length()).map { i ->
+            val obj = arr.getJSONObject(i)
+            ParserCase(
+                name = obj.getString("name"),
+                query = obj.getString("query"),
+                queryMode = QueryMode.fromString(obj.getString("queryMode")),
+                expectedAst = nodeFromJson(obj.getJSONObject("ast")),
+            )
+        }
+        return cases.stream()
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("loadCases")
+    @DisplayName("query-parsing.json parity – all 15 cases")
+    fun `parser parity`(case: ParserCase) {
+        val result = parse(case.query, case.queryMode)
+        assertEquals(case.expectedAst, result, "Case '${case.name}': parse(\"${case.query}\", ${case.queryMode}) AST mismatch")
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/settings/LocalSearchSettingsTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/localsearch/settings/LocalSearchSettingsTest.kt
@@ -1,0 +1,123 @@
+package sh.kavi.fasttravel.localsearch.settings
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import sh.kavi.fasttravel.core.Command
+import sh.kavi.fasttravel.core.CommandType
+import sh.kavi.fasttravel.core.FastTravelConfig
+import sh.kavi.fasttravel.core.Group
+import sh.kavi.fasttravel.core.Route
+import sh.kavi.fasttravel.core.RouteDevices
+
+/**
+ * Unit tests for the pure Local Search settings helpers.
+ * All tests run on the JVM — no android.* dependencies.
+ */
+class LocalSearchSettingsTest {
+
+    // ── canEnableLocalSearch ──────────────────────────────────────────────────
+
+    @Test
+    fun `canEnableLocalSearch returns true when permission granted and no s collision`() {
+        assertTrue(canEnableLocalSearch(hasPermission = true, configHasS = false))
+    }
+
+    @Test
+    fun `canEnableLocalSearch returns false when permission missing regardless of collision`() {
+        assertFalse(canEnableLocalSearch(hasPermission = false, configHasS = false))
+        assertFalse(canEnableLocalSearch(hasPermission = false, configHasS = true))
+    }
+
+    @Test
+    fun `canEnableLocalSearch returns false when s collision exists even if permission granted`() {
+        assertFalse(canEnableLocalSearch(hasPermission = true, configHasS = true))
+    }
+
+    // ── configHasSTrigger ─────────────────────────────────────────────────────
+
+    /** Builds a minimal FastTravelConfig with a single command using the given triggers. */
+    private fun configWithTriggers(vararg triggers: String): FastTravelConfig {
+        val cmd = Command(
+            id = "test-cmd",
+            triggers = triggers.toList(),
+            name = "Test",
+            type = CommandType.Standard,
+            routes = listOf(
+                Route(
+                    devices = RouteDevices.Wildcard,
+                    defaultUrl = "https://example.com/{query}",
+                )
+            ),
+        )
+        val group = Group(id = "test-group", name = "Test Group", commands = listOf(cmd))
+        return FastTravelConfig(
+            version = 1,
+            defaultCommand = "g",
+            groups = listOf(group),
+            ignoreList = emptyList(),
+        )
+    }
+
+    private fun emptyConfig() = FastTravelConfig(
+        version = 1,
+        defaultCommand = "g",
+        groups = emptyList(),
+        ignoreList = emptyList(),
+    )
+
+    @Test
+    fun `configHasSTrigger returns false for empty config`() {
+        assertFalse(configHasSTrigger(emptyConfig()))
+    }
+
+    @Test
+    fun `configHasSTrigger returns false when no command uses the s trigger`() {
+        assertFalse(configHasSTrigger(configWithTriggers("g", "gh", "wiki", "so")))
+    }
+
+    @Test
+    fun `configHasSTrigger returns true when a command uses lowercase s`() {
+        assertTrue(configHasSTrigger(configWithTriggers("s")))
+    }
+
+    @Test
+    fun `configHasSTrigger returns true when a command uses uppercase S (case-insensitive)`() {
+        // buildTriggerMap lowercases all triggers, so "S" must also match.
+        assertTrue(configHasSTrigger(configWithTriggers("S")))
+    }
+
+    @Test
+    fun `configHasSTrigger returns true when s is one of several triggers on a command`() {
+        assertTrue(configHasSTrigger(configWithTriggers("search", "s", "find")))
+    }
+
+    @Test
+    fun `configHasSTrigger does not match triggers that merely start with s`() {
+        assertFalse(configHasSTrigger(configWithTriggers("so", "sp", "search", "si")))
+    }
+
+    @Test
+    fun `configHasSTrigger detects s across multiple groups`() {
+        val cmd1 = Command(
+            id = "cmd-a", triggers = listOf("g"), name = "Google",
+            type = CommandType.Standard,
+            routes = listOf(Route(devices = RouteDevices.Wildcard, defaultUrl = "https://google.com")),
+        )
+        val cmd2 = Command(
+            id = "cmd-b", triggers = listOf("s"), name = "Stack Overflow",
+            type = CommandType.Standard,
+            routes = listOf(Route(devices = RouteDevices.Wildcard, defaultUrl = "https://stackoverflow.com")),
+        )
+        val config = FastTravelConfig(
+            version = 1,
+            defaultCommand = "g",
+            groups = listOf(
+                Group(id = "g1", name = "Group 1", commands = listOf(cmd1)),
+                Group(id = "g2", name = "Group 2", commands = listOf(cmd2)),
+            ),
+            ignoreList = emptyList(),
+        )
+        assertTrue(configHasSTrigger(config))
+    }
+}

--- a/companion/cmd/fast-travel-companion/main.go
+++ b/companion/cmd/fast-travel-companion/main.go
@@ -75,7 +75,9 @@ func main() {
 	// --- 7. XDG autostart (best-effort) ---
 	autostartDir := filepath.Join(userCfgDir, "autostart")
 	selfPath := selfExecPath()
-	if !autostart.IsInstalled(autostartDir) {
+	if selfPath == "" {
+		log.Printf("fast-travel-companion: warn: could not determine executable path; skipping autostart")
+	} else {
 		if err := autostart.Install(autostartDir, selfPath); err != nil {
 			log.Printf("fast-travel-companion: warn: could not install autostart entry: %v", err)
 		}

--- a/companion/cmd/fast-travel-companion/main.go
+++ b/companion/cmd/fast-travel-companion/main.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -62,23 +63,23 @@ func main() {
 	}
 
 	// --- 6. Build server ---
+	opener := server.NewOpener()
 	srv := server.New(server.Deps{
 		Registry: reg,
 		Pairing:  pm,
-		Opener:   &server.XDGOpener{},
+		Opener:   opener,
 		Name:     "fast-travel-companion",
 		Version:  version,
-		OS:       protocol.OSLinux,
+		OS:       protocolOS(runtime.GOOS),
 		Port:     port,
 	})
 
-	// --- 7. XDG autostart (best-effort) ---
-	autostartDir := filepath.Join(userCfgDir, "autostart")
+	// --- 7. OS autostart (best-effort) ---
 	selfPath := selfExecPath()
 	if selfPath == "" {
 		log.Printf("fast-travel-companion: warn: could not determine executable path; skipping autostart")
 	} else {
-		if err := autostart.Install(autostartDir, selfPath); err != nil {
+		if err := autostart.Install(selfPath); err != nil {
 			log.Printf("fast-travel-companion: warn: could not install autostart entry: %v", err)
 		}
 	}
@@ -86,7 +87,6 @@ func main() {
 	// --- 8. First-run: open pairing window + setup page ---
 	if !pm.Paired() {
 		pm.OpenPairingWindow(5 * time.Minute)
-		opener := &server.XDGOpener{}
 		setupURL := fmt.Sprintf("http://127.0.0.1:%d/setup", port)
 		if err := opener.Open(setupURL); err != nil {
 			log.Printf("fast-travel-companion: warn: could not open setup page (%v)", err)
@@ -114,6 +114,15 @@ func main() {
 		log.Fatalf("fast-travel-companion: serve error: %v", err)
 	}
 	log.Printf("fast-travel-companion: stopped")
+}
+
+// protocolOS maps runtime.GOOS to the protocol.OS value reported in /v1/ping.
+// darwin → "macos"; all others pass through ("linux", "windows", …).
+func protocolOS(goos string) protocol.OS {
+	if goos == "darwin" {
+		return protocol.OSMacOS
+	}
+	return protocol.OS(goos)
 }
 
 // selfExecPath returns the path to the running executable.

--- a/companion/cmd/fast-travel-companion/main.go
+++ b/companion/cmd/fast-travel-companion/main.go
@@ -1,0 +1,125 @@
+// Command fast-travel-companion is the companion daemon for the Fast Travel
+// browser extension. It exposes a loopback HTTP server that the extension
+// uses to search files on the local machine via native OS indexers (Baloo,
+// Tracker, plocate). The daemon must be running before the extension can
+// execute local-file searches.
+//
+// Version is injected at build time via ldflags:
+//
+//	go build -ldflags "-X main.version=1.2.3" ./cmd/fast-travel-companion
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/autostart"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/config"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/pairing"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/server"
+)
+
+// version is set via -ldflags at build time; falls back to "dev".
+var version = "dev"
+
+func main() {
+	// --- 1. Config dir ---
+	userCfgDir, err := os.UserConfigDir()
+	if err != nil {
+		log.Fatalf("fast-travel-companion: cannot determine user config dir: %v", err)
+	}
+	configDir := filepath.Join(userCfgDir, "fast-travel-companion")
+
+	// --- 2. Load config ---
+	cfg, cfgErr := config.Load(configDir)
+	if cfgErr != nil {
+		log.Printf("fast-travel-companion: warn: could not load config (%v); using defaults", cfgErr)
+	}
+	cfg = cfg.WithDefaults()
+
+	// --- 3. Detect indexers ---
+	reg := index.Detect(index.ExecRunner{}, cfg.PreferredIndexer)
+
+	// --- 4. Pairing manager ---
+	pm, err := pairing.New(configDir, cfg.AllowedOrigins)
+	if err != nil {
+		log.Fatalf("fast-travel-companion: pairing.New: %v", err)
+	}
+
+	// --- 5. Bind loopback port ---
+	ln, port, err := server.ListenLoopback(cfg.Port)
+	if err != nil {
+		log.Fatalf("fast-travel-companion: %v", err)
+	}
+
+	// --- 6. Build server ---
+	srv := server.New(server.Deps{
+		Registry: reg,
+		Pairing:  pm,
+		Opener:   &server.XDGOpener{},
+		Name:     "fast-travel-companion",
+		Version:  version,
+		OS:       protocol.OSLinux,
+		Port:     port,
+	})
+
+	// --- 7. XDG autostart (best-effort) ---
+	autostartDir := filepath.Join(userCfgDir, "autostart")
+	selfPath := selfExecPath()
+	if !autostart.IsInstalled(autostartDir) {
+		if err := autostart.Install(autostartDir, selfPath); err != nil {
+			log.Printf("fast-travel-companion: warn: could not install autostart entry: %v", err)
+		}
+	}
+
+	// --- 8. First-run: open pairing window + setup page ---
+	if !pm.Paired() {
+		pm.OpenPairingWindow(5 * time.Minute)
+		opener := &server.XDGOpener{}
+		setupURL := fmt.Sprintf("http://127.0.0.1:%d/setup", port)
+		if err := opener.Open(setupURL); err != nil {
+			log.Printf("fast-travel-companion: warn: could not open setup page (%v)", err)
+		}
+	}
+
+	// --- 9. Serve with graceful shutdown ---
+	httpSrv := &http.Server{Handler: srv.Handler()}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigCh
+		log.Printf("fast-travel-companion: received %v — shutting down", sig)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpSrv.Shutdown(ctx); err != nil {
+			log.Printf("fast-travel-companion: shutdown error: %v", err)
+		}
+	}()
+
+	log.Printf("fast-travel-companion v%s listening on http://127.0.0.1:%d", version, port)
+	if err := httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("fast-travel-companion: serve error: %v", err)
+	}
+	log.Printf("fast-travel-companion: stopped")
+}
+
+// selfExecPath returns the path to the running executable.
+// On failure it returns an empty string (autostart will be skipped gracefully).
+func selfExecPath() string {
+	path, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return path
+}

--- a/companion/go.mod
+++ b/companion/go.mod
@@ -1,0 +1,3 @@
+module github.com/DoubleGremlin181/fast-travel-app/companion
+
+go 1.23

--- a/companion/internal/autostart/autostart.go
+++ b/companion/internal/autostart/autostart.go
@@ -1,0 +1,49 @@
+// Package autostart installs and removes an XDG autostart entry so the
+// companion daemon starts automatically when the user logs in.
+//
+// The XDG autostart spec places .desktop files in ~/.config/autostart/.
+// Callers should pass filepath.Join(os.UserConfigDir(), "autostart") as
+// autostartDir in production; tests use t.TempDir() for isolation.
+package autostart
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const desktopFilename = "fast-travel-companion.desktop"
+
+// desktopContent returns the .desktop file contents for the given execPath.
+func desktopContent(execPath string) string {
+	return fmt.Sprintf("[Desktop Entry]\nType=Application\nName=Fast Travel Companion\nExec=%s\nX-GNOME-Autostart-enabled=true\nNoDisplay=true\nTerminal=false\n", execPath)
+}
+
+// Install writes the XDG autostart .desktop file into autostartDir.
+// It creates the directory (mode 0700) if absent and writes the file with
+// mode 0644. Calling Install a second time overwrites the file (idempotent).
+func Install(autostartDir, execPath string) error {
+	if err := os.MkdirAll(autostartDir, 0700); err != nil {
+		return err
+	}
+	path := filepath.Join(autostartDir, desktopFilename)
+	return os.WriteFile(path, []byte(desktopContent(execPath)), 0644)
+}
+
+// Uninstall removes the .desktop file from autostartDir.
+// It is a no-op (returns nil) if the file does not exist.
+func Uninstall(autostartDir string) error {
+	path := filepath.Join(autostartDir, desktopFilename)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// IsInstalled reports whether the .desktop file exists in autostartDir.
+func IsInstalled(autostartDir string) bool {
+	path := filepath.Join(autostartDir, desktopFilename)
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/companion/internal/autostart/autostart.go
+++ b/companion/internal/autostart/autostart.go
@@ -1,29 +1,49 @@
-// Package autostart installs and removes an XDG autostart entry so the
+// Package autostart installs and removes a per-OS autostart entry so the
 // companion daemon starts automatically when the user logs in.
 //
-// The XDG autostart spec places .desktop files in ~/.config/autostart/.
-// Callers should pass filepath.Join(os.UserConfigDir(), "autostart") as
-// autostartDir in production; tests use t.TempDir() for isolation.
+// Linux:   XDG autostart (~/.config/autostart/fast-travel-companion.desktop)
+// Windows: HKCU Run registry key (FastTravelCompanion) via reg.exe
+// macOS:   LaunchAgent plist (~/.Library/LaunchAgents/sh.kavi.fasttravel.companion.plist)
+// Other:   no-op
+//
+// All per-OS command/content builders are pure functions testable on any
+// platform. Only the Install/Uninstall/IsInstalled side-effects are
+// dispatched on runtime.GOOS.
 package autostart
 
 import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
-const desktopFilename = "fast-travel-companion.desktop"
+// ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+
+const (
+	desktopFilename     = "fast-travel-companion.desktop"
+	launchAgentFilename = "sh.kavi.fasttravel.companion.plist"
+	regKeyPath          = `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`
+	regValueName        = "FastTravelCompanion"
+)
+
+// ---------------------------------------------------------------------------
+// Linux: XDG autostart (.desktop)
+// ---------------------------------------------------------------------------
 
 // desktopContent returns the .desktop file contents for the given execPath.
 func desktopContent(execPath string) string {
 	return fmt.Sprintf("[Desktop Entry]\nType=Application\nName=Fast Travel Companion\nExec=%s\nX-GNOME-Autostart-enabled=true\nNoDisplay=true\nTerminal=false\n", execPath)
 }
 
-// Install writes the XDG autostart .desktop file into autostartDir.
+// installLinux writes the XDG autostart .desktop file into autostartDir.
 // It creates the directory (mode 0700) if absent and writes the file with
-// mode 0644. Calling Install a second time overwrites the file (idempotent).
-func Install(autostartDir, execPath string) error {
+// mode 0644. Calling installLinux a second time overwrites the file (idempotent).
+func installLinux(autostartDir, execPath string) error {
 	if err := os.MkdirAll(autostartDir, 0700); err != nil {
 		return err
 	}
@@ -31,9 +51,9 @@ func Install(autostartDir, execPath string) error {
 	return os.WriteFile(path, []byte(desktopContent(execPath)), 0644)
 }
 
-// Uninstall removes the .desktop file from autostartDir.
+// uninstallLinux removes the .desktop file from autostartDir.
 // It is a no-op (returns nil) if the file does not exist.
-func Uninstall(autostartDir string) error {
+func uninstallLinux(autostartDir string) error {
 	path := filepath.Join(autostartDir, desktopFilename)
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -41,9 +61,153 @@ func Uninstall(autostartDir string) error {
 	return nil
 }
 
-// IsInstalled reports whether the .desktop file exists in autostartDir.
-func IsInstalled(autostartDir string) bool {
+// isInstalledLinux reports whether the .desktop file exists in autostartDir.
+func isInstalledLinux(autostartDir string) bool {
 	path := filepath.Join(autostartDir, desktopFilename)
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// linuxAutostartDir returns the XDG autostart directory (~/.config/autostart).
+func linuxAutostartDir() (string, error) {
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cfgDir, "autostart"), nil
+}
+
+// ---------------------------------------------------------------------------
+// Windows: HKCU Run registry key (via reg.exe)
+// ---------------------------------------------------------------------------
+
+// buildRegAddArgs returns the argv slice (after "reg") to install the Run key.
+func buildRegAddArgs(execPath string) []string {
+	return []string{"add", regKeyPath, "/v", regValueName, "/t", "REG_SZ", "/d", execPath, "/f"}
+}
+
+// buildRegQueryArgs returns the argv slice (after "reg") to check the Run key.
+func buildRegQueryArgs() []string {
+	return []string{"query", regKeyPath, "/v", regValueName}
+}
+
+// buildRegDeleteArgs returns the argv slice (after "reg") to remove the Run key.
+func buildRegDeleteArgs() []string {
+	return []string{"delete", regKeyPath, "/v", regValueName, "/f"}
+}
+
+// ---------------------------------------------------------------------------
+// macOS: LaunchAgent plist
+// ---------------------------------------------------------------------------
+
+// buildLaunchAgentPlist returns the plist XML content for a RunAtLoad LaunchAgent.
+func buildLaunchAgentPlist(execPath string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>sh.kavi.fasttravel.companion</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>%s</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>
+`, execPath)
+}
+
+// darwinLaunchAgentDir returns ~/Library/LaunchAgents.
+func darwinLaunchAgentDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents"), nil
+}
+
+// ---------------------------------------------------------------------------
+// Public API — dispatches on runtime.GOOS
+// ---------------------------------------------------------------------------
+
+// Install installs the autostart entry for the current OS using execPath as
+// the command to launch on login. It is idempotent. Unknown OSes return nil.
+func Install(execPath string) error {
+	switch runtime.GOOS {
+	case "linux":
+		dir, err := linuxAutostartDir()
+		if err != nil {
+			return err
+		}
+		return installLinux(dir, execPath)
+	case "windows":
+		return exec.Command("reg", buildRegAddArgs(execPath)...).Run()
+	case "darwin":
+		dir, err := darwinLaunchAgentDir()
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return err
+		}
+		path := filepath.Join(dir, launchAgentFilename)
+		return os.WriteFile(path, []byte(buildLaunchAgentPlist(execPath)), 0644)
+	default:
+		return nil
+	}
+}
+
+// Uninstall removes the autostart entry for the current OS. It is a no-op
+// (returns nil) if the entry does not exist. Unknown OSes return nil.
+func Uninstall() error {
+	switch runtime.GOOS {
+	case "linux":
+		dir, err := linuxAutostartDir()
+		if err != nil {
+			return err
+		}
+		return uninstallLinux(dir)
+	case "windows":
+		// reg delete exits non-zero if the value doesn't exist; treat as no-op.
+		exec.Command("reg", buildRegDeleteArgs()...).Run() //nolint:errcheck
+		return nil
+	case "darwin":
+		dir, err := darwinLaunchAgentDir()
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(dir, launchAgentFilename)
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// IsInstalled reports whether the autostart entry is present for the current OS.
+// Unknown OSes return false.
+func IsInstalled() bool {
+	switch runtime.GOOS {
+	case "linux":
+		dir, err := linuxAutostartDir()
+		if err != nil {
+			return false
+		}
+		return isInstalledLinux(dir)
+	case "windows":
+		return exec.Command("reg", buildRegQueryArgs()...).Run() == nil
+	case "darwin":
+		dir, err := darwinLaunchAgentDir()
+		if err != nil {
+			return false
+		}
+		_, err = os.Stat(filepath.Join(dir, launchAgentFilename))
+		return err == nil
+	default:
+		return false
+	}
 }

--- a/companion/internal/autostart/autostart_test.go
+++ b/companion/internal/autostart/autostart_test.go
@@ -67,6 +67,24 @@ func TestInstall_FilePermissions(t *testing.T) {
 	}
 }
 
+// TestInstall_DirPermissions verifies that Install creates autostartDir with
+// mode 0700 when it does not already exist.
+func TestInstall_DirPermissions(t *testing.T) {
+	// Use a non-existent subdir so MkdirAll inside Install must create it.
+	dir := filepath.Join(t.TempDir(), "new-autostart-subdir")
+	if err := autostart.Install(dir, "/usr/local/bin/fast-travel-companion"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat dir: %v", err)
+	}
+	got := info.Mode().Perm()
+	if got != 0700 {
+		t.Errorf("dir permissions: got %o, want 0700", got)
+	}
+}
+
 // TestInstall_Idempotent verifies that calling Install twice does not error
 // and the file still reflects the latest exec path.
 func TestInstall_Idempotent(t *testing.T) {

--- a/companion/internal/autostart/autostart_test.go
+++ b/companion/internal/autostart/autostart_test.go
@@ -1,24 +1,28 @@
-package autostart_test
+// Tests are in package autostart (not autostart_test) so they can exercise
+// the unexported installLinux / uninstallLinux / isInstalledLinux helpers
+// and the pure builders (buildRegAddArgs, buildLaunchAgentPlist, etc.) that
+// are testable on any platform without spawning real processes.
+package autostart
 
 import (
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/autostart"
 )
 
-const desktopFilename = "fast-travel-companion.desktop"
+// ---------------------------------------------------------------------------
+// Linux installLinux / isInstalledLinux / uninstallLinux (via t.TempDir)
+// ---------------------------------------------------------------------------
 
-// TestInstall_WritesFile verifies Install creates the .desktop file containing
-// the exec path.
-func TestInstall_WritesFile(t *testing.T) {
+// TestInstallLinux_WritesFile verifies installLinux creates the .desktop file
+// containing the exec path and all required fields.
+func TestInstallLinux_WritesFile(t *testing.T) {
 	dir := t.TempDir()
 	execPath := "/usr/local/bin/fast-travel-companion"
 
-	if err := autostart.Install(dir, execPath); err != nil {
-		t.Fatalf("Install: %v", err)
+	if err := installLinux(dir, execPath); err != nil {
+		t.Fatalf("installLinux: %v", err)
 	}
 
 	path := filepath.Join(dir, desktopFilename)
@@ -51,11 +55,11 @@ func TestInstall_WritesFile(t *testing.T) {
 	}
 }
 
-// TestInstall_FilePermissions checks that the .desktop file is 0644.
-func TestInstall_FilePermissions(t *testing.T) {
+// TestInstallLinux_FilePermissions checks that the .desktop file is 0644.
+func TestInstallLinux_FilePermissions(t *testing.T) {
 	dir := t.TempDir()
-	if err := autostart.Install(dir, "/bin/ftc"); err != nil {
-		t.Fatalf("Install: %v", err)
+	if err := installLinux(dir, "/bin/ftc"); err != nil {
+		t.Fatalf("installLinux: %v", err)
 	}
 	info, err := os.Stat(filepath.Join(dir, desktopFilename))
 	if err != nil {
@@ -67,13 +71,12 @@ func TestInstall_FilePermissions(t *testing.T) {
 	}
 }
 
-// TestInstall_DirPermissions verifies that Install creates autostartDir with
-// mode 0700 when it does not already exist.
-func TestInstall_DirPermissions(t *testing.T) {
-	// Use a non-existent subdir so MkdirAll inside Install must create it.
+// TestInstallLinux_DirPermissions verifies that installLinux creates
+// autostartDir with mode 0700 when it does not already exist.
+func TestInstallLinux_DirPermissions(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "new-autostart-subdir")
-	if err := autostart.Install(dir, "/usr/local/bin/fast-travel-companion"); err != nil {
-		t.Fatalf("Install: %v", err)
+	if err := installLinux(dir, "/usr/local/bin/fast-travel-companion"); err != nil {
+		t.Fatalf("installLinux: %v", err)
 	}
 	info, err := os.Stat(dir)
 	if err != nil {
@@ -85,18 +88,18 @@ func TestInstall_DirPermissions(t *testing.T) {
 	}
 }
 
-// TestInstall_Idempotent verifies that calling Install twice does not error
-// and the file still reflects the latest exec path.
-func TestInstall_Idempotent(t *testing.T) {
+// TestInstallLinux_Idempotent verifies that calling installLinux twice does not
+// error and the file reflects the latest exec path.
+func TestInstallLinux_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 	first := "/usr/bin/ftc-old"
 	second := "/usr/bin/ftc-new"
 
-	if err := autostart.Install(dir, first); err != nil {
-		t.Fatalf("first Install: %v", err)
+	if err := installLinux(dir, first); err != nil {
+		t.Fatalf("first installLinux: %v", err)
 	}
-	if err := autostart.Install(dir, second); err != nil {
-		t.Fatalf("second Install: %v", err)
+	if err := installLinux(dir, second); err != nil {
+		t.Fatalf("second installLinux: %v", err)
 	}
 
 	data, err := os.ReadFile(filepath.Join(dir, desktopFilename))
@@ -104,43 +107,155 @@ func TestInstall_Idempotent(t *testing.T) {
 		t.Fatalf("ReadFile: %v", err)
 	}
 	if !strings.Contains(string(data), "Exec="+second) {
-		t.Errorf("expected Exec=%q after second Install; got:\n%s", second, data)
+		t.Errorf("expected Exec=%q after second installLinux; got:\n%s", second, data)
 	}
 }
 
-// TestIsInstalled_TrueAfterInstall verifies IsInstalled returns true after Install.
-func TestIsInstalled_TrueAfterInstall(t *testing.T) {
+// TestIsInstalledLinux_TrueAfterInstall verifies isInstalledLinux returns true
+// after installLinux and false before.
+func TestIsInstalledLinux_TrueAfterInstall(t *testing.T) {
 	dir := t.TempDir()
-	if autostart.IsInstalled(dir) {
-		t.Fatal("IsInstalled: expected false before Install")
+	if isInstalledLinux(dir) {
+		t.Fatal("isInstalledLinux: expected false before installLinux")
 	}
-	if err := autostart.Install(dir, "/bin/ftc"); err != nil {
-		t.Fatalf("Install: %v", err)
+	if err := installLinux(dir, "/bin/ftc"); err != nil {
+		t.Fatalf("installLinux: %v", err)
 	}
-	if !autostart.IsInstalled(dir) {
-		t.Error("IsInstalled: expected true after Install")
+	if !isInstalledLinux(dir) {
+		t.Error("isInstalledLinux: expected true after installLinux")
 	}
 }
 
-// TestUninstall_RemovesFile verifies Uninstall removes the .desktop file.
-func TestUninstall_RemovesFile(t *testing.T) {
+// TestUninstallLinux_RemovesFile verifies uninstallLinux removes the .desktop file.
+func TestUninstallLinux_RemovesFile(t *testing.T) {
 	dir := t.TempDir()
-	if err := autostart.Install(dir, "/bin/ftc"); err != nil {
-		t.Fatalf("Install: %v", err)
+	if err := installLinux(dir, "/bin/ftc"); err != nil {
+		t.Fatalf("installLinux: %v", err)
 	}
-	if err := autostart.Uninstall(dir); err != nil {
-		t.Fatalf("Uninstall: %v", err)
+	if err := uninstallLinux(dir); err != nil {
+		t.Fatalf("uninstallLinux: %v", err)
 	}
-	if autostart.IsInstalled(dir) {
-		t.Error("IsInstalled: expected false after Uninstall")
+	if isInstalledLinux(dir) {
+		t.Error("isInstalledLinux: expected false after uninstallLinux")
 	}
 }
 
-// TestUninstall_NotInstalled verifies Uninstall is a no-op (no error) when
-// the file does not exist.
-func TestUninstall_NotInstalled(t *testing.T) {
+// TestUninstallLinux_NotInstalled verifies uninstallLinux is a no-op (no error)
+// when the file does not exist.
+func TestUninstallLinux_NotInstalled(t *testing.T) {
 	dir := t.TempDir()
-	if err := autostart.Uninstall(dir); err != nil {
-		t.Fatalf("Uninstall on missing file: unexpected error: %v", err)
+	if err := uninstallLinux(dir); err != nil {
+		t.Fatalf("uninstallLinux on missing file: unexpected error: %v", err)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Windows registry pure builders
+// ---------------------------------------------------------------------------
+
+func TestBuildRegAddArgs(t *testing.T) {
+	execPath := `C:\Program Files\FastTravel\fast-travel-companion.exe`
+	args := buildRegAddArgs(execPath)
+
+	// Must start with "add" and reference the Run key.
+	if len(args) == 0 || args[0] != "add" {
+		t.Errorf("first arg: got %v, want \"add\"", args)
+	}
+	if !containsStr(args, regKeyPath) {
+		t.Errorf("args missing Run key path %q; got %v", regKeyPath, args)
+	}
+	if !containsStr(args, regValueName) {
+		t.Errorf("args missing value name %q; got %v", regValueName, args)
+	}
+	if !containsStr(args, "REG_SZ") {
+		t.Errorf("args missing REG_SZ; got %v", args)
+	}
+	if !containsStr(args, execPath) {
+		t.Errorf("args missing execPath %q; got %v", execPath, args)
+	}
+	if !containsStr(args, "/f") {
+		t.Errorf("args missing /f (force flag); got %v", args)
+	}
+}
+
+func TestBuildRegQueryArgs(t *testing.T) {
+	args := buildRegQueryArgs()
+
+	if len(args) == 0 || args[0] != "query" {
+		t.Errorf("first arg: got %v, want \"query\"", args)
+	}
+	if !containsStr(args, regKeyPath) {
+		t.Errorf("args missing Run key path %q; got %v", regKeyPath, args)
+	}
+	if !containsStr(args, regValueName) {
+		t.Errorf("args missing value name %q; got %v", regValueName, args)
+	}
+}
+
+func TestBuildRegDeleteArgs(t *testing.T) {
+	args := buildRegDeleteArgs()
+
+	if len(args) == 0 || args[0] != "delete" {
+		t.Errorf("first arg: got %v, want \"delete\"", args)
+	}
+	if !containsStr(args, regKeyPath) {
+		t.Errorf("args missing Run key path %q; got %v", regKeyPath, args)
+	}
+	if !containsStr(args, regValueName) {
+		t.Errorf("args missing value name %q; got %v", regValueName, args)
+	}
+	if !containsStr(args, "/f") {
+		t.Errorf("args missing /f (force flag); got %v", args)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// macOS LaunchAgent plist pure builder
+// ---------------------------------------------------------------------------
+
+func TestBuildLaunchAgentPlist(t *testing.T) {
+	execPath := "/usr/local/bin/fast-travel-companion"
+	plist := buildLaunchAgentPlist(execPath)
+
+	if !strings.Contains(plist, "RunAtLoad") {
+		t.Error("plist missing RunAtLoad key")
+	}
+	if !strings.Contains(plist, "<true/>") {
+		t.Error("plist missing <true/> for RunAtLoad")
+	}
+	if !strings.Contains(plist, execPath) {
+		t.Errorf("plist missing execPath %q", execPath)
+	}
+	if !strings.Contains(plist, "ProgramArguments") {
+		t.Error("plist missing ProgramArguments key")
+	}
+	if !strings.Contains(plist, "sh.kavi.fasttravel.companion") {
+		t.Error("plist missing Label / bundle ID")
+	}
+	if !strings.Contains(plist, "<?xml") {
+		t.Error("plist missing XML declaration")
+	}
+}
+
+// TestBuildLaunchAgentPlist_EmbedExecPath verifies the exec path is correctly
+// embedded even when it contains path separators.
+func TestBuildLaunchAgentPlist_EmbedExecPath(t *testing.T) {
+	execPath := "/opt/homebrew/bin/fast-travel-companion"
+	plist := buildLaunchAgentPlist(execPath)
+	if !strings.Contains(plist, "<string>"+execPath+"</string>") {
+		t.Errorf("plist does not embed execPath as <string> element; plist:\n%s", plist)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/companion/internal/autostart/autostart_test.go
+++ b/companion/internal/autostart/autostart_test.go
@@ -1,0 +1,128 @@
+package autostart_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/autostart"
+)
+
+const desktopFilename = "fast-travel-companion.desktop"
+
+// TestInstall_WritesFile verifies Install creates the .desktop file containing
+// the exec path.
+func TestInstall_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	execPath := "/usr/local/bin/fast-travel-companion"
+
+	if err := autostart.Install(dir, execPath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	path := filepath.Join(dir, desktopFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "[Desktop Entry]") {
+		t.Error("missing [Desktop Entry] header")
+	}
+	if !strings.Contains(content, "Exec="+execPath) {
+		t.Errorf("missing Exec line with %q", execPath)
+	}
+	if !strings.Contains(content, "Type=Application") {
+		t.Error("missing Type=Application")
+	}
+	if !strings.Contains(content, "Name=Fast Travel Companion") {
+		t.Error("missing Name=Fast Travel Companion")
+	}
+	if !strings.Contains(content, "NoDisplay=true") {
+		t.Error("missing NoDisplay=true")
+	}
+	if !strings.Contains(content, "Terminal=false") {
+		t.Error("missing Terminal=false")
+	}
+	if !strings.Contains(content, "X-GNOME-Autostart-enabled=true") {
+		t.Error("missing X-GNOME-Autostart-enabled=true")
+	}
+}
+
+// TestInstall_FilePermissions checks that the .desktop file is 0644.
+func TestInstall_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if err := autostart.Install(dir, "/bin/ftc"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, desktopFilename))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	got := info.Mode().Perm()
+	if got != 0644 {
+		t.Errorf("file permissions: got %o, want 0644", got)
+	}
+}
+
+// TestInstall_Idempotent verifies that calling Install twice does not error
+// and the file still reflects the latest exec path.
+func TestInstall_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	first := "/usr/bin/ftc-old"
+	second := "/usr/bin/ftc-new"
+
+	if err := autostart.Install(dir, first); err != nil {
+		t.Fatalf("first Install: %v", err)
+	}
+	if err := autostart.Install(dir, second); err != nil {
+		t.Fatalf("second Install: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, desktopFilename))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "Exec="+second) {
+		t.Errorf("expected Exec=%q after second Install; got:\n%s", second, data)
+	}
+}
+
+// TestIsInstalled_TrueAfterInstall verifies IsInstalled returns true after Install.
+func TestIsInstalled_TrueAfterInstall(t *testing.T) {
+	dir := t.TempDir()
+	if autostart.IsInstalled(dir) {
+		t.Fatal("IsInstalled: expected false before Install")
+	}
+	if err := autostart.Install(dir, "/bin/ftc"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !autostart.IsInstalled(dir) {
+		t.Error("IsInstalled: expected true after Install")
+	}
+}
+
+// TestUninstall_RemovesFile verifies Uninstall removes the .desktop file.
+func TestUninstall_RemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := autostart.Install(dir, "/bin/ftc"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := autostart.Uninstall(dir); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if autostart.IsInstalled(dir) {
+		t.Error("IsInstalled: expected false after Uninstall")
+	}
+}
+
+// TestUninstall_NotInstalled verifies Uninstall is a no-op (no error) when
+// the file does not exist.
+func TestUninstall_NotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	if err := autostart.Uninstall(dir); err != nil {
+		t.Fatalf("Uninstall on missing file: unexpected error: %v", err)
+	}
+}

--- a/companion/internal/config/config.go
+++ b/companion/internal/config/config.go
@@ -1,0 +1,70 @@
+// Package config loads and saves the companion-local configuration file.
+// The config is a small JSON document stored in the companion's config dir.
+// All fields are optional; Load returns a zero Config (not an error) when
+// the file is absent, and WithDefaults fills in standard defaults.
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const filename = "companion.json"
+
+// Config is the companion-local configuration persisted to disk.
+// All fields are optional; missing fields use zero values and WithDefaults
+// fills in operational defaults.
+type Config struct {
+	// Port is the preferred loopback port. 0 means "use the default" (7333).
+	Port int `json:"port,omitempty"`
+	// PreferredIndexer selects a specific search backend by ID (e.g. "baloo",
+	// "plocate"). Empty string means auto-detect by priority order.
+	PreferredIndexer string `json:"preferredIndexer,omitempty"`
+	// AllowedOrigins is a list of extension origins that may auto-pair without
+	// the user opening the pairing window (e.g. "chrome-extension://<id>").
+	AllowedOrigins []string `json:"allowedOrigins,omitempty"`
+}
+
+// WithDefaults returns a copy of c with operational defaults applied to any
+// zero fields.
+func (c Config) WithDefaults() Config {
+	if c.Port == 0 {
+		c.Port = 7333
+	}
+	return c
+}
+
+// Load reads the config file from configDir/companion.json.
+// A missing file is not an error — Load returns a zero Config and nil.
+// A malformed file returns a descriptive error.
+func Load(configDir string) (Config, error) {
+	path := filepath.Join(configDir, filename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Config{}, nil
+		}
+		return Config{}, err
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Save writes c as JSON to configDir/companion.json.
+// The directory is created (mode 0700) if absent.
+// The file is written with mode 0600.
+func Save(configDir string, c Config) error {
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(configDir, filename), data, 0600)
+}

--- a/companion/internal/config/config_test.go
+++ b/companion/internal/config/config_test.go
@@ -1,0 +1,122 @@
+package config_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/config"
+)
+
+// TestLoad_MissingFile returns zero Config + nil error when the file is absent.
+func TestLoad_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load on missing file: unexpected error: %v", err)
+	}
+	// Zero value — no port, no indexer, no origins.
+	if cfg.Port != 0 {
+		t.Errorf("Port: got %d, want 0", cfg.Port)
+	}
+	if cfg.PreferredIndexer != "" {
+		t.Errorf("PreferredIndexer: got %q, want empty", cfg.PreferredIndexer)
+	}
+	if len(cfg.AllowedOrigins) != 0 {
+		t.Errorf("AllowedOrigins: got %v, want nil/empty", cfg.AllowedOrigins)
+	}
+}
+
+// TestLoad_Malformed returns an error for invalid JSON.
+func TestLoad_Malformed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "companion.json")
+	if err := os.WriteFile(path, []byte("{not-valid-json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := config.Load(dir)
+	if err == nil {
+		t.Fatal("Load on malformed JSON: expected error, got nil")
+	}
+}
+
+// TestLoad_RoundTrip saves a Config, loads it back, and verifies all fields.
+func TestLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	original := config.Config{
+		Port:             8080,
+		PreferredIndexer: "plocate",
+		AllowedOrigins:   []string{"chrome-extension://abc", "moz-extension://xyz"},
+	}
+	if err := config.Save(dir, original); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Port != original.Port {
+		t.Errorf("Port: got %d, want %d", loaded.Port, original.Port)
+	}
+	if loaded.PreferredIndexer != original.PreferredIndexer {
+		t.Errorf("PreferredIndexer: got %q, want %q", loaded.PreferredIndexer, original.PreferredIndexer)
+	}
+	if len(loaded.AllowedOrigins) != len(original.AllowedOrigins) {
+		t.Errorf("AllowedOrigins length: got %d, want %d", len(loaded.AllowedOrigins), len(original.AllowedOrigins))
+	} else {
+		for i, o := range original.AllowedOrigins {
+			if loaded.AllowedOrigins[i] != o {
+				t.Errorf("AllowedOrigins[%d]: got %q, want %q", i, loaded.AllowedOrigins[i], o)
+			}
+		}
+	}
+}
+
+// TestWithDefaults_Port applies the default port when Port is zero.
+func TestWithDefaults_Port(t *testing.T) {
+	cfg := config.Config{}.WithDefaults()
+	if cfg.Port != 7333 {
+		t.Errorf("WithDefaults Port: got %d, want 7333", cfg.Port)
+	}
+}
+
+// TestWithDefaults_PortPreserved does not override a non-zero port.
+func TestWithDefaults_PortPreserved(t *testing.T) {
+	cfg := config.Config{Port: 9090}.WithDefaults()
+	if cfg.Port != 9090 {
+		t.Errorf("WithDefaults Port preserved: got %d, want 9090", cfg.Port)
+	}
+}
+
+// TestSave_FilePermissions verifies 0600 file permissions.
+func TestSave_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if err := config.Save(dir, config.Config{Port: 7333}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "companion.json"))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	got := info.Mode().Perm()
+	if got != 0600 {
+		t.Errorf("file permissions: got %o, want 0600", got)
+	}
+}
+
+// TestSave_ValidJSON verifies the written file is valid JSON.
+func TestSave_ValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := config.Save(dir, config.Config{Port: 7333, PreferredIndexer: "baloo"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "companion.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v (raw: %s)", err, data)
+	}
+}

--- a/companion/internal/config/config_test.go
+++ b/companion/internal/config/config_test.go
@@ -105,6 +105,24 @@ func TestSave_FilePermissions(t *testing.T) {
 	}
 }
 
+// TestSave_DirPermissions verifies that Save creates the config directory with
+// mode 0700 when it does not already exist.
+func TestSave_DirPermissions(t *testing.T) {
+	// Use a non-existent subdir so MkdirAll must create it.
+	dir := filepath.Join(t.TempDir(), "new-config-subdir")
+	if err := config.Save(dir, config.Config{Port: 7333}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat dir: %v", err)
+	}
+	got := info.Mode().Perm()
+	if got != 0700 {
+		t.Errorf("dir permissions: got %o, want 0700", got)
+	}
+}
+
 // TestSave_ValidJSON verifies the written file is valid JSON.
 func TestSave_ValidJSON(t *testing.T) {
 	dir := t.TempDir()

--- a/companion/internal/index/baloo.go
+++ b/companion/internal/index/baloo.go
@@ -10,8 +10,12 @@ import (
 	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
 )
 
-// balooLimit caps the number of index candidates requested per baloosearch call.
-const balooLimit = "500"
+// balooLimit is the candidate cap passed to baloosearch as a CLI argument.
+// balooLimitN is the numeric equivalent used to detect a cap hit (Bug C).
+const (
+	balooLimit  = "500"
+	balooLimitN = 500
+)
 
 // BalooIndexer queries the KDE Baloo file index via the baloosearch CLI.
 type BalooIndexer struct {
@@ -72,6 +76,7 @@ func (b *BalooIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, 
 	}
 
 	var all []string
+	degraded := false
 	for _, branch := range ORBranches(ast) {
 		seed, ok := PositiveSeed(branch)
 		if !ok {
@@ -82,9 +87,15 @@ func (b *BalooIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, 
 		if err != nil {
 			continue
 		}
-		all = append(all, parseBalooOutput(out)...)
+		paths := parseBalooOutput(out)
+		if len(paths) >= balooLimitN {
+			// Cap hit: the index returned exactly the limit, so results may be
+			// incomplete. Signal degraded so the count is not presented as exact.
+			degraded = true
+		}
+		all = append(all, paths...)
 	}
-	return normalizeAndDedupe(all), false, nil
+	return normalizeAndDedupe(all), degraded, nil
 }
 
 // parseBalooOutput reads baloosearch stdout. baloosearch prints one absolute

--- a/companion/internal/index/baloo.go
+++ b/companion/internal/index/baloo.go
@@ -1,0 +1,104 @@
+package index
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// balooLimit caps the number of index candidates requested per baloosearch call.
+const balooLimit = "500"
+
+// BalooIndexer queries the KDE Baloo file index via the baloosearch CLI.
+type BalooIndexer struct {
+	runner Runner
+	avail  bool
+}
+
+// NewBalooIndexer creates a BalooIndexer using r for command execution.
+// Available() returns true if baloosearch is found on PATH.
+func NewBalooIndexer(r Runner) *BalooIndexer {
+	_, ok := LookPath("baloosearch")
+	return &BalooIndexer{runner: r, avail: ok}
+}
+
+func (b *BalooIndexer) ID() string      { return "baloo" }
+func (b *BalooIndexer) Name() string    { return "KDE Baloo" }
+func (b *BalooIndexer) Available() bool { return b.avail }
+
+// Capabilities for Baloo:
+//   - BooleanOps: true   — Baloo's query language supports AND/OR/NOT
+//   - PrefixWildcard: true
+//   - InfixWildcard: true
+//   - Regex: false        — baloosearch has no native regex support
+//   - PathScope: true     — Baloo indexes by file path
+//   - Content: true       — Baloo indexes file content
+func (b *BalooIndexer) Capabilities() protocol.Capabilities {
+	return protocol.Capabilities{
+		BooleanOps:     true,
+		PrefixWildcard: true,
+		InfixWildcard:  true,
+		Regex:          false,
+		PathScope:      true,
+		Content:        true,
+	}
+}
+
+// Query returns candidate FileResults from the KDE Baloo index.
+//
+// Regex mode is not supported by baloosearch. If the AST is a regex node,
+// Query returns (nil, true, nil) so the registry can route the query elsewhere.
+//
+// Otherwise, for each OR branch with a positive literal seed, issues one
+// `baloosearch -l 500 -- <seed>` call and unions the results.
+//
+// baloosearch output format (confirmed on this host):
+//
+//	/absolute/path/to/file1
+//	/absolute/path/to/file2
+//	Elapsed: 11.4065 msecs
+//
+// The trailing "Elapsed: …" line and any other non-absolute-path lines are
+// dropped by parseBalooOutput. All paths are normalized and deduplicated;
+// stale index entries (Normalize fails) are silently skipped.
+func (b *BalooIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
+	if _, ok := RegexPattern(ast); ok {
+		// Baloo has no regex; signal degraded so the registry routes elsewhere.
+		return nil, true, nil
+	}
+
+	var all []string
+	for _, branch := range ORBranches(ast) {
+		seed, ok := PositiveSeed(branch)
+		if !ok {
+			// No positive literal anchor; skip this branch.
+			continue
+		}
+		out, err := b.runner.Run(ctx, "baloosearch", "-l", balooLimit, "--", seed)
+		if err != nil {
+			continue
+		}
+		all = append(all, parseBalooOutput(out)...)
+	}
+	return normalizeAndDedupe(all), false, nil
+}
+
+// parseBalooOutput reads baloosearch stdout. baloosearch prints one absolute
+// path per line and appends a trailing "Elapsed: N msecs" summary. Only lines
+// beginning with '/' are treated as paths; all others are ignored silently.
+func parseBalooOutput(out []byte) []string {
+	var paths []string
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || !strings.HasPrefix(line, "/") {
+			continue
+		}
+		paths = append(paths, line)
+	}
+	return paths
+}

--- a/companion/internal/index/baloo_test.go
+++ b/companion/internal/index/baloo_test.go
@@ -1,0 +1,239 @@
+package index_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// --- BalooIndexer tests ---
+
+func TestBaloo_Capabilities(t *testing.T) {
+	idx := index.NewBalooIndexer(&fakeRunner{})
+	caps := idx.Capabilities()
+	if !caps.BooleanOps {
+		t.Error("BooleanOps should be true")
+	}
+	if !caps.PrefixWildcard {
+		t.Error("PrefixWildcard should be true")
+	}
+	if !caps.InfixWildcard {
+		t.Error("InfixWildcard should be true")
+	}
+	if caps.Regex {
+		t.Error("Regex should be false")
+	}
+	if !caps.PathScope {
+		t.Error("PathScope should be true")
+	}
+	if !caps.Content {
+		t.Error("Content should be true")
+	}
+}
+
+func TestBaloo_IDAndName(t *testing.T) {
+	idx := index.NewBalooIndexer(&fakeRunner{})
+	if idx.ID() != "baloo" {
+		t.Errorf("ID=%q want baloo", idx.ID())
+	}
+	if idx.Name() != "KDE Baloo" {
+		t.Errorf("Name=%q want 'KDE Baloo'", idx.Name())
+	}
+}
+
+func TestBaloo_RegexMode_Degraded(t *testing.T) {
+	fr := &fakeRunner{}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse(`inv.*\.pdf`, query.ModeRegex)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !degraded {
+		t.Error("expected degraded=true for regex mode (Baloo has no native regex)")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for degraded regex, got %d", len(results))
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for regex mode, got %d", len(fr.calls))
+	}
+}
+
+func TestBaloo_SubstringMode_Command(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "report.pdf")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\nElapsed: 5.42 msecs\n"}}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse("report", query.ModeSimple)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false for substring mode")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+
+	if call.name != "baloosearch" {
+		t.Errorf("binary=%q want baloosearch", call.name)
+	}
+	if !argsContain(call.args, "-l") {
+		t.Error("expected -l flag")
+	}
+	if !argsContain(call.args, "500") {
+		t.Error("expected limit 500")
+	}
+	if !argsContain(call.args, "report") {
+		t.Error("expected seed 'report' in args")
+	}
+	ddIdx := argIndex(call.args, "--")
+	seedIdx := argIndex(call.args, "report")
+	if ddIdx < 0 {
+		t.Fatal("expected -- in args")
+	}
+	if ddIdx >= seedIdx {
+		t.Error("-- must appear before the seed")
+	}
+}
+
+func TestBaloo_ElapsedSummaryLineSkipped(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "photo.png")
+	writeTestFile(t, f)
+
+	// baloosearch appends "Elapsed: N msecs" — must not appear in results.
+	stdout := f + "\nElapsed: 11.4065 msecs\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse("photo", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (summary line skipped), got %d", len(results))
+	}
+	if results[0].Path != f {
+		t.Errorf("path=%q want %q", results[0].Path, f)
+	}
+}
+
+func TestBaloo_MissingPathsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "exists.txt")
+	writeTestFile(t, real)
+
+	stale := "/nonexistent/path/stale_baloo_entry_99.txt"
+	stdout := real + "\n" + stale + "\nElapsed: 1.0 msecs\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse("exists", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (stale entry skipped), got %d", len(results))
+	}
+	if results[0].Path != real {
+		t.Errorf("path=%q want %q", results[0].Path, real)
+	}
+}
+
+func TestBaloo_ORQuery_TwoInvocations(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "doc1.txt")
+	f2 := filepath.Join(dir, "doc2.txt")
+	writeTestFile(t, f1)
+	writeTestFile(t, f2)
+
+	fr := &fakeRunner{stdouts: []string{
+		f1 + "\nElapsed: 1 msecs\n",
+		f2 + "\nElapsed: 2 msecs\n",
+	}}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse("doc1 | doc2", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+
+	if len(fr.calls) != 2 {
+		t.Fatalf("expected 2 runner calls (one per OR branch), got %d", len(fr.calls))
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (union), got %d", len(results))
+	}
+}
+
+func TestBaloo_DeduplicatePaths(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "dup.txt")
+	writeTestFile(t, f)
+
+	// Both branches return the same path.
+	fr := &fakeRunner{stdouts: []string{
+		f + "\nElapsed: 1 msecs\n",
+		f + "\nElapsed: 1 msecs\n",
+	}}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse("dup | dup", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 deduplicated result, got %d", len(results))
+	}
+}
+
+func TestBaloo_PureNegation_NoCall(t *testing.T) {
+	fr := &fakeRunner{}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse("-foo", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for pure-negation branch, got %d", len(fr.calls))
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestBaloo_ResultsNeverNil(t *testing.T) {
+	fr := &fakeRunner{stdouts: []string{"Elapsed: 0 msecs\n"}}
+	idx := index.NewBalooIndexer(fr)
+
+	ast, _ := query.Parse("anything", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if results == nil {
+		t.Error("results must never be nil")
+	}
+}

--- a/companion/internal/index/classify.go
+++ b/companion/internal/index/classify.go
@@ -1,0 +1,65 @@
+package index
+
+import "github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+
+// extCategory maps lowercase file extensions to FileType categories.
+var extCategory = map[string]protocol.FileType{
+	// image
+	"jpg": protocol.FileTypeImage, "jpeg": protocol.FileTypeImage,
+	"png": protocol.FileTypeImage, "gif": protocol.FileTypeImage,
+	"webp": protocol.FileTypeImage, "bmp": protocol.FileTypeImage,
+	"svg": protocol.FileTypeImage, "heic": protocol.FileTypeImage,
+	"tiff": protocol.FileTypeImage, "ico": protocol.FileTypeImage,
+
+	// video
+	"mp4": protocol.FileTypeVideo, "mkv": protocol.FileTypeVideo,
+	"mov": protocol.FileTypeVideo, "avi": protocol.FileTypeVideo,
+	"webm": protocol.FileTypeVideo, "flv": protocol.FileTypeVideo,
+	"wmv": protocol.FileTypeVideo, "m4v": protocol.FileTypeVideo,
+
+	// audio
+	"mp3": protocol.FileTypeAudio, "flac": protocol.FileTypeAudio,
+	"wav": protocol.FileTypeAudio, "ogg": protocol.FileTypeAudio,
+	"m4a": protocol.FileTypeAudio, "aac": protocol.FileTypeAudio,
+	"opus": protocol.FileTypeAudio,
+
+	// archive
+	"zip": protocol.FileTypeArchive, "tar": protocol.FileTypeArchive,
+	"gz": protocol.FileTypeArchive, "bz2": protocol.FileTypeArchive,
+	"xz": protocol.FileTypeArchive, "7z": protocol.FileTypeArchive,
+	"rar": protocol.FileTypeArchive, "zst": protocol.FileTypeArchive,
+
+	// code
+	"go": protocol.FileTypeCode, "js": protocol.FileTypeCode,
+	"ts": protocol.FileTypeCode, "tsx": protocol.FileTypeCode,
+	"jsx": protocol.FileTypeCode, "py": protocol.FileTypeCode,
+	"rs": protocol.FileTypeCode, "java": protocol.FileTypeCode,
+	"kt": protocol.FileTypeCode, "c": protocol.FileTypeCode,
+	"h": protocol.FileTypeCode, "cpp": protocol.FileTypeCode,
+	"hpp": protocol.FileTypeCode, "cs": protocol.FileTypeCode,
+	"rb": protocol.FileTypeCode, "php": protocol.FileTypeCode,
+	"sh": protocol.FileTypeCode, "json": protocol.FileTypeCode,
+	"yaml": protocol.FileTypeCode, "yml": protocol.FileTypeCode,
+	"toml": protocol.FileTypeCode, "xml": protocol.FileTypeCode,
+	"html": protocol.FileTypeCode, "css": protocol.FileTypeCode,
+	"sql": protocol.FileTypeCode,
+
+	// document
+	"pdf": protocol.FileTypeDocument, "doc": protocol.FileTypeDocument,
+	"docx": protocol.FileTypeDocument, "xls": protocol.FileTypeDocument,
+	"xlsx": protocol.FileTypeDocument, "ppt": protocol.FileTypeDocument,
+	"pptx": protocol.FileTypeDocument, "odt": protocol.FileTypeDocument,
+	"ods": protocol.FileTypeDocument, "odp": protocol.FileTypeDocument,
+	"txt": protocol.FileTypeDocument, "md": protocol.FileTypeDocument,
+	"rtf": protocol.FileTypeDocument, "csv": protocol.FileTypeDocument,
+	"epub": protocol.FileTypeDocument,
+}
+
+// ClassifyType returns the FileType category for a given lowercase extension.
+// If the extension is unknown, it returns FileTypeOther.
+func ClassifyType(ext string) protocol.FileType {
+	if t, ok := extCategory[ext]; ok {
+		return t
+	}
+	return protocol.FileTypeOther
+}

--- a/companion/internal/index/compile.go
+++ b/companion/internal/index/compile.go
@@ -10,6 +10,11 @@ import (
 // ORBranches returns the immediate child nodes when n is an "or" node, or a
 // single-element slice containing n for any other op. Backends call this to
 // iterate over independent OR branches and issue one native query per branch.
+//
+// Flat-OR invariant: the query grammar has no grouping syntax, so the parser
+// emits only a single flat top-level "or" — branches never contain a nested
+// "or" node. PositiveSeed relies on this: it walks branch internals without
+// needing to handle recursive OR splitting.
 func ORBranches(n query.Node) []query.Node {
 	if n.Op == "or" {
 		return n.Nodes
@@ -25,6 +30,10 @@ func ORBranches(n query.Node) []query.Node {
 // Recall safety: using any literal substring as the native query seed means the
 // index returns a superset of true matches. The pipeline matcher enforces the
 // full query semantics over that superset.
+//
+// Flat-OR invariant: branches passed here are leaves of a flat OR (see
+// ORBranches). They may contain AND/NOT nodes but never a nested OR, so the
+// walk below does not need to split on "or" to remain recall-safe.
 //
 // Returns ("", false) if no fragment of length ≥ 1 exists (e.g. pure negation,
 // or a regex node).
@@ -76,6 +85,219 @@ func RegexPattern(n query.Node) (string, bool) {
 		return n.Value, true
 	}
 	return "", false
+}
+
+// RegexSeeds derives plocate substring seeds from an RE2 pattern that are
+// recall-safe: every string the pattern matches contains at least one of the
+// returned seeds. It splits the pattern on top-level alternation and extracts
+// the longest REQUIRED literal run from each alternative. If any alternative has
+// no usable required literal (len >= 2), it returns broad=true, signalling the
+// caller to fall back to a whole-index scan (the RE2 matcher still filters).
+//
+// Seeds are deduplicated before return.
+func RegexSeeds(pattern string) (seeds []string, broad bool) {
+	alternatives := splitTopLevelAlternation(pattern)
+	seen := make(map[string]struct{}, len(alternatives))
+	var result []string
+	for _, alt := range alternatives {
+		seed := longestRequiredLiteralRun(alt)
+		if len(seed) < 2 {
+			return nil, true
+		}
+		if _, dup := seen[seed]; !dup {
+			seen[seed] = struct{}{}
+			result = append(result, seed)
+		}
+	}
+	return result, false
+}
+
+// splitTopLevelAlternation splits pattern on top-level '|' characters —
+// those not escaped (\|), not inside a char class ([...]), and not inside
+// a group (...). It returns at least one element.
+func splitTopLevelAlternation(pattern string) []string {
+	var alternatives []string
+	depth := 0
+	inClass := false
+	start := 0
+	i := 0
+	for i < len(pattern) {
+		ch := pattern[i]
+		switch {
+		case ch == '\\' && i+1 < len(pattern):
+			i += 2 // skip the escaped character
+		case inClass:
+			if ch == ']' {
+				inClass = false
+			}
+			i++
+		case ch == '[':
+			inClass = true
+			i++
+		case ch == '(':
+			depth++
+			i++
+		case ch == ')':
+			if depth > 0 {
+				depth--
+			}
+			i++
+		case ch == '|' && depth == 0:
+			alternatives = append(alternatives, pattern[start:i])
+			start = i + 1
+			i++
+		default:
+			i++
+		}
+	}
+	alternatives = append(alternatives, pattern[start:])
+	return alternatives
+}
+
+// longestRequiredLiteralRun finds the longest contiguous run of characters
+// that MUST appear in every string matched by the RE2 alternative alt.
+//
+// Rules (left-to-right scan):
+//   - Ordinary literal chars and escaped non-letter metacharacters (\. \* \\ etc.)
+//     extend the current run.
+//   - Quantifiers after a run char: '*' or '?' → drop the last char (may be
+//     zero), break the run. '+' → keep the char (at least one), break the run.
+//     '{' (any interval) → drop the last char (conservatively), skip to '}',
+//     break the run.
+//   - Run-breakers (start a new empty run): '.', '[…]' (skip the class),
+//     '(', ')', '^', '$', any '\<letter>' escape (\d \w \s etc.).
+//   - Quantifiers on breaker elements are consumed but don't affect an empty run.
+func longestRequiredLiteralRun(alt string) string {
+	best := ""
+	cur := make([]byte, 0, 16)
+
+	endRun := func() {
+		if len(cur) > len(best) {
+			best = string(cur)
+		}
+		cur = cur[:0]
+	}
+	dropLastAndEndRun := func() {
+		if len(cur) > 0 {
+			cur = cur[:len(cur)-1]
+		}
+		endRun()
+	}
+	// consumeQuantifier advances i past an optional quantifier at position i.
+	// Returns the new i.
+	consumeQuantifier := func(i int) int {
+		if i >= len(alt) {
+			return i
+		}
+		switch alt[i] {
+		case '*', '?', '+':
+			return i + 1
+		case '{':
+			i++
+			for i < len(alt) && alt[i] != '}' {
+				i++
+			}
+			if i < len(alt) {
+				i++ // skip '}'
+			}
+		}
+		return i
+	}
+
+	i := 0
+	for i < len(alt) {
+		ch := alt[i]
+
+		if ch == '\\' && i+1 < len(alt) {
+			next := alt[i+1]
+			i += 2
+			if (next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z') {
+				// \d \w \s \D \W \S \b \B and any other letter escape:
+				// these are class shorthands or zero-width assertions → break run.
+				endRun()
+				i = consumeQuantifier(i)
+			} else {
+				// \. \* \( \) \\ \{ \} \+ \? \^ \$ etc. → literal symbol.
+				cur = append(cur, next)
+				if i < len(alt) {
+					switch alt[i] {
+					case '*', '?':
+						dropLastAndEndRun()
+						i++
+					case '+':
+						endRun()
+						i++
+					case '{':
+						dropLastAndEndRun()
+						i = consumeQuantifier(i)
+					}
+				}
+			}
+			continue
+		}
+
+		switch ch {
+		case '.':
+			endRun()
+			i++
+			i = consumeQuantifier(i)
+
+		case '[':
+			endRun()
+			i++ // skip '['
+			// Handle negation and leading ']' that is literal inside the class.
+			if i < len(alt) && alt[i] == '^' {
+				i++
+			}
+			if i < len(alt) && alt[i] == ']' {
+				i++ // ']' at the start of a class is a literal member
+			}
+			for i < len(alt) && alt[i] != ']' {
+				if alt[i] == '\\' {
+					i++ // skip escaped char inside class
+				}
+				i++
+			}
+			if i < len(alt) {
+				i++ // skip closing ']'
+			}
+			i = consumeQuantifier(i)
+
+		case '(', ')', '^', '$':
+			endRun()
+			i++
+
+		case '*', '?', '+':
+			// Stray quantifier (no preceding literal in current run); just consume.
+			endRun()
+			i++
+
+		case '{':
+			// Stray interval quantifier.
+			endRun()
+			i = consumeQuantifier(i)
+
+		default:
+			// Regular literal character.
+			cur = append(cur, ch)
+			i++
+			if i < len(alt) {
+				switch alt[i] {
+				case '*', '?':
+					dropLastAndEndRun()
+					i++
+				case '+':
+					endRun()
+					i++
+				case '{':
+					dropLastAndEndRun()
+					i = consumeQuantifier(i)
+				}
+			}
+		}
+	}
+	endRun()
+	return best
 }
 
 // normalizeAndDedupe converts a slice of filesystem paths into FileResults.

--- a/companion/internal/index/compile.go
+++ b/companion/internal/index/compile.go
@@ -167,6 +167,8 @@ func splitTopLevelAlternation(pattern string) []string {
 //   - Run-breakers (start a new empty run): '.', '[…]' (skip the class),
 //     '(', ')', '^', '$', any '\<letter>' escape (\d \w \s etc.).
 //   - Quantifiers on breaker elements are consumed but don't affect an empty run.
+//   - Only TOP-LEVEL literals (paren depth 0) are collected: a group (…) may be
+//     quantified/optional (e.g. (foo)*bar), so its contents are never required.
 func longestRequiredLiteralRun(alt string) string {
 	best := ""
 	cur := make([]byte, 0, 16)
@@ -204,6 +206,7 @@ func longestRequiredLiteralRun(alt string) string {
 		return i
 	}
 
+	depth := 0
 	i := 0
 	for i < len(alt) {
 		ch := alt[i]
@@ -216,7 +219,7 @@ func longestRequiredLiteralRun(alt string) string {
 				// these are class shorthands or zero-width assertions → break run.
 				endRun()
 				i = consumeQuantifier(i)
-			} else {
+			} else if depth == 0 {
 				// \. \* \( \) \\ \{ \} \+ \? \^ \$ etc. → literal symbol.
 				cur = append(cur, next)
 				if i < len(alt) {
@@ -263,7 +266,19 @@ func longestRequiredLiteralRun(alt string) string {
 			}
 			i = consumeQuantifier(i)
 
-		case '(', ')', '^', '$':
+		case '(':
+			depth++
+			endRun()
+			i++
+
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			endRun()
+			i++
+
+		case '^', '$':
 			endRun()
 			i++
 
@@ -278,20 +293,23 @@ func longestRequiredLiteralRun(alt string) string {
 			i = consumeQuantifier(i)
 
 		default:
-			// Regular literal character.
-			cur = append(cur, ch)
+			// Regular literal character — collected only at the top level
+			// (depth 0); characters inside a group (...) are never required.
 			i++
-			if i < len(alt) {
-				switch alt[i] {
-				case '*', '?':
-					dropLastAndEndRun()
-					i++
-				case '+':
-					endRun()
-					i++
-				case '{':
-					dropLastAndEndRun()
-					i = consumeQuantifier(i)
+			if depth == 0 {
+				cur = append(cur, ch)
+				if i < len(alt) {
+					switch alt[i] {
+					case '*', '?':
+						dropLastAndEndRun()
+						i++
+					case '+':
+						endRun()
+						i++
+					case '{':
+						dropLastAndEndRun()
+						i = consumeQuantifier(i)
+					}
 				}
 			}
 		}

--- a/companion/internal/index/compile.go
+++ b/companion/internal/index/compile.go
@@ -1,0 +1,100 @@
+package index
+
+import (
+	"strings"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// ORBranches returns the immediate child nodes when n is an "or" node, or a
+// single-element slice containing n for any other op. Backends call this to
+// iterate over independent OR branches and issue one native query per branch.
+func ORBranches(n query.Node) []query.Node {
+	if n.Op == "or" {
+		return n.Nodes
+	}
+	return []query.Node{n}
+}
+
+// PositiveSeed returns the longest contiguous literal fragment from positive
+// (not under a "not") term and phrase nodes in branch. Wildcard characters
+// ('*' and '?') split a term value into fragments; the longest fragment wins.
+// Regex nodes are always skipped — their values are not safe as literal seeds.
+//
+// Recall safety: using any literal substring as the native query seed means the
+// index returns a superset of true matches. The pipeline matcher enforces the
+// full query semantics over that superset.
+//
+// Returns ("", false) if no fragment of length ≥ 1 exists (e.g. pure negation,
+// or a regex node).
+func PositiveSeed(branch query.Node) (string, bool) {
+	best := ""
+	var walk func(n query.Node, negated bool)
+	walk = func(n query.Node, negated bool) {
+		switch n.Op {
+		case "and", "or":
+			for _, child := range n.Nodes {
+				walk(child, negated)
+			}
+		case "not":
+			if n.Node != nil {
+				walk(*n.Node, true)
+			}
+		case "term", "phrase":
+			if negated {
+				return
+			}
+			for _, frag := range wildcardFragments(n.Value) {
+				if len(frag) > len(best) {
+					best = frag
+				}
+			}
+			// "regex": intentionally skipped — pass through to default.
+		}
+	}
+	walk(branch, false)
+	if len(best) == 0 {
+		return "", false
+	}
+	return best, true
+}
+
+// wildcardFragments splits s on '*' and '?' and returns the non-empty pieces.
+// A value with no wildcards returns a single-element slice [s].
+func wildcardFragments(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return r == '*' || r == '?'
+	})
+}
+
+// RegexPattern returns (n.Value, true) when n is a "regex" node, signalling
+// that the query was parsed in regex mode and the pattern can be forwarded
+// directly to an index binary that supports native regex (e.g. plocate --regexp).
+func RegexPattern(n query.Node) (string, bool) {
+	if n.Op == "regex" {
+		return n.Value, true
+	}
+	return "", false
+}
+
+// normalizeAndDedupe converts a slice of filesystem paths into FileResults.
+// Each path is stat-ed via Normalize; paths that fail (stale index entries)
+// are silently skipped. Duplicate paths are removed. The returned slice is
+// always non-nil.
+func normalizeAndDedupe(paths []string) []protocol.FileResult {
+	seen := make(map[string]struct{}, len(paths))
+	results := make([]protocol.FileResult, 0, len(paths))
+	for _, p := range paths {
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		r, err := Normalize(p)
+		if err != nil {
+			continue // stale index entry — path no longer exists
+		}
+		results = append(results, r)
+	}
+	return results
+}

--- a/companion/internal/index/compile_test.go
+++ b/companion/internal/index/compile_test.go
@@ -240,6 +240,39 @@ func TestRegexSeeds_WildcardOnly_Broad(t *testing.T) {
 	}
 }
 
+func TestRegexSeeds_QuantifiedGroupSeedsOutsideGroup(t *testing.T) {
+	// (foo)*bar — "foo" is inside an optional group, so the only required
+	// literal is "bar". Seeding on "foo" would drop matches like "bar".
+	seeds, broad := index.RegexSeeds(`(foo)*bar`)
+	if broad {
+		t.Fatalf("expected broad=false; seeds=%v", seeds)
+	}
+	if len(seeds) != 1 || seeds[0] != "bar" {
+		t.Errorf("seeds=%v want [bar]", seeds)
+	}
+}
+
+func TestRegexSeeds_GroupLiteralsIgnored(t *testing.T) {
+	// (budget)_2024 — literals inside the group are never used as a required
+	// seed; the required top-level run is "_2024".
+	seeds, broad := index.RegexSeeds(`(budget)_2024`)
+	if broad {
+		t.Fatalf("expected broad=false; seeds=%v", seeds)
+	}
+	if len(seeds) != 1 || seeds[0] != "_2024" {
+		t.Errorf("seeds=%v want [_2024]", seeds)
+	}
+}
+
+func TestRegexSeeds_OnlyShortTopLevelLiterals_Broad(t *testing.T) {
+	// a(bc)*d — the only top-level literals are "a" and "d" (each len 1), so
+	// no usable seed exists and we must scan broadly (recall-safe fallback).
+	_, broad := index.RegexSeeds(`a(bc)*d`)
+	if !broad {
+		t.Error("expected broad=true for a(bc)*d")
+	}
+}
+
 func TestRegexSeeds_EscapedDotPattern(t *testing.T) {
 	// inv\.pdf — \. is a literal dot; longest run is "inv.pdf"
 	seeds, broad := index.RegexSeeds(`inv\.pdf`)

--- a/companion/internal/index/compile_test.go
+++ b/companion/internal/index/compile_test.go
@@ -179,3 +179,107 @@ func TestRegexPattern_ANDNode_False(t *testing.T) {
 		t.Error("expected ok=false for and node")
 	}
 }
+
+// --- RegexSeeds ---
+
+func TestRegexSeeds_PlainLiteral(t *testing.T) {
+	seeds, broad := index.RegexSeeds("report")
+	if broad {
+		t.Fatal("expected broad=false")
+	}
+	if len(seeds) != 1 || seeds[0] != "report" {
+		t.Errorf("seeds=%v want [report]", seeds)
+	}
+}
+
+func TestRegexSeeds_BudgetPattern(t *testing.T) {
+	// ^budget_\d{4}\.xlsx$ — longest required run is "budget_" (breaks at \d)
+	seeds, broad := index.RegexSeeds(`^budget_\d{4}\.xlsx$`)
+	if broad {
+		t.Fatal("expected broad=false")
+	}
+	if len(seeds) != 1 || seeds[0] != "budget_" {
+		t.Errorf("seeds=%v want [budget_]", seeds)
+	}
+}
+
+func TestRegexSeeds_Alternation(t *testing.T) {
+	// foo|bar — two seeds
+	seeds, broad := index.RegexSeeds("foo|bar")
+	if broad {
+		t.Fatal("expected broad=false")
+	}
+	if len(seeds) != 2 {
+		t.Fatalf("len(seeds)=%d want 2; seeds=%v", len(seeds), seeds)
+	}
+	has := func(s string) bool {
+		for _, v := range seeds {
+			if v == s {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("foo") || !has("bar") {
+		t.Errorf("seeds=%v; want both foo and bar", seeds)
+	}
+}
+
+func TestRegexSeeds_SingleCharAlternation_Broad(t *testing.T) {
+	// a|.* — "a" is len 1 (< 2), so broad=true
+	_, broad := index.RegexSeeds(`a|.*`)
+	if !broad {
+		t.Error("expected broad=true (one alternative has no usable literal)")
+	}
+}
+
+func TestRegexSeeds_WildcardOnly_Broad(t *testing.T) {
+	_, broad := index.RegexSeeds(`^.*$`)
+	if !broad {
+		t.Error("expected broad=true for ^.*$")
+	}
+}
+
+func TestRegexSeeds_EscapedDotPattern(t *testing.T) {
+	// inv\.pdf — \. is a literal dot; longest run is "inv.pdf"
+	seeds, broad := index.RegexSeeds(`inv\.pdf`)
+	if broad {
+		t.Fatalf("expected broad=false; seeds=%v", seeds)
+	}
+	if len(seeds) != 1 {
+		t.Fatalf("len(seeds)=%d want 1; seeds=%v", len(seeds), seeds)
+	}
+	if seeds[0] != "inv.pdf" {
+		t.Errorf("seed=%q want inv.pdf", seeds[0])
+	}
+}
+
+func TestRegexSeeds_CharClassPrefix(t *testing.T) {
+	// [ab]cdef — char class breaks run, "cdef" is the longest required run
+	seeds, broad := index.RegexSeeds("[ab]cdef")
+	if broad {
+		t.Fatal("expected broad=false")
+	}
+	if len(seeds) != 1 || seeds[0] != "cdef" {
+		t.Errorf("seeds=%v want [cdef]", seeds)
+	}
+}
+
+func TestRegexSeeds_Deduplication(t *testing.T) {
+	// same seed from two branches → deduplicated
+	seeds, broad := index.RegexSeeds("foo|foo")
+	if broad {
+		t.Fatal("expected broad=false")
+	}
+	if len(seeds) != 1 || seeds[0] != "foo" {
+		t.Errorf("seeds=%v want [foo] (deduplicated)", seeds)
+	}
+}
+
+func TestRegexSeeds_FlatOR_ThreeBranches(t *testing.T) {
+	// a | b | c — each branch is len 1 → broad=true
+	_, broad := index.RegexSeeds("a|b|c")
+	if !broad {
+		t.Error("expected broad=true for single-char alternation branches")
+	}
+}

--- a/companion/internal/index/compile_test.go
+++ b/companion/internal/index/compile_test.go
@@ -1,0 +1,181 @@
+package index_test
+
+import (
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// --- ORBranches ---
+
+func TestORBranches_SingleTerm(t *testing.T) {
+	n, err := query.Parse("hello", query.ModeSimple)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	branches := index.ORBranches(n)
+	if len(branches) != 1 {
+		t.Fatalf("len=%d want 1", len(branches))
+	}
+	if branches[0].Op != "term" {
+		t.Errorf("op=%q want term", branches[0].Op)
+	}
+}
+
+func TestORBranches_ORTwoBranches(t *testing.T) {
+	n, err := query.Parse("hello | world", query.ModeSimple)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	branches := index.ORBranches(n)
+	if len(branches) != 2 {
+		t.Fatalf("len=%d want 2", len(branches))
+	}
+}
+
+func TestORBranches_ORThreeBranches(t *testing.T) {
+	n, err := query.Parse("a | b | c", query.ModeSimple)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	branches := index.ORBranches(n)
+	if len(branches) != 3 {
+		t.Fatalf("len=%d want 3", len(branches))
+	}
+}
+
+func TestORBranches_ANDIsNotOR(t *testing.T) {
+	// "hello world" parses to an AND node — not split into branches.
+	n, err := query.Parse("hello world", query.ModeSimple)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	branches := index.ORBranches(n)
+	if len(branches) != 1 {
+		t.Fatalf("len=%d want 1", len(branches))
+	}
+	if branches[0].Op != "and" {
+		t.Errorf("op=%q want and", branches[0].Op)
+	}
+}
+
+// --- PositiveSeed ---
+
+func TestPositiveSeed_PlainTerm(t *testing.T) {
+	n, _ := query.Parse("invoice", query.ModeSimple)
+	seed, ok := index.PositiveSeed(n)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if seed != "invoice" {
+		t.Errorf("seed=%q want invoice", seed)
+	}
+}
+
+func TestPositiveSeed_MultiTermPicksLongest(t *testing.T) {
+	// "ab cdef" → AND{term:ab, term:cdef}; longest fragment is "cdef" (4 > 2).
+	n, _ := query.Parse("ab cdef", query.ModeSimple)
+	seed, ok := index.PositiveSeed(n)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if seed != "cdef" {
+		t.Errorf("seed=%q want cdef", seed)
+	}
+}
+
+func TestPositiveSeed_WildcardTermSplitsOnStar(t *testing.T) {
+	// "inv*.pdf" splits on '*' → ["inv", ".pdf"]; longest is ".pdf" (4 > 3).
+	n, _ := query.Parse("inv*.pdf", query.ModeWildcard)
+	seed, ok := index.PositiveSeed(n)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if seed != ".pdf" {
+		t.Errorf("seed=%q want .pdf", seed)
+	}
+}
+
+func TestPositiveSeed_WildcardTermSplitsOnQuestion(t *testing.T) {
+	// "inv?oice" splits on '?' → ["inv", "oice"]; longest is "oice" (4 > 3).
+	n, _ := query.Parse("inv?oice", query.ModeWildcard)
+	seed, ok := index.PositiveSeed(n)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if seed != "oice" {
+		t.Errorf("seed=%q want oice", seed)
+	}
+}
+
+func TestPositiveSeed_Phrase(t *testing.T) {
+	// Phrases have no wildcards; the whole value is the fragment.
+	n, _ := query.Parse(`"hello world"`, query.ModeSimple)
+	seed, ok := index.PositiveSeed(n)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if seed != "hello world" {
+		t.Errorf("seed=%q want 'hello world'", seed)
+	}
+}
+
+func TestPositiveSeed_NegatedTermIgnored(t *testing.T) {
+	// "-foo bar" → AND{not{term:foo}, term:bar}; "foo" is negated, "bar" is positive.
+	n, _ := query.Parse("-foo bar", query.ModeSimple)
+	seed, ok := index.PositiveSeed(n)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if seed != "bar" {
+		t.Errorf("seed=%q want bar", seed)
+	}
+}
+
+func TestPositiveSeed_PureNegation_NoSeed(t *testing.T) {
+	// "-foo" → not{term:foo}; no positive terms → no seed.
+	n, _ := query.Parse("-foo", query.ModeSimple)
+	_, ok := index.PositiveSeed(n)
+	if ok {
+		t.Error("expected ok=false for pure negation")
+	}
+}
+
+func TestPositiveSeed_RegexNodeSkipped(t *testing.T) {
+	// Regex-mode input → regex node; PositiveSeed must not use the regex as a literal seed.
+	n, _ := query.Parse("foo", query.ModeRegex)
+	_, ok := index.PositiveSeed(n)
+	if ok {
+		t.Error("expected ok=false for regex node")
+	}
+}
+
+// --- RegexPattern ---
+
+func TestRegexPattern_RegexNode(t *testing.T) {
+	n, _ := query.Parse(`inv.*\.pdf`, query.ModeRegex)
+	pat, ok := index.RegexPattern(n)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if pat != `inv.*\.pdf` {
+		t.Errorf("pat=%q want inv.*\\.pdf", pat)
+	}
+}
+
+func TestRegexPattern_TermNode_False(t *testing.T) {
+	n, _ := query.Parse("invoice", query.ModeSimple)
+	_, ok := index.RegexPattern(n)
+	if ok {
+		t.Error("expected ok=false for term node")
+	}
+}
+
+func TestRegexPattern_ANDNode_False(t *testing.T) {
+	n, _ := query.Parse("hello world", query.ModeSimple)
+	_, ok := index.RegexPattern(n)
+	if ok {
+		t.Error("expected ok=false for and node")
+	}
+}

--- a/companion/internal/index/everything.go
+++ b/companion/internal/index/everything.go
@@ -56,21 +56,26 @@ func (e *EverythingIndexer) Capabilities() protocol.Capabilities {
 
 // Query returns candidate FileResults from the Everything index.
 //
-// Regex mode: Everything natively supports regex via es -r. The raw RE2
-// pattern is forwarded directly as: es -r -n <LIMIT> -- <pattern>.
+// Regex mode: Everything natively supports regex via es -r.
+// es uses ECMAScript regex, not RE2. The common subset (\d \w . * + ? {n} [...])
+// is compatible; RE2-only constructs ((?i), (?P<name>...), \p{...}) may cause
+// es to fail/return empty — under-return for those inputs. The RE2 matcher
+// post-filters for precision but cannot recover missing candidates.
 // degraded=false because results are a true regex index match.
 //
 // Substring mode: for each OR branch with a positive literal seed, issues
-// one `es -n <LIMIT> -- <seed>` call (substring/glob match on path/name).
+// one `es -full-path-and-name -n <LIMIT> -- <seed>` call.
 // Results across branches are unioned.
 //
-// es prints one full absolute path per line by default. normalizeAndDedupe
-// stats each path and silently drops stale entries (path no longer exists).
+// -full-path-and-name forces es to emit full paths even on non-default
+// Everything configurations; normalizeAndDedupe stats each path and silently
+// drops stale entries (path no longer exists).
 func (e *EverythingIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
 	if pat, ok := RegexPattern(ast); ok {
 		// Everything natively supports regex; forward the raw pattern with -r.
+		// -full-path-and-name ensures full paths regardless of es configuration.
 		// degraded=false: the index itself performs regex filtering.
-		out, err := e.runner.Run(ctx, e.Bin, "-r", "-n", everythingLimit, "--", pat)
+		out, err := e.runner.Run(ctx, e.Bin, "-r", "-full-path-and-name", "-n", everythingLimit, "--", pat)
 		if err != nil {
 			return normalizeAndDedupe(nil), false, err
 		}
@@ -85,7 +90,7 @@ func (e *EverythingIndexer) Query(ctx context.Context, ast query.Node, _ query.M
 			// No positive literal anchor (e.g. pure negation); skip this branch.
 			continue
 		}
-		out, err := e.runner.Run(ctx, e.Bin, "-n", everythingLimit, "--", seed)
+		out, err := e.runner.Run(ctx, e.Bin, "-full-path-and-name", "-n", everythingLimit, "--", seed)
 		if err != nil {
 			continue
 		}

--- a/companion/internal/index/everything.go
+++ b/companion/internal/index/everything.go
@@ -7,8 +7,12 @@ import (
 	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
 )
 
-// everythingLimit caps the number of index candidates requested per invocation.
-const everythingLimit = "500"
+// everythingLimit is the candidate cap passed to es as a CLI argument.
+// everythingLimitN is the numeric equivalent used to detect a cap hit (Bug C).
+const (
+	everythingLimit  = "500"
+	everythingLimitN = 500
+)
 
 // EverythingIndexer queries Voidtools Everything via the es CLI (Everything
 // Search). It supports native regex via es -r, making it the preferred
@@ -79,11 +83,14 @@ func (e *EverythingIndexer) Query(ctx context.Context, ast query.Node, _ query.M
 		if err != nil {
 			return normalizeAndDedupe(nil), false, err
 		}
-		return normalizeAndDedupe(parseWinPaths(out)), false, nil
+		paths := parseWinPaths(out)
+		degraded := len(paths) >= everythingLimitN
+		return normalizeAndDedupe(paths), degraded, nil
 	}
 
 	// Substring mode: one invocation per OR branch with a resolvable seed.
 	var all []string
+	degraded := false
 	for _, branch := range ORBranches(ast) {
 		seed, ok := PositiveSeed(branch)
 		if !ok {
@@ -94,7 +101,13 @@ func (e *EverythingIndexer) Query(ctx context.Context, ast query.Node, _ query.M
 		if err != nil {
 			continue
 		}
-		all = append(all, parseWinPaths(out)...)
+		paths := parseWinPaths(out)
+		if len(paths) >= everythingLimitN {
+			// Cap hit: the index returned exactly the limit, so results may be
+			// incomplete. Signal degraded so the count is not presented as exact.
+			degraded = true
+		}
+		all = append(all, paths...)
 	}
-	return normalizeAndDedupe(all), false, nil
+	return normalizeAndDedupe(all), degraded, nil
 }

--- a/companion/internal/index/everything.go
+++ b/companion/internal/index/everything.go
@@ -1,0 +1,95 @@
+package index
+
+import (
+	"context"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// everythingLimit caps the number of index candidates requested per invocation.
+const everythingLimit = "500"
+
+// EverythingIndexer queries Voidtools Everything via the es CLI (Everything
+// Search). It supports native regex via es -r, making it the preferred
+// regex-capable backend on Windows. Inert on Linux/macOS where es is absent.
+type EverythingIndexer struct {
+	runner Runner
+	// Bin is the resolved es binary path, selected at construction time.
+	// Exported so tests can set it explicitly without PATH lookups.
+	Bin   string
+	avail bool
+}
+
+// NewEverythingIndexer creates an EverythingIndexer using r for command
+// execution. It resolves es / es.exe at construction time; Available() returns
+// false if neither is on PATH (e.g. on Linux/macOS).
+func NewEverythingIndexer(r Runner) *EverythingIndexer {
+	bin, ok := LookPath("es")
+	if !ok {
+		bin, ok = LookPath("es.exe")
+	}
+	return &EverythingIndexer{runner: r, Bin: bin, avail: ok}
+}
+
+func (e *EverythingIndexer) ID() string      { return "everything" }
+func (e *EverythingIndexer) Name() string    { return "Everything" }
+func (e *EverythingIndexer) Available() bool { return e.avail }
+
+// Capabilities for Everything (Voidtools):
+//   - BooleanOps: true     — es space-separated terms imply AND
+//   - PrefixWildcard: true — glob wildcard support
+//   - InfixWildcard: true  — glob wildcard support
+//   - Regex: true          — native regex via es -r
+//   - PathScope: true      — Everything always indexes and returns full paths
+//   - Content: false       — Everything is a path/name index only
+func (e *EverythingIndexer) Capabilities() protocol.Capabilities {
+	return protocol.Capabilities{
+		BooleanOps:     true,
+		PrefixWildcard: true,
+		InfixWildcard:  true,
+		Regex:          true,
+		PathScope:      true,
+		Content:        false,
+	}
+}
+
+// Query returns candidate FileResults from the Everything index.
+//
+// Regex mode: Everything natively supports regex via es -r. The raw RE2
+// pattern is forwarded directly as: es -r -n <LIMIT> -- <pattern>.
+// degraded=false because results are a true regex index match.
+//
+// Substring mode: for each OR branch with a positive literal seed, issues
+// one `es -n <LIMIT> -- <seed>` call (substring/glob match on path/name).
+// Results across branches are unioned.
+//
+// es prints one full absolute path per line by default. normalizeAndDedupe
+// stats each path and silently drops stale entries (path no longer exists).
+func (e *EverythingIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
+	if pat, ok := RegexPattern(ast); ok {
+		// Everything natively supports regex; forward the raw pattern with -r.
+		// degraded=false: the index itself performs regex filtering.
+		out, err := e.runner.Run(ctx, e.Bin, "-r", "-n", everythingLimit, "--", pat)
+		if err != nil {
+			return normalizeAndDedupe(nil), false, err
+		}
+		return normalizeAndDedupe(parseWinPaths(out)), false, nil
+	}
+
+	// Substring mode: one invocation per OR branch with a resolvable seed.
+	var all []string
+	for _, branch := range ORBranches(ast) {
+		seed, ok := PositiveSeed(branch)
+		if !ok {
+			// No positive literal anchor (e.g. pure negation); skip this branch.
+			continue
+		}
+		out, err := e.runner.Run(ctx, e.Bin, "-n", everythingLimit, "--", seed)
+		if err != nil {
+			continue
+		}
+		all = append(all, parseWinPaths(out)...)
+	}
+	return normalizeAndDedupe(all), false, nil
+}

--- a/companion/internal/index/everything_test.go
+++ b/companion/internal/index/everything_test.go
@@ -16,8 +16,8 @@ import (
 // On Linux (CI), es is absent so Available()=false. All tests use a fakeRunner
 // so no real es binary is invoked.
 //
-// Regex invocation:  es -r -n 500 -- <pattern>   (native regex; degraded=false)
-// Substring invocation: es -n 500 -- <seed>       (per OR branch; degraded=false)
+// Regex invocation:  es -r -full-path-and-name -n 500 -- <pattern>   (native regex; degraded=false)
+// Substring invocation: es -full-path-and-name -n 500 -- <seed>       (per OR branch; degraded=false)
 
 func TestEverything_Capabilities(t *testing.T) {
 	idx := index.NewEverythingIndexer(&fakeRunner{})
@@ -88,6 +88,9 @@ func TestEverything_RegexMode_UsesMinusR(t *testing.T) {
 	if !argsContain(call.args, "-r") {
 		t.Error("regex mode must pass -r to es")
 	}
+	if !argsContain(call.args, "-full-path-and-name") {
+		t.Error("regex mode must pass -full-path-and-name to es")
+	}
 	if !argsContain(call.args, "-n") {
 		t.Error("expected -n flag for limit")
 	}
@@ -141,6 +144,9 @@ func TestEverything_SubstringMode_Command(t *testing.T) {
 	}
 	if argsContain(call.args, "-r") {
 		t.Error("substring mode must NOT pass -r to es")
+	}
+	if !argsContain(call.args, "-full-path-and-name") {
+		t.Error("substring mode must pass -full-path-and-name to es")
 	}
 	if !argsContain(call.args, "-n") {
 		t.Error("expected -n flag for limit")

--- a/companion/internal/index/everything_test.go
+++ b/companion/internal/index/everything_test.go
@@ -1,0 +1,394 @@
+package index_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// --- EverythingIndexer tests ---
+//
+// EverythingIndexer queries Voidtools Everything via the es CLI.
+// On Linux (CI), es is absent so Available()=false. All tests use a fakeRunner
+// so no real es binary is invoked.
+//
+// Regex invocation:  es -r -n 500 -- <pattern>   (native regex; degraded=false)
+// Substring invocation: es -n 500 -- <seed>       (per OR branch; degraded=false)
+
+func TestEverything_Capabilities(t *testing.T) {
+	idx := index.NewEverythingIndexer(&fakeRunner{})
+	caps := idx.Capabilities()
+	if !caps.BooleanOps {
+		t.Error("BooleanOps should be true")
+	}
+	if !caps.PrefixWildcard {
+		t.Error("PrefixWildcard should be true")
+	}
+	if !caps.InfixWildcard {
+		t.Error("InfixWildcard should be true")
+	}
+	if !caps.Regex {
+		t.Error("Regex should be true")
+	}
+	if !caps.PathScope {
+		t.Error("PathScope should be true")
+	}
+	if caps.Content {
+		t.Error("Content should be false")
+	}
+}
+
+func TestEverything_IDAndName(t *testing.T) {
+	idx := index.NewEverythingIndexer(&fakeRunner{})
+	if idx.ID() != "everything" {
+		t.Errorf("ID=%q want everything", idx.ID())
+	}
+	if idx.Name() != "Everything" {
+		t.Errorf("Name=%q want 'Everything'", idx.Name())
+	}
+}
+
+func TestEverything_RegexMode_UsesMinusR(t *testing.T) {
+	// Regex mode must invoke es with -r and pass the raw pattern after --.
+	// degraded must be false (Everything natively supports regex).
+	dir := t.TempDir()
+	f := filepath.Join(dir, "invoice.pdf")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n"}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse(`inv.*\.pdf`, query.ModeRegex)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false for regex mode (Everything has native regex)")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Path != f {
+		t.Errorf("path=%q want %q", results[0].Path, f)
+	}
+
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+	if call.name != "es" {
+		t.Errorf("binary=%q want es", call.name)
+	}
+	if !argsContain(call.args, "-r") {
+		t.Error("regex mode must pass -r to es")
+	}
+	if !argsContain(call.args, "-n") {
+		t.Error("expected -n flag for limit")
+	}
+	if !argsContain(call.args, "500") {
+		t.Error("expected limit 500")
+	}
+	ddIdx := argIndex(call.args, "--")
+	if ddIdx < 0 {
+		t.Fatal("expected -- in args")
+	}
+	patIdx := argIndex(call.args, `inv.*\.pdf`)
+	if patIdx < 0 {
+		t.Error("expected raw regex pattern in args")
+	}
+	if patIdx <= ddIdx {
+		t.Error("pattern must appear after --")
+	}
+}
+
+func TestEverything_SubstringMode_Command(t *testing.T) {
+	// Substring mode: es -n 500 -- <seed>, no -r flag.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "report.pdf")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n"}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse("report", query.ModeSimple)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false for substring mode")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Path != f {
+		t.Errorf("path=%q want %q", results[0].Path, f)
+	}
+
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+	if call.name != "es" {
+		t.Errorf("binary=%q want es", call.name)
+	}
+	if argsContain(call.args, "-r") {
+		t.Error("substring mode must NOT pass -r to es")
+	}
+	if !argsContain(call.args, "-n") {
+		t.Error("expected -n flag for limit")
+	}
+	if !argsContain(call.args, "500") {
+		t.Error("expected limit 500")
+	}
+	if !argsContain(call.args, "report") {
+		t.Error("expected seed 'report' in args")
+	}
+	ddIdx := argIndex(call.args, "--")
+	if ddIdx < 0 {
+		t.Fatal("expected -- in args")
+	}
+	seedIdx := argIndex(call.args, "report")
+	if seedIdx <= ddIdx {
+		t.Error("seed must appear after --")
+	}
+}
+
+func TestEverything_RegexMode_NotDegraded(t *testing.T) {
+	// Any regex query to Everything must return degraded=false.
+	fr := &fakeRunner{stdouts: []string{""}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse(`report`, query.ModeRegex)
+	_, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false: Everything has native regex support")
+	}
+}
+
+func TestEverything_ORQuery_TwoInvocations(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "alpha.txt")
+	f2 := filepath.Join(dir, "beta.txt")
+	writeTestFile(t, f1)
+	writeTestFile(t, f2)
+
+	fr := &fakeRunner{stdouts: []string{f1 + "\n", f2 + "\n"}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse("alpha | beta", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("expected 2 runner calls (one per OR branch), got %d", len(fr.calls))
+	}
+	seed0 := fr.calls[0].args[len(fr.calls[0].args)-1]
+	seed1 := fr.calls[1].args[len(fr.calls[1].args)-1]
+	if (seed0 != "alpha" || seed1 != "beta") && (seed0 != "beta" || seed1 != "alpha") {
+		t.Errorf("unexpected seeds %q, %q; want alpha and beta", seed0, seed1)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (union), got %d", len(results))
+	}
+}
+
+func TestEverything_MissingPathsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.txt")
+	writeTestFile(t, real)
+
+	stdout := real + "\nC:\\stale_everything_entry_99.txt\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse("real", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (stale skipped), got %d", len(results))
+	}
+	if results[0].Path != real {
+		t.Errorf("path=%q want %q", results[0].Path, real)
+	}
+}
+
+func TestEverything_DeduplicatePaths(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "dup.txt")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n", f + "\n"}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse("dup | dup", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 deduplicated result, got %d", len(results))
+	}
+}
+
+func TestEverything_PureNegation_NoCall(t *testing.T) {
+	fr := &fakeRunner{}
+	idx := index.NewEverythingIndexer(fr)
+
+	ast, _ := query.Parse("-foo", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for pure-negation branch, got %d", len(fr.calls))
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestEverything_ResultsNeverNil(t *testing.T) {
+	fr := &fakeRunner{stdouts: []string{""}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse("anything", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if results == nil {
+		t.Error("results must never be nil")
+	}
+}
+
+func TestEverything_BlankLinesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "note.txt")
+	writeTestFile(t, f)
+
+	stdout := "\n  \n" + f + "\n\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewEverythingIndexer(fr)
+	idx.Bin = "es"
+
+	ast, _ := query.Parse("note", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+}
+
+// --- Registry wiring tests for Windows backends ---
+
+var (
+	capsWSearch = protocol.Capabilities{
+		BooleanOps: true, PrefixWildcard: true, InfixWildcard: true,
+		Regex: false, PathScope: true, Content: true,
+	}
+	capsEverything = protocol.Capabilities{
+		BooleanOps: true, PrefixWildcard: true, InfixWildcard: true,
+		Regex: true, PathScope: true, Content: false,
+	}
+)
+
+func TestRegistry_WindowsBackends_InInfos(t *testing.T) {
+	// Both backends must appear in Infos() in priority order:
+	// everything (index 3) before wsearch (index 4) in priorityOrder.
+	everything := makeIdx("everything", "Everything", false, capsEverything)
+	wsearch := makeIdx("wsearch", "Windows Search", false, capsWSearch)
+
+	reg := index.NewRegistry([]index.Indexer{wsearch, everything}, "")
+	infos := reg.Infos()
+
+	if len(infos) != 2 {
+		t.Fatalf("Infos() len=%d want 2", len(infos))
+	}
+	if infos[0].ID != "everything" {
+		t.Errorf("infos[0].ID=%q want everything (higher priority)", infos[0].ID)
+	}
+	if infos[1].ID != "wsearch" {
+		t.Errorf("infos[1].ID=%q want wsearch", infos[1].ID)
+	}
+	if !infos[0].Capabilities.Regex {
+		t.Error("everything.Capabilities.Regex should be true")
+	}
+	if infos[1].Capabilities.Regex {
+		t.Error("wsearch.Capabilities.Regex should be false")
+	}
+	if !infos[1].Capabilities.Content {
+		t.Error("wsearch.Capabilities.Content should be true")
+	}
+	if infos[0].Capabilities.Content {
+		t.Error("everything.Capabilities.Content should be false")
+	}
+}
+
+func TestRegistry_RegexRouting_ToEverything(t *testing.T) {
+	// On Windows with Everything available, regex queries route to Everything
+	// (regex-capable) and degraded=false.
+	everything := makeIdx("everything", "Everything", true, capsEverything)
+	wsearch := makeIdx("wsearch", "Windows Search", true, capsWSearch)
+
+	reg := index.NewRegistry([]index.Indexer{wsearch, everything}, "")
+	if reg.Default() == nil {
+		t.Fatal("Default() must not be nil")
+	}
+	if reg.Default().ID() != "everything" {
+		t.Errorf("Default()=%q want everything (higher priority, available)", reg.Default().ID())
+	}
+
+	resp, err := reg.Search(context.Background(), protocol.SearchRequest{
+		Query: "report", QueryMode: query.ModeRegex, PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if resp.Indexer != "everything" {
+		t.Errorf("resp.Indexer=%q want everything (native regex routing)", resp.Indexer)
+	}
+	if resp.Degraded {
+		t.Error("resp.Degraded must be false when Everything is available for regex")
+	}
+}
+
+func TestRegistry_WindowsSearch_NoRegexCapable_FallsBackDegraded(t *testing.T) {
+	// If only WSearch is available (no regex-capable backend), a regex request
+	// falls back to the default and Degraded=true.
+	wsearch := makeIdx("wsearch", "Windows Search", true, capsWSearch)
+
+	reg := index.NewRegistry([]index.Indexer{wsearch}, "")
+	resp, err := reg.Search(context.Background(), protocol.SearchRequest{
+		Query: "report", QueryMode: query.ModeRegex, PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if resp.Indexer != "wsearch" {
+		t.Errorf("resp.Indexer=%q want wsearch (only available backend)", resp.Indexer)
+	}
+	if !resp.Degraded {
+		t.Error("resp.Degraded must be true when no regex-capable backend is available")
+	}
+}

--- a/companion/internal/index/exec.go
+++ b/companion/internal/index/exec.go
@@ -1,0 +1,29 @@
+package index
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Runner abstracts command execution so backends can be tested without shelling
+// out to real binaries. Inject ExecRunner{} for production use.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) (stdout []byte, err error)
+}
+
+// ExecRunner is the production Runner that shells out via exec.CommandContext.
+// stdout is captured and returned; stderr is discarded (index tools write
+// diagnostic output to stderr and meaningful results to stdout).
+type ExecRunner struct{}
+
+// Run executes name with the given args and returns its stdout.
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+// LookPath reports whether name is resolvable on PATH and returns the full
+// binary path. It wraps exec.LookPath so callers do not import os/exec.
+func LookPath(name string) (string, bool) {
+	path, err := exec.LookPath(name)
+	return path, err == nil
+}

--- a/companion/internal/index/indexer.go
+++ b/companion/internal/index/indexer.go
@@ -1,0 +1,65 @@
+package index
+
+import (
+	"context"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// Indexer is the abstraction over OS-specific file-index backends.
+// The pipeline always post-filters candidates with the matcher to guarantee
+// correctness regardless of what the backend returns.
+type Indexer interface {
+	// ID returns a short stable identifier for this indexer (e.g. "mem", "baloo").
+	ID() string
+	// Name returns a human-readable display name.
+	Name() string
+	// Available reports whether the backend is operational on this host.
+	Available() bool
+	// Capabilities describes what the backend supports natively.
+	Capabilities() protocol.Capabilities
+	// Query returns candidate results for the given AST. Backends may perform
+	// best-effort native narrowing; the pipeline ALWAYS post-filters with the
+	// matcher to guarantee correctness. degraded is true when the backend could
+	// not fully serve the requested mode (e.g. a regex satisfied by scanning a
+	// candidate set rather than a native index).
+	Query(ctx context.Context, ast query.Node, mode query.Mode, req protocol.SearchRequest) (results []protocol.FileResult, degraded bool, err error)
+}
+
+// MemIndexer is an in-memory Indexer for tests and development. It holds a
+// fixed slice of FileResults and returns them all verbatim on every Query call,
+// leaving all filtering, scoring, and sorting to the pipeline.
+type MemIndexer struct {
+	Items        []protocol.FileResult
+	Caps         protocol.Capabilities
+	IDVal        string
+	NameVal      string
+	AvailableVal bool
+	DegradedVal  bool
+}
+
+// NewMemIndexer creates a MemIndexer with sensible defaults (id "mem", name
+// "In-memory", available true) over the supplied items and capabilities.
+func NewMemIndexer(items []protocol.FileResult, caps protocol.Capabilities) *MemIndexer {
+	return &MemIndexer{
+		Items:        items,
+		Caps:         caps,
+		IDVal:        "mem",
+		NameVal:      "In-memory",
+		AvailableVal: true,
+	}
+}
+
+func (m *MemIndexer) ID() string                      { return m.IDVal }
+func (m *MemIndexer) Name() string                    { return m.NameVal }
+func (m *MemIndexer) Available() bool                 { return m.AvailableVal }
+func (m *MemIndexer) Capabilities() protocol.Capabilities { return m.Caps }
+
+// Query returns a copy of all Items. It performs no filtering so the pipeline's
+// matcher and filters are fully exercised in tests.
+func (m *MemIndexer) Query(_ context.Context, _ query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
+	out := make([]protocol.FileResult, len(m.Items))
+	copy(out, m.Items)
+	return out, m.DegradedVal, nil
+}

--- a/companion/internal/index/match.go
+++ b/companion/internal/index/match.go
@@ -9,13 +9,15 @@ import (
 )
 
 // Matches reports whether r satisfies the AST node n.
+// caseSensitive controls whether term and phrase comparisons are case-sensitive.
+// Regex nodes are unaffected by caseSensitive — the pattern's own flags control case.
 // mode is passed for completeness; the node shapes already encode
 // wildcard/regex semantics, so branching on mode is rarely needed.
-func Matches(r protocol.FileResult, n query.Node, mode query.Mode) bool {
+func Matches(r protocol.FileResult, n query.Node, mode query.Mode, caseSensitive bool) bool {
 	switch n.Op {
 	case "and":
 		for _, child := range n.Nodes {
-			if !Matches(r, child, mode) {
+			if !Matches(r, child, mode, caseSensitive) {
 				return false
 			}
 		}
@@ -23,7 +25,7 @@ func Matches(r protocol.FileResult, n query.Node, mode query.Mode) bool {
 
 	case "or":
 		for _, child := range n.Nodes {
-			if Matches(r, child, mode) {
+			if Matches(r, child, mode, caseSensitive) {
 				return true
 			}
 		}
@@ -33,20 +35,27 @@ func Matches(r protocol.FileResult, n query.Node, mode query.Mode) bool {
 		if n.Node == nil {
 			return true
 		}
-		return !Matches(r, *n.Node, mode)
+		return !Matches(r, *n.Node, mode, caseSensitive)
 
 	case "term":
 		field := resolveField(r, n.Field)
 		if n.Wildcard != nil && *n.Wildcard {
-			return globMatch(n.Value, field)
+			return globMatch(n.Value, field, caseSensitive)
+		}
+		if caseSensitive {
+			return strings.Contains(field, n.Value)
 		}
 		return strings.Contains(strings.ToLower(field), strings.ToLower(n.Value))
 
 	case "phrase":
 		field := resolveField(r, n.Field)
+		if caseSensitive {
+			return strings.Contains(field, n.Value)
+		}
 		return strings.Contains(strings.ToLower(field), strings.ToLower(n.Value))
 
 	case "regex":
+		// Regex is unaffected by caseSensitive; the pattern controls its own flags.
 		field := resolveField(r, n.Field)
 		re, err := regexp.Compile(n.Value)
 		if err != nil {
@@ -68,13 +77,18 @@ func resolveField(r protocol.FileResult, field string) string {
 	return r.Name
 }
 
-// globMatch performs an anchored case-insensitive glob match of pattern against s.
+// globMatch performs an anchored glob match of pattern against s.
 // Only * (match any sequence) and ? (match any single character) are wildcards;
 // all other regex metacharacters in pattern are escaped.
-func globMatch(pattern, s string) bool {
+// When caseSensitive is false (default) the match is case-insensitive via (?i).
+func globMatch(pattern, s string, caseSensitive bool) bool {
 	// Build an anchored regex from the glob pattern.
 	var sb strings.Builder
-	sb.WriteString("(?i)^")
+	if caseSensitive {
+		sb.WriteString("^")
+	} else {
+		sb.WriteString("(?i)^")
+	}
 	for _, ch := range pattern {
 		switch ch {
 		case '*':

--- a/companion/internal/index/match.go
+++ b/companion/internal/index/match.go
@@ -1,0 +1,94 @@
+package index
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// Matches reports whether r satisfies the AST node n.
+// mode is passed for completeness; the node shapes already encode
+// wildcard/regex semantics, so branching on mode is rarely needed.
+func Matches(r protocol.FileResult, n query.Node, mode query.Mode) bool {
+	switch n.Op {
+	case "and":
+		for _, child := range n.Nodes {
+			if !Matches(r, child, mode) {
+				return false
+			}
+		}
+		return true
+
+	case "or":
+		for _, child := range n.Nodes {
+			if Matches(r, child, mode) {
+				return true
+			}
+		}
+		return false
+
+	case "not":
+		if n.Node == nil {
+			return true
+		}
+		return !Matches(r, *n.Node, mode)
+
+	case "term":
+		field := resolveField(r, n.Field)
+		if n.Wildcard != nil && *n.Wildcard {
+			return globMatch(n.Value, field)
+		}
+		return strings.Contains(strings.ToLower(field), strings.ToLower(n.Value))
+
+	case "phrase":
+		field := resolveField(r, n.Field)
+		return strings.Contains(strings.ToLower(field), strings.ToLower(n.Value))
+
+	case "regex":
+		field := resolveField(r, n.Field)
+		re, err := regexp.Compile(n.Value)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(field)
+
+	default:
+		return false
+	}
+}
+
+// resolveField returns the FileResult field value for a given field name.
+// "path" maps to r.Path; all other values default to r.Name.
+func resolveField(r protocol.FileResult, field string) string {
+	if field == "path" {
+		return r.Path
+	}
+	return r.Name
+}
+
+// globMatch performs an anchored case-insensitive glob match of pattern against s.
+// Only * (match any sequence) and ? (match any single character) are wildcards;
+// all other regex metacharacters in pattern are escaped.
+func globMatch(pattern, s string) bool {
+	// Build an anchored regex from the glob pattern.
+	var sb strings.Builder
+	sb.WriteString("(?i)^")
+	for _, ch := range pattern {
+		switch ch {
+		case '*':
+			sb.WriteString(".*")
+		case '?':
+			sb.WriteByte('.')
+		default:
+			sb.WriteString(regexp.QuoteMeta(string(ch)))
+		}
+	}
+	sb.WriteString("$")
+	re, err := regexp.Compile(sb.String())
+	if err != nil {
+		return false
+	}
+	return re.MatchString(s)
+}

--- a/companion/internal/index/match_test.go
+++ b/companion/internal/index/match_test.go
@@ -20,6 +20,29 @@ func makeResult(name, path string) protocol.FileResult {
 	}
 }
 
+// TestMatches_CaseSensitive verifies that the caseSensitive flag is threaded
+// through Matches correctly: a query that matches case-insensitively should
+// not match when caseSensitive=true and the case differs.
+func TestMatches_CaseSensitive(t *testing.T) {
+	r := makeResult("report.pdf", "/home/alice/docs/report.pdf")
+
+	// "Report" has a capital R; the file name is all-lowercase.
+	n, err := query.Parse("Report", query.ModeSimple)
+	if err != nil {
+		t.Fatalf("query.Parse: %v", err)
+	}
+
+	// caseSensitive=false (default): case-insensitive comparison should match.
+	if !index.Matches(r, n, query.ModeSimple, false) {
+		t.Error("caseSensitive=false: 'Report' should match 'report.pdf' (case-insensitive)")
+	}
+
+	// caseSensitive=true: 'R' != 'r' so it must NOT match.
+	if index.Matches(r, n, query.ModeSimple, true) {
+		t.Error("caseSensitive=true: 'Report' should NOT match 'report.pdf'")
+	}
+}
+
 func TestMatches(t *testing.T) {
 	type tc struct {
 		name    string
@@ -184,7 +207,7 @@ func TestMatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("query.Parse(%q, %q): %v", c.queryS, c.mode, err)
 			}
-			got := index.Matches(c.result, n, c.mode)
+			got := index.Matches(c.result, n, c.mode, false) // default caseSensitive=false
 			if got != c.want {
 				t.Errorf("Matches(%q, %q) = %v, want %v", c.queryS, c.result.Name, got, c.want)
 			}

--- a/companion/internal/index/match_test.go
+++ b/companion/internal/index/match_test.go
@@ -1,0 +1,193 @@
+package index_test
+
+import (
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// makeResult builds a minimal FileResult for matcher tests.
+func makeResult(name, path string) protocol.FileResult {
+	return protocol.FileResult{
+		ID:   path,
+		Name: name,
+		Path: path,
+		Dir:  "/home/alice/docs",
+		Ext:  "pdf",
+		Type: protocol.FileTypeDocument,
+	}
+}
+
+func TestMatches(t *testing.T) {
+	type tc struct {
+		name    string
+		queryS  string
+		mode    query.Mode
+		result  protocol.FileResult
+		want    bool
+	}
+
+	cases := []tc{
+		// Substring term – hit
+		{
+			name:   "substring term hit",
+			queryS: "report",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   true,
+		},
+		// Substring term – miss
+		{
+			name:   "substring term miss",
+			queryS: "budget",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   false,
+		},
+		// Prefix substring hit (the term "ann" is a substring of "annual-...")
+		{
+			name:   "prefix substring hit",
+			queryS: "ann",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   true,
+		},
+		// Wildcard glob anchored hit – inv*.pdf matches invoice_2024.pdf
+		{
+			name:   "wildcard glob hit",
+			queryS: "inv*.pdf",
+			mode:   query.ModeWildcard,
+			result: makeResult("invoice_2024.pdf", "/home/bob/Invoices/invoice_2024.pdf"),
+			want:   true,
+		},
+		// Wildcard glob anchored near-miss – inv*.pdf should NOT match "invoice_2024.txt"
+		{
+			name:   "wildcard glob near-miss",
+			queryS: "inv*.pdf",
+			mode:   query.ModeWildcard,
+			result: makeResult("invoice_2024.txt", "/home/bob/Invoices/invoice_2024.txt"),
+			want:   false,
+		},
+		// Phrase with internal space
+		{
+			name:   "phrase with space hit",
+			queryS: `"annual report"`,
+			mode:   query.ModeSimple,
+			result: makeResult("annual report 2024.pdf", "/home/alice/docs/annual report 2024.pdf"),
+			want:   true,
+		},
+		{
+			name:   "phrase with space miss",
+			queryS: `"annual report"`,
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   false,
+		},
+		// Regex on name
+		{
+			name:   "regex on name hit",
+			queryS: `^budget_\d{4}\.xlsx$`,
+			mode:   query.ModeRegex,
+			result: makeResult("budget_2024.xlsx", "/home/bob/Finance/budget_2024.xlsx"),
+			want:   true,
+		},
+		{
+			name:   "regex on name miss",
+			queryS: `^budget_\d{4}\.xlsx$`,
+			mode:   query.ModeRegex,
+			result: makeResult("budget_summary.xlsx", "/home/bob/Finance/budget_summary.xlsx"),
+			want:   false,
+		},
+		// path: term matches on path but not name
+		{
+			name:   "path term matches path not name",
+			queryS: "path:Finance",
+			mode:   query.ModeSimple,
+			result: makeResult("report.pdf", "/home/bob/Finance/report.pdf"),
+			want:   true,
+		},
+		{
+			name:   "path term does not match when not in path",
+			queryS: "path:Finance",
+			mode:   query.ModeSimple,
+			result: makeResult("report.pdf", "/home/alice/Documents/report.pdf"),
+			want:   false,
+		},
+		// AND – both terms required
+		{
+			name:   "AND both match",
+			queryS: "annual report",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   true,
+		},
+		{
+			name:   "AND one missing",
+			queryS: "annual budget",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   false,
+		},
+		// OR – either term sufficient
+		{
+			name:   "OR first matches",
+			queryS: "annual | budget",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   true,
+		},
+		{
+			name:   "OR second matches",
+			queryS: "invoice | report",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   true,
+		},
+		{
+			name:   "OR neither matches",
+			queryS: "invoice | budget",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   false,
+		},
+		// NOT – excludes matching term
+		{
+			name:   "NOT excludes",
+			queryS: "-budget",
+			mode:   query.ModeSimple,
+			result: makeResult("budget_2024.xlsx", "/home/bob/Finance/budget_2024.xlsx"),
+			want:   false,
+		},
+		{
+			name:   "NOT passes when term absent",
+			queryS: "-budget",
+			mode:   query.ModeSimple,
+			result: makeResult("annual-report-2024.pdf", "/home/alice/docs/annual-report-2024.pdf"),
+			want:   true,
+		},
+		// Wildcard infix glob – *report* matches annual_report
+		{
+			name:   "wildcard infix glob hit",
+			queryS: "*report*",
+			mode:   query.ModeWildcard,
+			result: makeResult("annual_report.pdf", "/home/alice/docs/annual_report.pdf"),
+			want:   true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			n, err := query.Parse(c.queryS, c.mode)
+			if err != nil {
+				t.Fatalf("query.Parse(%q, %q): %v", c.queryS, c.mode, err)
+			}
+			got := index.Matches(c.result, n, c.mode)
+			if got != c.want {
+				t.Errorf("Matches(%q, %q) = %v, want %v", c.queryS, c.result.Name, got, c.want)
+			}
+		})
+	}
+}

--- a/companion/internal/index/normalize.go
+++ b/companion/internal/index/normalize.go
@@ -1,0 +1,51 @@
+package index
+
+import (
+	"mime"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+)
+
+// Normalize converts an absolute filesystem path into a FileResult.
+// It stats the path and returns an error if the path does not exist.
+//
+// CreatedAt is always set to 0: retrieving birth-time on Linux requires
+// statx(STATX_BTIME), which is a deliberate later, platform-specific
+// enhancement. This normalizer intentionally stays cross-platform/stdlib.
+func Normalize(path string) (protocol.FileResult, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return protocol.FileResult{}, err
+	}
+
+	r := protocol.FileResult{
+		ID:         path,
+		Name:       filepath.Base(path),
+		Path:       path,
+		Dir:        filepath.Dir(path),
+		ModifiedAt: info.ModTime().UnixMilli(),
+		// Score and IconHint are filled in later by the pipeline.
+	}
+
+	if info.IsDir() {
+		r.Type = protocol.FileTypeFolder
+		// Size, Ext, and Mime remain zero values for directories.
+	} else {
+		r.Size = info.Size()
+		r.Ext = strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
+		r.Type = ClassifyType(r.Ext)
+		if r.Ext != "" {
+			full := mime.TypeByExtension("." + r.Ext)
+			// Strip any "; param=value" suffix — callers only need the type.
+			if idx := strings.Index(full, ";"); idx >= 0 {
+				full = strings.TrimSpace(full[:idx])
+			}
+			r.Mime = full
+		}
+	}
+
+	return r, nil
+}

--- a/companion/internal/index/normalize_test.go
+++ b/companion/internal/index/normalize_test.go
@@ -1,0 +1,130 @@
+package index_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+)
+
+func TestNormalize_MissingPath(t *testing.T) {
+	_, err := index.Normalize("/nonexistent/path/that/does/not/exist.txt")
+	if err == nil {
+		t.Error("expected error for missing path, got nil")
+	}
+}
+
+func TestNormalize_RegularFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.pdf")
+	if err := os.WriteFile(path, []byte("hello pdf"), 0o644); err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
+
+	r, err := index.Normalize(path)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	if r.Name != "report.pdf" {
+		t.Errorf("Name: got %q, want %q", r.Name, "report.pdf")
+	}
+	if r.Dir != dir {
+		t.Errorf("Dir: got %q, want %q", r.Dir, dir)
+	}
+	if r.Ext != "pdf" {
+		t.Errorf("Ext: got %q, want %q", r.Ext, "pdf")
+	}
+	if r.Type != protocol.FileTypeDocument {
+		t.Errorf("Type: got %q, want %q", r.Type, protocol.FileTypeDocument)
+	}
+	if r.Size != 9 {
+		t.Errorf("Size: got %d, want 9", r.Size)
+	}
+	if r.ModifiedAt == 0 {
+		t.Error("ModifiedAt should be non-zero for a real file")
+	}
+	if r.ID != path {
+		t.Errorf("ID: got %q, want %q", r.ID, path)
+	}
+	if r.Path != path {
+		t.Errorf("Path: got %q, want %q", r.Path, path)
+	}
+	// Mime should be non-empty for a known extension.
+	if r.Mime == "" {
+		t.Error("Mime should be non-empty for .pdf")
+	}
+	// CreatedAt is always 0 (birth-time not available cross-platform).
+	if r.CreatedAt != 0 {
+		t.Errorf("CreatedAt: got %d, want 0", r.CreatedAt)
+	}
+}
+
+func TestNormalize_UpperCaseExt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "PHOTO.PNG")
+	if err := os.WriteFile(path, []byte("png data"), 0o644); err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
+
+	r, err := index.Normalize(path)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if r.Ext != "png" {
+		t.Errorf("Ext: got %q, want %q (ext should be lowercased)", r.Ext, "png")
+	}
+	if r.Type != protocol.FileTypeImage {
+		t.Errorf("Type: got %q, want %q", r.Type, protocol.FileTypeImage)
+	}
+}
+
+func TestNormalize_Directory(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "mydir")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+
+	r, err := index.Normalize(subdir)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if r.Type != protocol.FileTypeFolder {
+		t.Errorf("Type: got %q, want %q", r.Type, protocol.FileTypeFolder)
+	}
+	if r.Size != 0 {
+		t.Errorf("Size: got %d, want 0 for directory", r.Size)
+	}
+	if r.Ext != "" {
+		t.Errorf("Ext: got %q, want empty for directory", r.Ext)
+	}
+	if r.Mime != "" {
+		t.Errorf("Mime: got %q, want empty for directory", r.Mime)
+	}
+}
+
+func TestNormalize_NoExtension(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Makefile")
+	if err := os.WriteFile(path, []byte("all:"), 0o644); err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
+
+	r, err := index.Normalize(path)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if r.Ext != "" {
+		t.Errorf("Ext: got %q, want empty for no-extension file", r.Ext)
+	}
+	if r.Type != protocol.FileTypeOther {
+		t.Errorf("Type: got %q, want %q", r.Type, protocol.FileTypeOther)
+	}
+	// Mime should be empty for unknown extension.
+	if r.Mime != "" {
+		t.Errorf("Mime: got %q, want empty for unknown extension", r.Mime)
+	}
+}

--- a/companion/internal/index/pipeline.go
+++ b/companion/internal/index/pipeline.go
@@ -84,7 +84,7 @@ func Search(ctx context.Context, idx Indexer, req protocol.SearchRequest) (proto
 			if hi > total {
 				hi = total
 			}
-			pageSlice = filtered[lo:hi]
+			pageSlice = append([]protocol.FileResult(nil), filtered[lo:hi]...)
 		}
 	}
 	if pageSlice == nil {
@@ -165,8 +165,10 @@ func coerceFieldsToName(n query.Node) query.Node {
 	}
 }
 
-// collectTerms recursively collects the Value of every term/phrase leaf in the
-// AST. Regex nodes are excluded — they don't contribute to name-bucket scoring.
+// collectTerms recursively collects the Value of every positive term/phrase leaf
+// in the AST. Regex nodes are excluded (they don't contribute to name-bucket
+// scoring). NOT subtrees are also skipped so negative terms like "-spam" in
+// "report -spam" never inflate a score.
 func collectTerms(n query.Node) []string {
 	var terms []string
 	var walk func(query.Node)
@@ -176,10 +178,7 @@ func collectTerms(n query.Node) []string {
 			for _, child := range n.Nodes {
 				walk(child)
 			}
-		case "not":
-			if n.Node != nil {
-				walk(*n.Node)
-			}
+		// "not": intentionally skipped — negative terms must not influence scoring.
 		case "term", "phrase":
 			terms = append(terms, n.Value)
 		// "regex": intentionally excluded from scoring

--- a/companion/internal/index/pipeline.go
+++ b/companion/internal/index/pipeline.go
@@ -29,6 +29,12 @@ func Search(ctx context.Context, idx Indexer, req protocol.SearchRequest) (proto
 		return protocol.SearchResponse{}, err
 	}
 
+	// ExactPhrase: treat the whole query as one ordered phrase (non-regex only).
+	// Regex mode ignores ExactPhrase; the pattern is already the entire query.
+	if req.ExactPhrase && req.QueryMode != query.ModeRegex {
+		ast = query.Node{Op: "phrase", Field: "name", Value: strings.TrimSpace(req.Query)}
+	}
+
 	raw, degraded, err := idx.Query(ctx, ast, req.QueryMode, req)
 	if err != nil {
 		return protocol.SearchResponse{}, err
@@ -45,7 +51,7 @@ func Search(ctx context.Context, idx Indexer, req protocol.SearchRequest) (proto
 	// Post-filter: guarantee correctness via the matcher.
 	filtered := make([]protocol.FileResult, 0, len(raw))
 	for _, r := range raw {
-		if Matches(r, matchAst, req.QueryMode) {
+		if Matches(r, matchAst, req.QueryMode, req.CaseSensitive) {
 			filtered = append(filtered, r)
 		}
 	}

--- a/companion/internal/index/pipeline.go
+++ b/companion/internal/index/pipeline.go
@@ -1,0 +1,345 @@
+package index
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// Search runs the full search pipeline:
+//  1. Parse the query; return an error (mapped to bad_request by the server) on failure.
+//  2. Fetch candidates from the indexer.
+//  3. Post-filter with the matcher for correctness:
+//     - TitleOnly=false: broaden each "name"-scoped leaf to also match "path",
+//       so a plain term like "report" matches both filenames and path components.
+//     - TitleOnly=true: coerce all leaf fields to "name" so path-only hits are excluded.
+//  4. Apply request filters (Types, ModifiedRange, CreatedRange, PathPrefix).
+//  5. Score each result (nameBucket×10 + historyBoost + recency).
+//  6. Stable-sort (relevance/created/modified × asc/desc) with Name/Path tiebreak.
+//  7. Paginate and return a SearchResponse with a non-nil Results slice.
+func Search(ctx context.Context, idx Indexer, req protocol.SearchRequest) (protocol.SearchResponse, error) {
+	start := time.Now()
+
+	ast, err := query.Parse(req.Query, req.QueryMode)
+	if err != nil {
+		return protocol.SearchResponse{}, err
+	}
+
+	raw, degraded, err := idx.Query(ctx, ast, req.QueryMode, req)
+	if err != nil {
+		return protocol.SearchResponse{}, err
+	}
+
+	// Build the match AST based on TitleOnly.
+	var matchAst query.Node
+	if req.Filters.TitleOnly {
+		matchAst = coerceFieldsToName(ast)
+	} else {
+		matchAst = broadenToPath(ast)
+	}
+
+	// Post-filter: guarantee correctness via the matcher.
+	filtered := make([]protocol.FileResult, 0, len(raw))
+	for _, r := range raw {
+		if Matches(r, matchAst, req.QueryMode) {
+			filtered = append(filtered, r)
+		}
+	}
+
+	// Apply request filters.
+	filtered = applyFilters(filtered, req.Filters)
+
+	// Score each surviving result.
+	terms := collectTerms(ast)
+	for i := range filtered {
+		filtered[i].Score = scoreResult(filtered[i], terms, req.History)
+	}
+
+	// Sort results.
+	sortResults(filtered, req.Sort)
+
+	total := len(filtered)
+
+	// Paginate.
+	page := req.Page
+	if page < 0 {
+		page = 0
+	}
+	size := req.PageSize
+
+	var pageSlice []protocol.FileResult
+	if size <= 0 {
+		// PageSize <= 0 means "return all"; tests always pass a positive size.
+		pageSlice = filtered
+	} else {
+		lo := page * size
+		hi := lo + size
+		if lo >= total {
+			pageSlice = []protocol.FileResult{} // out-of-range page → empty, not nil
+		} else {
+			if hi > total {
+				hi = total
+			}
+			pageSlice = filtered[lo:hi]
+		}
+	}
+	if pageSlice == nil {
+		pageSlice = []protocol.FileResult{}
+	}
+
+	return protocol.SearchResponse{
+		Results:  pageSlice,
+		Total:    total,
+		Page:     page,
+		TookMs:   time.Since(start).Milliseconds(),
+		Indexer:  idx.ID(),
+		Degraded: degraded,
+	}, nil
+}
+
+// broadenToPath expands every leaf node with field="name" into an OR that also
+// checks field="path". This is the default (TitleOnly=false) behaviour: a plain
+// term like "report" matches both filenames and directory path components.
+// Leaves that already carry an explicit field (e.g. path:Finance) are unchanged.
+func broadenToPath(n query.Node) query.Node {
+	switch n.Op {
+	case "and", "or":
+		children := make([]query.Node, len(n.Nodes))
+		for i, child := range n.Nodes {
+			children[i] = broadenToPath(child)
+		}
+		out := n
+		out.Nodes = children
+		return out
+	case "not":
+		if n.Node == nil {
+			return n
+		}
+		inner := broadenToPath(*n.Node)
+		out := n
+		out.Node = &inner
+		return out
+	case "term", "phrase", "regex":
+		if n.Field != "name" {
+			return n
+		}
+		pathLeaf := n
+		pathLeaf.Field = "path"
+		return query.Node{Op: "or", Nodes: []query.Node{n, pathLeaf}}
+	default:
+		return n
+	}
+}
+
+// coerceFieldsToName returns a copy of the AST with every leaf's Field set to
+// "name". Used when TitleOnly=true so path-scoped queries match only filenames
+// and path-only hits are excluded from results.
+func coerceFieldsToName(n query.Node) query.Node {
+	switch n.Op {
+	case "and", "or":
+		children := make([]query.Node, len(n.Nodes))
+		for i, child := range n.Nodes {
+			children[i] = coerceFieldsToName(child)
+		}
+		out := n
+		out.Nodes = children
+		return out
+	case "not":
+		if n.Node == nil {
+			return n
+		}
+		inner := coerceFieldsToName(*n.Node)
+		out := n
+		out.Node = &inner
+		return out
+	case "term", "phrase", "regex":
+		out := n
+		out.Field = "name"
+		return out
+	default:
+		return n
+	}
+}
+
+// collectTerms recursively collects the Value of every term/phrase leaf in the
+// AST. Regex nodes are excluded — they don't contribute to name-bucket scoring.
+func collectTerms(n query.Node) []string {
+	var terms []string
+	var walk func(query.Node)
+	walk = func(n query.Node) {
+		switch n.Op {
+		case "and", "or":
+			for _, child := range n.Nodes {
+				walk(child)
+			}
+		case "not":
+			if n.Node != nil {
+				walk(*n.Node)
+			}
+		case "term", "phrase":
+			terms = append(terms, n.Value)
+		// "regex": intentionally excluded from scoring
+		}
+	}
+	walk(n)
+	return terms
+}
+
+// applyFilters applies each request filter independently, in-place.
+// CreatedRange: if any bound is set and r.CreatedAt==0 (birth-time unknown on
+// this host), the result is excluded — we cannot prove it falls in range.
+func applyFilters(results []protocol.FileResult, f protocol.Filters) []protocol.FileResult {
+	out := results[:0]
+	for _, r := range results {
+		// Types filter.
+		if len(f.Types) > 0 {
+			matched := false
+			for _, t := range f.Types {
+				if r.Type == t {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		// ModifiedRange filter: a bound of 0 means unbounded on that side.
+		if f.ModifiedRange != nil {
+			if f.ModifiedRange.From != 0 && r.ModifiedAt < f.ModifiedRange.From {
+				continue
+			}
+			if f.ModifiedRange.To != 0 && r.ModifiedAt > f.ModifiedRange.To {
+				continue
+			}
+		}
+
+		// CreatedRange filter: if any bound is set and createdAt is 0 (unknown), exclude.
+		if f.CreatedRange != nil {
+			hasBound := f.CreatedRange.From != 0 || f.CreatedRange.To != 0
+			if hasBound && r.CreatedAt == 0 {
+				continue
+			}
+			if f.CreatedRange.From != 0 && r.CreatedAt < f.CreatedRange.From {
+				continue
+			}
+			if f.CreatedRange.To != 0 && r.CreatedAt > f.CreatedRange.To {
+				continue
+			}
+		}
+
+		// PathPrefix filter.
+		if f.PathPrefix != "" && !strings.HasPrefix(r.Path, f.PathPrefix) {
+			continue
+		}
+
+		out = append(out, r)
+	}
+	return out
+}
+
+// Scoring weights:
+//   - nameBucket × 10: name-prefix match = 30, name-substring = 20,
+//     path-only match = 10, no match = 0.
+//   - historyBoost = 5: result ID appears in req.History.
+//   - recency = ModifiedAt / 2e13: small tiebreaker in [0, 1) for reasonable
+//     timestamps (≈ 0.05–0.065 for years 2001–2011); 0 when ModifiedAt is 0.
+//
+// Scoring is intentionally light — OS indexers do their own ranking; we only
+// re-rank lightly to surface name-matches above path-only hits (issue #25).
+func scoreResult(r protocol.FileResult, terms []string, history []string) float64 {
+	nameLower := strings.ToLower(r.Name)
+	pathLower := strings.ToLower(r.Path)
+
+	nameBucket := 0
+	for _, t := range terms {
+		if strings.HasPrefix(nameLower, strings.ToLower(t)) {
+			nameBucket = 3
+			break
+		}
+	}
+	if nameBucket == 0 {
+		for _, t := range terms {
+			if strings.Contains(nameLower, strings.ToLower(t)) {
+				nameBucket = 2
+				break
+			}
+		}
+	}
+	if nameBucket == 0 {
+		for _, t := range terms {
+			if strings.Contains(pathLower, strings.ToLower(t)) {
+				nameBucket = 1
+				break
+			}
+		}
+	}
+
+	historyBoost := 0.0
+	for _, id := range history {
+		if id == r.ID {
+			historyBoost = 5
+			break
+		}
+	}
+
+	recency := 0.0
+	if r.ModifiedAt != 0 {
+		recency = float64(r.ModifiedAt) / 2e13
+	}
+
+	return float64(nameBucket*10) + historyBoost + recency
+}
+
+// sortResults sorts results in-place according to the sort spec. Missing Field
+// defaults to "relevance"; missing Dir defaults to "desc". The sort is stable
+// with a deterministic tiebreak on Name (asc) then Path (asc) so equal primary
+// keys always produce the same order across runs.
+func sortResults(results []protocol.FileResult, s protocol.Sort) {
+	field := s.Field
+	if field == "" {
+		field = "relevance"
+	}
+	dir := s.Dir
+	if dir == "" {
+		dir = "desc"
+	}
+	asc := dir == "asc"
+
+	sort.SliceStable(results, func(i, j int) bool {
+		a, b := results[i], results[j]
+		switch field {
+		case "created":
+			if a.CreatedAt != b.CreatedAt {
+				if asc {
+					return a.CreatedAt < b.CreatedAt
+				}
+				return a.CreatedAt > b.CreatedAt
+			}
+		case "modified":
+			if a.ModifiedAt != b.ModifiedAt {
+				if asc {
+					return a.ModifiedAt < b.ModifiedAt
+				}
+				return a.ModifiedAt > b.ModifiedAt
+			}
+		default: // "relevance"
+			if a.Score != b.Score {
+				if asc {
+					return a.Score < b.Score
+				}
+				return a.Score > b.Score
+			}
+		}
+		// Deterministic tiebreak: Name asc, then Path asc.
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.Path < b.Path
+	})
+}

--- a/companion/internal/index/pipeline_test.go
+++ b/companion/internal/index/pipeline_test.go
@@ -516,6 +516,44 @@ func TestSearch_RegexPathBroadening(t *testing.T) {
 	}
 }
 
+// TestSearch_ExactPhrase verifies the ExactPhrase option: a 2-word query
+// matches both results as AND'd terms (default), but only the file whose
+// name contains the exact contiguous phrase when ExactPhrase=true.
+func TestSearch_ExactPhrase(t *testing.T) {
+	// p1: both words present but joined with underscore (not a space).
+	// p2: both words present as a contiguous phrase with a space.
+	phraseCorpus := []protocol.FileResult{
+		{ID: "p1", Name: "annual_report.pdf", Path: "/docs/annual_report.pdf", Dir: "/docs", Ext: "pdf", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts1},
+		{ID: "p2", Name: "annual report.pdf", Path: "/docs/annual report.pdf", Dir: "/docs", Ext: "pdf", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts1},
+	}
+	idx := index.NewMemIndexer(phraseCorpus, protocol.Capabilities{})
+
+	// ExactPhrase=false (default): "annual report" is AND'd; both p1 and p2 match.
+	req := newSearch("annual report")
+	req.ExactPhrase = false
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (ExactPhrase=false): %v", err)
+	}
+	if resp.Total != 2 {
+		t.Errorf("ExactPhrase=false: want 2 results (AND match), got %d: %v", resp.Total, resultIDs(resp.Results))
+	}
+
+	// ExactPhrase=true: the whole query is one ordered phrase; only p2 matches
+	// ("annual report" is a contiguous substring of its name; p1 has an underscore).
+	req.ExactPhrase = true
+	resp, err = index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (ExactPhrase=true): %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("ExactPhrase=true: want 1 result (phrase match only), got %d: %v", resp.Total, resultIDs(resp.Results))
+	}
+	if resp.Total == 1 && resp.Results[0].ID != "p2" {
+		t.Errorf("ExactPhrase=true: want p2 (phrase match), got %q", resp.Results[0].ID)
+	}
+}
+
 func TestSearch_EmptyQueryError(t *testing.T) {
 	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
 	req := protocol.SearchRequest{

--- a/companion/internal/index/pipeline_test.go
+++ b/companion/internal/index/pipeline_test.go
@@ -398,6 +398,124 @@ func TestSearch_NonNilEmptyResults(t *testing.T) {
 	}
 }
 
+// financeCorpus is a small fixture used by path-scope and regex-broadening tests.
+//
+//	g1 – "Finance" in path dir only; name is neutral
+//	g2 – "Finance" in name only; path dir is neutral (name appears in path but dir doesn't contain Finance)
+//	g3 – "Finance" in both name and path
+//	g4 – "Finance" nowhere
+//
+// NOTE: In g2, the Path field is set to a directory that does not contain the
+// word "Finance", so Path="/accounting/budget.xlsx" while Name="Finance_plan.xlsx".
+// This lets us distinguish name-only vs path-only matches cleanly.
+var financeCorpus = []protocol.FileResult{
+	{ID: "g1", Name: "quarterly.pdf", Path: "/Finance/quarterly.pdf", Dir: "/Finance", Ext: "pdf", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts1},
+	{ID: "g2", Name: "Finance_plan.xlsx", Path: "/accounting/budget.xlsx", Dir: "/accounting", Ext: "xlsx", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts1},
+	{ID: "g3", Name: "Finance_summary.pdf", Path: "/Finance/Finance_summary.pdf", Dir: "/Finance", Ext: "pdf", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts1},
+	{ID: "g4", Name: "budget.csv", Path: "/other/budget.csv", Dir: "/other", Ext: "csv", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts1},
+}
+
+// TestSearch_ExplicitPathScope verifies that an explicit path:-scoped term is
+// never broadened to also check the name field (TitleOnly=false), and that
+// TitleOnly=true coerces the path: leaf to a name check instead.
+func TestSearch_ExplicitPathScope(t *testing.T) {
+	idx := index.NewMemIndexer(financeCorpus, protocol.Capabilities{})
+
+	// TitleOnly=false: explicit path:Finance leaf stays path-scoped (broadenToPath
+	// only widens name-field leaves). So only files with "Finance" in their PATH
+	// match; a file with "Finance" only in its name does NOT match.
+	req := newSearch("path:Finance")
+	req.Filters.TitleOnly = false
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (path:Finance, TitleOnly=false): %v", err)
+	}
+	// g1 and g3 have Finance in their path → must match.
+	// g2 has Finance only in its name, not path → must NOT match.
+	// g4 has Finance nowhere → must NOT match.
+	foundG1, foundG3 := false, false
+	for _, r := range resp.Results {
+		switch r.ID {
+		case "g1":
+			foundG1 = true
+		case "g2":
+			t.Error("TitleOnly=false: g2 (Finance only in name, path lacks it) must NOT match explicit path:Finance — path: leaf must not be broadened to name")
+		case "g3":
+			foundG3 = true
+		case "g4":
+			t.Error("TitleOnly=false: g4 (Finance nowhere) must NOT match")
+		}
+	}
+	if !foundG1 {
+		t.Error("TitleOnly=false: g1 (Finance in path dir, not in name) must match explicit path:Finance")
+	}
+	if !foundG3 {
+		t.Error("TitleOnly=false: g3 (Finance in both name and path) must match explicit path:Finance")
+	}
+
+	// TitleOnly=true: coerceFieldsToName forces the path: leaf to evaluate
+	// against the name field. Outcome: g2 (Finance in name) and g3 (Finance in
+	// both) now match; g1 (Finance only in path dir, not in name) no longer does.
+	req.Filters.TitleOnly = true
+	resp, err = index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (path:Finance, TitleOnly=true): %v", err)
+	}
+	foundG2, foundG3 := false, false
+	for _, r := range resp.Results {
+		switch r.ID {
+		case "g1":
+			t.Error("TitleOnly=true: g1 (Finance only in path, not name) must NOT match once path: is coerced to name-check")
+		case "g2":
+			foundG2 = true
+		case "g3":
+			foundG3 = true
+		case "g4":
+			t.Error("TitleOnly=true: g4 (Finance nowhere) must NOT match")
+		}
+	}
+	if !foundG2 {
+		t.Error("TitleOnly=true: g2 (Finance in name) must match — path: leaf coerced to name-check")
+	}
+	if !foundG3 {
+		t.Error("TitleOnly=true: g3 (Finance in both name and path) must match")
+	}
+}
+
+// TestSearch_RegexPathBroadening verifies that a regex-mode query without an
+// explicit path: prefix is broadened to name-OR-path (TitleOnly=false), so a
+// file whose PATH matches the pattern is included even when the name does not.
+func TestSearch_RegexPathBroadening(t *testing.T) {
+	idx := index.NewMemIndexer(financeCorpus, protocol.Capabilities{})
+
+	// "Finance" in regex mode produces a regex leaf with field="name".
+	// broadenToPath then wraps it as OR(name-regex, path-regex), so g1
+	// (Finance in path dir, not in name) is returned.
+	req := newSearch("Finance")
+	req.QueryMode = query.ModeRegex
+	req.Filters.TitleOnly = false
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (regex Finance, TitleOnly=false): %v", err)
+	}
+	// g1 matches via path, g2 via name, g3 via both; g4 matches neither.
+	foundG1 := false
+	for _, r := range resp.Results {
+		switch r.ID {
+		case "g1":
+			foundG1 = true
+		case "g4":
+			t.Error("regex TitleOnly=false: g4 (Finance nowhere) must NOT match")
+		}
+	}
+	if !foundG1 {
+		t.Error("regex TitleOnly=false: g1 (Finance in path only) must match — regex leaves are broadened to name-OR-path")
+	}
+	if resp.Total != 3 {
+		t.Errorf("regex TitleOnly=false: want 3 results (g1, g2, g3), got %d: %v", resp.Total, resultIDs(resp.Results))
+	}
+}
+
 func TestSearch_EmptyQueryError(t *testing.T) {
 	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
 	req := protocol.SearchRequest{

--- a/companion/internal/index/pipeline_test.go
+++ b/companion/internal/index/pipeline_test.go
@@ -1,0 +1,411 @@
+package index_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// Fixed timestamps in ascending order (milliseconds since epoch).
+const (
+	ts0 = int64(1000000000000) // ~Sep 2001
+	ts1 = int64(1100000000000) // ~Sep 2004
+	ts2 = int64(1200000000000) // ~Jan 2008
+	ts3 = int64(1300000000000) // ~Mar 2011
+)
+
+// testCorpus is a small fixed FileResult set used across pipeline tests.
+//
+//	a  – "report" prefix in Name, document type, under /docs/, created ts0
+//	b  – "report" substring in Name, document type, under /docs/, created ts1
+//	c  – "report" only in Path (not Name), document type, unknown createdAt (0)
+//	d  – no "report" anywhere, video type
+//	e  – "report" prefix in Name, code type, under /code/
+//	f1 – "report" substring in Name, other type, ModifiedAt=ts1 (tiebreak pair with f2)
+//	f2 – "report" substring in Name, other type, ModifiedAt=ts1 (tiebreak pair with f1)
+var testCorpus = []protocol.FileResult{
+	{ID: "a", Name: "report_q1.pdf", Path: "/docs/report_q1.pdf", Dir: "/docs", Ext: "pdf", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts0},
+	{ID: "b", Name: "annual_report.pdf", Path: "/docs/annual_report.pdf", Dir: "/docs", Ext: "pdf", Type: protocol.FileTypeDocument, ModifiedAt: ts2, CreatedAt: ts1},
+	{ID: "c", Name: "summary.txt", Path: "/reports/summary.txt", Dir: "/reports", Ext: "txt", Type: protocol.FileTypeDocument, ModifiedAt: ts3, CreatedAt: 0},
+	{ID: "d", Name: "vacation.mp4", Path: "/videos/vacation.mp4", Dir: "/videos", Ext: "mp4", Type: protocol.FileTypeVideo, ModifiedAt: ts0, CreatedAt: ts0},
+	{ID: "e", Name: "report_gen.py", Path: "/code/report_gen.py", Dir: "/code", Ext: "py", Type: protocol.FileTypeCode, ModifiedAt: ts2, CreatedAt: ts2},
+	{ID: "f1", Name: "b_report.log", Path: "/logs/b_report.log", Dir: "/logs", Ext: "log", Type: protocol.FileTypeOther, ModifiedAt: ts1, CreatedAt: ts1},
+	{ID: "f2", Name: "a_report.log", Path: "/logs/a_report.log", Dir: "/logs", Ext: "log", Type: protocol.FileTypeOther, ModifiedAt: ts1, CreatedAt: ts1},
+}
+
+// newSearch builds a minimal SearchRequest with sensible defaults.
+func newSearch(q string) protocol.SearchRequest {
+	return protocol.SearchRequest{
+		Query:     q,
+		QueryMode: query.ModeSimple,
+		Sort:      protocol.Sort{Field: "relevance", Dir: "desc"},
+		PageSize:  100,
+	}
+}
+
+// resultIDs returns the IDs of the results in order, for diagnostic messages.
+func resultIDs(results []protocol.FileResult) []string {
+	out := make([]string, len(results))
+	for i, r := range results {
+		out[i] = r.ID
+	}
+	return out
+}
+
+func TestSearch_BasicMatch(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	resp, err := index.Search(context.Background(), idx, newSearch("report"))
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// a, b, c, e, f1, f2 match "report"; d does not.
+	if resp.Total != 6 {
+		t.Errorf("Total = %d, want 6; results: %v", resp.Total, resultIDs(resp.Results))
+	}
+	for _, r := range resp.Results {
+		if r.ID == "d" {
+			t.Error("result 'd' (vacation.mp4) should not match 'report'")
+		}
+	}
+}
+
+func TestSearch_TypeFilter(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	req := newSearch("report")
+	req.Filters.Types = []protocol.FileType{protocol.FileTypeDocument}
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// a, b, c are documents that match "report"; e (code) and f1/f2 (other) are excluded.
+	wantIDs := map[string]bool{"a": true, "b": true, "c": true}
+	if resp.Total != 3 {
+		t.Errorf("Total = %d, want 3; results: %v", resp.Total, resultIDs(resp.Results))
+	}
+	for _, r := range resp.Results {
+		if !wantIDs[r.ID] {
+			t.Errorf("unexpected result %q (type=%s) with Types filter=[document]", r.ID, r.Type)
+		}
+	}
+}
+
+func TestSearch_ModifiedRangeFilter(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	req := newSearch("report")
+	req.Filters.ModifiedRange = &protocol.DateRange{From: ts2} // ts2 and ts3 pass; ts1 excluded
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// b(ts2), c(ts3), e(ts2) pass; a(ts1), f1(ts1), f2(ts1) excluded.
+	wantIDs := map[string]bool{"b": true, "c": true, "e": true}
+	if resp.Total != 3 {
+		t.Errorf("Total = %d, want 3; results: %v", resp.Total, resultIDs(resp.Results))
+	}
+	for _, r := range resp.Results {
+		if !wantIDs[r.ID] {
+			t.Errorf("unexpected result %q (modifiedAt=%d) with modifiedRange.From=%d", r.ID, r.ModifiedAt, ts2)
+		}
+	}
+}
+
+func TestSearch_CreatedRangeFilter_ExcludesUnknown(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	req := newSearch("report")
+	// From is set, so any result with createdAt==0 (unknown) must be excluded.
+	req.Filters.CreatedRange = &protocol.DateRange{From: ts0}
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// c has createdAt=0 → excluded; a(ts0), b(ts1), e(ts2), f1(ts1), f2(ts1) pass.
+	if resp.Total != 5 {
+		t.Errorf("Total = %d, want 5 (c excluded due to unknown createdAt); results: %v", resp.Total, resultIDs(resp.Results))
+	}
+	for _, r := range resp.Results {
+		if r.ID == "c" {
+			t.Error("result 'c' (createdAt=0) should be excluded when a createdRange bound is set")
+		}
+	}
+}
+
+func TestSearch_PathPrefixFilter(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	req := newSearch("report")
+	req.Filters.PathPrefix = "/docs/"
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// Only a and b are under /docs/.
+	wantIDs := map[string]bool{"a": true, "b": true}
+	if resp.Total != 2 {
+		t.Errorf("Total = %d, want 2; results: %v", resp.Total, resultIDs(resp.Results))
+	}
+	for _, r := range resp.Results {
+		if !wantIDs[r.ID] {
+			t.Errorf("unexpected result %q (path=%s) with pathPrefix=/docs/", r.ID, r.Path)
+		}
+	}
+}
+
+func TestSearch_TitleOnly(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+
+	// Without TitleOnly: c matches via its path (/reports/summary.txt).
+	req := newSearch("report")
+	req.Filters.TitleOnly = false
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (TitleOnly=false): %v", err)
+	}
+	foundC := false
+	for _, r := range resp.Results {
+		if r.ID == "c" {
+			foundC = true
+		}
+	}
+	if !foundC {
+		t.Error("TitleOnly=false: expected 'c' (path-only match) to be included")
+	}
+
+	// With TitleOnly: c must be excluded because its Name does not contain "report".
+	req.Filters.TitleOnly = true
+	resp, err = index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (TitleOnly=true): %v", err)
+	}
+	for _, r := range resp.Results {
+		if r.ID == "c" {
+			t.Error("TitleOnly=true: 'c' (path-only match) should be excluded")
+		}
+	}
+}
+
+func TestSearch_SortModifiedAscDesc(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+
+	// Ascending: each successive result must have ModifiedAt >= previous.
+	req := newSearch("report")
+	req.Sort = protocol.Sort{Field: "modified", Dir: "asc"}
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (modified asc): %v", err)
+	}
+	prev := int64(0)
+	for _, r := range resp.Results {
+		if r.ModifiedAt < prev {
+			t.Errorf("modified asc: out of order – %q has ModifiedAt=%d after prev=%d", r.ID, r.ModifiedAt, prev)
+		}
+		prev = r.ModifiedAt
+	}
+
+	// Descending: each successive result must have ModifiedAt <= previous.
+	req.Sort = protocol.Sort{Field: "modified", Dir: "desc"}
+	resp, err = index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search (modified desc): %v", err)
+	}
+	prev = int64(1 << 62)
+	for _, r := range resp.Results {
+		if r.ModifiedAt > prev {
+			t.Errorf("modified desc: out of order – %q has ModifiedAt=%d after prev=%d", r.ID, r.ModifiedAt, prev)
+		}
+		prev = r.ModifiedAt
+	}
+}
+
+func TestSearch_RelevanceOrder(t *testing.T) {
+	// Scoring bucket hierarchy: name-prefix (3) > name-substring (2) > path-only (1).
+	// Expected order (desc): e(prefix,ts2) > a(prefix,ts1) > b(substr,ts2) > f2/f1(substr,ts1) > c(path,ts3).
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	resp, err := index.Search(context.Background(), idx, newSearch("report"))
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	posOf := func(id string) int {
+		for i, r := range resp.Results {
+			if r.ID == id {
+				return i
+			}
+		}
+		return -1
+	}
+	iA, iB, iC, iE := posOf("a"), posOf("b"), posOf("c"), posOf("e")
+	if iA < 0 || iB < 0 || iC < 0 || iE < 0 {
+		t.Fatalf("missing results: a=%d b=%d c=%d e=%d; all results: %v", iA, iB, iC, iE, resultIDs(resp.Results))
+	}
+
+	// Both prefix matches must rank above the substring match.
+	if iA > iB {
+		t.Errorf("prefix match 'a' (pos %d) should rank before substring 'b' (pos %d)", iA, iB)
+	}
+	if iE > iB {
+		t.Errorf("prefix match 'e' (pos %d) should rank before substring 'b' (pos %d)", iE, iB)
+	}
+	// The substring match must rank above the path-only match.
+	if iB > iC {
+		t.Errorf("substring 'b' (pos %d) should rank before path-only 'c' (pos %d)", iB, iC)
+	}
+}
+
+func TestSearch_NamePathTiebreak(t *testing.T) {
+	// f1 "b_report.log" and f2 "a_report.log" have identical scores:
+	// same nameBucket (2), same ModifiedAt (ts1), no history.
+	// Deterministic tiebreak by Name ascending: "a_report.log" < "b_report.log" → f2 before f1.
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	resp, err := index.Search(context.Background(), idx, newSearch("report"))
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	iF1, iF2 := -1, -1
+	for i, r := range resp.Results {
+		switch r.ID {
+		case "f1":
+			iF1 = i
+		case "f2":
+			iF2 = i
+		}
+	}
+	if iF1 < 0 || iF2 < 0 {
+		t.Fatalf("f1=%d f2=%d: both should be present; results: %v", iF1, iF2, resultIDs(resp.Results))
+	}
+	if iF2 > iF1 {
+		t.Errorf("tiebreak: f2 (Name 'a_report.log', pos %d) should appear before f1 (Name 'b_report.log', pos %d)", iF2, iF1)
+	}
+}
+
+func TestSearch_HistoryBoost(t *testing.T) {
+	// Two results with equal nameBucket (2); h is in History (boost +5), i is not.
+	// Score(h) = 20 + 5 + recency(ts1) ≈ 25.055 >> Score(i) = 20 + 0 + recency(ts2) ≈ 20.06.
+	// h must rank first.
+	items := []protocol.FileResult{
+		{ID: "h", Name: "annual_report_h.txt", Path: "/h/annual_report_h.txt", Type: protocol.FileTypeDocument, ModifiedAt: ts1, CreatedAt: ts1},
+		{ID: "i", Name: "annual_report_i.txt", Path: "/i/annual_report_i.txt", Type: protocol.FileTypeDocument, ModifiedAt: ts2, CreatedAt: ts2},
+	}
+	idx := index.NewMemIndexer(items, protocol.Capabilities{})
+	req := newSearch("report")
+	req.History = []string{"h"}
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(resp.Results))
+	}
+	if resp.Results[0].ID != "h" {
+		t.Errorf("history boost: 'h' should rank first; got %q first (results: %v)", resp.Results[0].ID, resultIDs(resp.Results))
+	}
+}
+
+func TestSearch_Pagination(t *testing.T) {
+	// 6 items match "report". PageSize=2 → 3 pages.
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	req := newSearch("report")
+	req.PageSize = 2
+
+	// Page 0: 2 results, Total=6.
+	req.Page = 0
+	resp, err := index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search page 0: %v", err)
+	}
+	if resp.Total != 6 {
+		t.Errorf("page 0: Total = %d, want 6", resp.Total)
+	}
+	if len(resp.Results) != 2 {
+		t.Errorf("page 0: len(Results) = %d, want 2", len(resp.Results))
+	}
+	if resp.Page != 0 {
+		t.Errorf("page 0: Page = %d, want 0", resp.Page)
+	}
+
+	// Page 1: next 2 results, Total still 6.
+	req.Page = 1
+	resp, err = index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search page 1: %v", err)
+	}
+	if resp.Total != 6 {
+		t.Errorf("page 1: Total = %d, want 6", resp.Total)
+	}
+	if len(resp.Results) != 2 {
+		t.Errorf("page 1: len(Results) = %d, want 2", len(resp.Results))
+	}
+	if resp.Page != 1 {
+		t.Errorf("page 1: Page = %d, want 1", resp.Page)
+	}
+
+	// Page 0 and page 1 must return different results.
+	page0IDs := resultIDs(resp.Results)
+	req.Page = 0
+	resp0, _ := index.Search(context.Background(), idx, req)
+	req.Page = 1
+	resp1, _ := index.Search(context.Background(), idx, req)
+	for _, id0 := range resultIDs(resp0.Results) {
+		for _, id1 := range resultIDs(resp1.Results) {
+			if id0 == id1 {
+				t.Errorf("page 0 and page 1 share result %q (page0=%v page1=%v)", id0, resultIDs(resp0.Results), page0IDs)
+			}
+		}
+	}
+
+	// Out-of-range page → empty results, Total still 6.
+	req.Page = 100
+	resp, err = index.Search(context.Background(), idx, req)
+	if err != nil {
+		t.Fatalf("Search page 100: %v", err)
+	}
+	if resp.Total != 6 {
+		t.Errorf("page 100: Total = %d, want 6", resp.Total)
+	}
+	if len(resp.Results) != 0 {
+		t.Errorf("page 100: len(Results) = %d, want 0", len(resp.Results))
+	}
+}
+
+func TestSearch_DegradedFlag(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	idx.DegradedVal = true
+	resp, err := index.Search(context.Background(), idx, newSearch("report"))
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !resp.Degraded {
+		t.Error("Degraded should be true when MemIndexer.DegradedVal is true")
+	}
+}
+
+func TestSearch_NonNilEmptyResults(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	// This query matches nothing in the corpus.
+	resp, err := index.Search(context.Background(), idx, newSearch("zzz_no_match_ever_zzz"))
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if resp.Results == nil {
+		t.Error("Results must be a non-nil empty slice (not nil) when nothing matches")
+	}
+	if len(resp.Results) != 0 {
+		t.Errorf("Results should be empty, got %d results", len(resp.Results))
+	}
+	if resp.Total != 0 {
+		t.Errorf("Total = %d, want 0", resp.Total)
+	}
+}
+
+func TestSearch_EmptyQueryError(t *testing.T) {
+	idx := index.NewMemIndexer(testCorpus, protocol.Capabilities{})
+	req := protocol.SearchRequest{
+		Query:    "",
+		PageSize: 10,
+	}
+	_, err := index.Search(context.Background(), idx, req)
+	if err == nil {
+		t.Error("Search with an empty query should return an error")
+	}
+}

--- a/companion/internal/index/plocate.go
+++ b/companion/internal/index/plocate.go
@@ -10,9 +10,13 @@ import (
 	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
 )
 
-// plocateLimit caps the number of index candidates requested per invocation.
+// plocateLimit is the candidate cap passed to plocate as a CLI argument.
 // The pipeline paginates the final result set, so 500 is a reasonable ceiling.
-const plocateLimit = "500"
+// plocateLimitN is the numeric equivalent used to detect a cap hit (Bug C).
+const (
+	plocateLimit  = "500"
+	plocateLimitN = 500
+)
 
 // PlocateIndexer queries the plocate (or locate) mlocate-compatible database.
 // It prefers the plocate binary and falls back to locate.
@@ -110,6 +114,7 @@ func (p *PlocateIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode
 
 	// Substring mode: one invocation per OR branch with a resolvable seed.
 	var all []string
+	degraded := false
 	for _, branch := range ORBranches(ast) {
 		seed, ok := PositiveSeed(branch)
 		if !ok {
@@ -120,9 +125,15 @@ func (p *PlocateIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode
 		if err != nil {
 			continue
 		}
-		all = append(all, parsePlocatePaths(out)...)
+		paths := parsePlocatePaths(out)
+		if len(paths) >= plocateLimitN {
+			// Cap hit: the index returned exactly the limit, so results may be
+			// incomplete. Signal degraded so the count is not presented as exact.
+			degraded = true
+		}
+		all = append(all, paths...)
 	}
-	return normalizeAndDedupe(all), false, nil
+	return normalizeAndDedupe(all), degraded, nil
 }
 
 // parsePlocatePaths reads plocate stdout: one absolute path per line.

--- a/companion/internal/index/plocate.go
+++ b/companion/internal/index/plocate.go
@@ -1,0 +1,110 @@
+package index
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// plocateLimit caps the number of index candidates requested per invocation.
+// The pipeline paginates the final result set, so 500 is a reasonable ceiling.
+const plocateLimit = "500"
+
+// PlocateIndexer queries the plocate (or locate) mlocate-compatible database.
+// It prefers the plocate binary and falls back to locate.
+type PlocateIndexer struct {
+	runner Runner
+	// Bin is the resolved binary path selected at construction time.
+	// Exported so callers and tests can verify which binary was chosen.
+	Bin   string
+	avail bool
+}
+
+// NewPlocateIndexer creates a PlocateIndexer using r for command execution.
+// It resolves the binary once at construction (plocate preferred over locate);
+// Available() returns false if neither is on PATH.
+func NewPlocateIndexer(r Runner) *PlocateIndexer {
+	bin, ok := LookPath("plocate")
+	if !ok {
+		bin, ok = LookPath("locate")
+	}
+	return &PlocateIndexer{runner: r, Bin: bin, avail: ok}
+}
+
+func (p *PlocateIndexer) ID() string      { return "plocate" }
+func (p *PlocateIndexer) Name() string    { return "plocate" }
+func (p *PlocateIndexer) Available() bool { return p.avail }
+
+// Capabilities for plocate:
+//   - BooleanOps: false  — plocate matches one pattern at a time
+//   - PrefixWildcard: true — plocate accepts glob patterns
+//   - InfixWildcard: true  — plocate accepts glob patterns
+//   - Regex: true          — plocate --regexp / --regex
+//   - PathScope: true      — plocate always matches on the full path
+//   - Content: false       — plocate is a path-name index only
+func (p *PlocateIndexer) Capabilities() protocol.Capabilities {
+	return protocol.Capabilities{
+		BooleanOps:     false,
+		PrefixWildcard: true,
+		InfixWildcard:  true,
+		Regex:          true,
+		PathScope:      true,
+		Content:        false,
+	}
+}
+
+// Query returns candidate FileResults from the plocate index.
+//
+// Regex mode: issues a single `<bin> --regexp -i -l 500 -- <pattern>` call.
+// plocate handles BRE regex natively; degraded is false.
+//
+// Substring mode: for each OR branch that has a positive literal seed, issues
+// one `<bin> -i -l 500 -- <seed>` call (case-insensitive substring match on
+// the full path). Results across branches are unioned. A branch with no
+// positive seed (e.g. pure negation) is skipped — no index seed exists.
+//
+// All paths from stdout are normalized and deduplicated. Paths that fail
+// Normalize (stale index entries) are silently dropped.
+func (p *PlocateIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
+	if pat, ok := RegexPattern(ast); ok {
+		out, err := p.runner.Run(ctx, p.Bin, "--regexp", "-i", "-l", plocateLimit, "--", pat)
+		if err != nil {
+			return nil, false, err
+		}
+		return normalizeAndDedupe(parsePlocatePaths(out)), false, nil
+	}
+
+	// Substring mode: one invocation per OR branch with a resolvable seed.
+	var all []string
+	for _, branch := range ORBranches(ast) {
+		seed, ok := PositiveSeed(branch)
+		if !ok {
+			// No positive literal anchor (e.g. pure negation); skip this branch.
+			continue
+		}
+		out, err := p.runner.Run(ctx, p.Bin, "-i", "-l", plocateLimit, "--", seed)
+		if err != nil {
+			continue
+		}
+		all = append(all, parsePlocatePaths(out)...)
+	}
+	return normalizeAndDedupe(all), false, nil
+}
+
+// parsePlocatePaths reads plocate stdout: one absolute path per line.
+// Blank and whitespace-only lines are ignored.
+func parsePlocatePaths(out []byte) []string {
+	var paths []string
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
+}

--- a/companion/internal/index/plocate.go
+++ b/companion/internal/index/plocate.go
@@ -43,7 +43,7 @@ func (p *PlocateIndexer) Available() bool { return p.avail }
 //   - BooleanOps: false  — plocate matches one pattern at a time
 //   - PrefixWildcard: true — plocate accepts glob patterns
 //   - InfixWildcard: true  — plocate accepts glob patterns
-//   - Regex: true          — plocate --regexp / --regex
+//   - Regex: true          — regex queries handled via literal-seed substring fallback
 //   - PathScope: true      — plocate always matches on the full path
 //   - Content: false       — plocate is a path-name index only
 func (p *PlocateIndexer) Capabilities() protocol.Capabilities {
@@ -59,8 +59,20 @@ func (p *PlocateIndexer) Capabilities() protocol.Capabilities {
 
 // Query returns candidate FileResults from the plocate index.
 //
-// Regex mode: issues a single `<bin> --regexp -i -l 500 -- <pattern>` call.
-// plocate handles BRE regex natively; degraded is false.
+// Regex mode: plocate's --regexp flag speaks POSIX BRE, which is incompatible
+// with Go RE2 syntax (\d, {n}, (?:…), (?i) etc.). Passing a raw RE2 pattern to
+// --regexp causes plocate to under-return, silently dropping true matches before
+// the pipeline's RE2 matcher sees them.
+//
+// Instead, RegexSeeds extracts the longest recall-safe literal substring(s) from
+// the pattern and issues ordinary substring queries:
+//   - If seeds are found, one substring query per seed; results are unioned.
+//   - If the pattern has no required literal of length ≥ 2 (broad=true), a single
+//     "/" query is used — every absolute path contains "/" — capping the candidate
+//     set at plocateLimit entries for the RE2 matcher to filter.
+//
+// degraded=true for all regex queries: results are a candidate superset, not a
+// definitive index match.
 //
 // Substring mode: for each OR branch that has a positive literal seed, issues
 // one `<bin> -i -l 500 -- <seed>` call (case-insensitive substring match on
@@ -71,11 +83,29 @@ func (p *PlocateIndexer) Capabilities() protocol.Capabilities {
 // Normalize (stale index entries) are silently dropped.
 func (p *PlocateIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
 	if pat, ok := RegexPattern(ast); ok {
-		out, err := p.runner.Run(ctx, p.Bin, "--regexp", "-i", "-l", plocateLimit, "--", pat)
-		if err != nil {
-			return nil, false, err
+		seeds, broad := RegexSeeds(pat)
+		var all []string
+		if broad {
+			// No required literal ≥ 2 chars: fall back to a capped whole-index scan
+			// using "/" as the seed (every absolute path contains "/"). The RE2
+			// matcher in the pipeline performs precision filtering over this superset.
+			out, err := p.runner.Run(ctx, p.Bin, "-i", "-l", plocateLimit, "--", "/")
+			if err != nil {
+				return nil, true, err
+			}
+			all = parsePlocatePaths(out)
+		} else {
+			for _, seed := range seeds {
+				out, err := p.runner.Run(ctx, p.Bin, "-i", "-l", plocateLimit, "--", seed)
+				if err != nil {
+					return nil, true, err
+				}
+				all = append(all, parsePlocatePaths(out)...)
+			}
 		}
-		return normalizeAndDedupe(parsePlocatePaths(out)), false, nil
+		// degraded=true: results are candidates from a substring superset query,
+		// not a true regex index match. The pipeline matcher filters for precision.
+		return normalizeAndDedupe(all), true, nil
 	}
 
 	// Substring mode: one invocation per OR branch with a resolvable seed.

--- a/companion/internal/index/plocate_test.go
+++ b/companion/internal/index/plocate_test.go
@@ -1,0 +1,321 @@
+package index_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// --- shared test helpers ---
+
+type runCall struct {
+	name string
+	args []string
+}
+
+// fakeRunner records calls and returns pre-canned stdout strings in order.
+// Once the stdouts slice is exhausted, the last element is repeated.
+// An empty stdouts slice always returns nil output.
+type fakeRunner struct {
+	calls   []runCall
+	stdouts []string
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, runCall{name: name, args: args})
+	if len(f.stdouts) == 0 {
+		return nil, nil
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.stdouts) {
+		idx = len(f.stdouts) - 1
+	}
+	return []byte(f.stdouts[idx]), nil
+}
+
+// writeTestFile creates a file at path with dummy content.
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("testcontent"), 0o644); err != nil {
+		t.Fatalf("create test file %s: %v", path, err)
+	}
+}
+
+// argsContain reports whether val appears anywhere in args.
+func argsContain(args []string, val string) bool {
+	for _, a := range args {
+		if a == val {
+			return true
+		}
+	}
+	return false
+}
+
+// argIndex returns the first position of val in args, or -1 if not found.
+func argIndex(args []string, val string) int {
+	for i, a := range args {
+		if a == val {
+			return i
+		}
+	}
+	return -1
+}
+
+// --- PlocateIndexer tests ---
+
+func TestPlocate_Capabilities(t *testing.T) {
+	idx := index.NewPlocateIndexer(&fakeRunner{})
+	caps := idx.Capabilities()
+	if caps.BooleanOps {
+		t.Error("BooleanOps should be false")
+	}
+	if !caps.PrefixWildcard {
+		t.Error("PrefixWildcard should be true")
+	}
+	if !caps.InfixWildcard {
+		t.Error("InfixWildcard should be true")
+	}
+	if !caps.Regex {
+		t.Error("Regex should be true")
+	}
+	if !caps.PathScope {
+		t.Error("PathScope should be true")
+	}
+	if caps.Content {
+		t.Error("Content should be false")
+	}
+}
+
+func TestPlocate_IDAndName(t *testing.T) {
+	idx := index.NewPlocateIndexer(&fakeRunner{})
+	if idx.ID() != "plocate" {
+		t.Errorf("ID=%q want plocate", idx.ID())
+	}
+	if idx.Name() != "plocate" {
+		t.Errorf("Name=%q want plocate", idx.Name())
+	}
+}
+
+func TestPlocate_RegexMode_Command(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "invoice.pdf")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse(`inv.*\.pdf`, query.ModeRegex)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false for regex mode")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+
+	if call.name != idx.Bin {
+		t.Errorf("binary: got %q, want %q", call.name, idx.Bin)
+	}
+	if !argsContain(call.args, "--regexp") {
+		t.Error("expected --regexp flag in regex mode")
+	}
+	if !argsContain(call.args, "-i") {
+		t.Error("expected -i (case-insensitive) flag")
+	}
+	if !argsContain(call.args, "500") {
+		t.Error("expected limit 500")
+	}
+	ddIdx := argIndex(call.args, "--")
+	patIdx := argIndex(call.args, `inv.*\.pdf`)
+	if ddIdx < 0 {
+		t.Fatal("expected -- in args")
+	}
+	if patIdx < 0 {
+		t.Fatal("expected regex pattern in args")
+	}
+	if ddIdx >= patIdx {
+		t.Error("-- must appear before the pattern")
+	}
+}
+
+func TestPlocate_SubstringMode_Command(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "report.pdf")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse("report", query.ModeSimple)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+
+	if argsContain(call.args, "--regexp") {
+		t.Error("--regexp must NOT appear in substring mode")
+	}
+	if !argsContain(call.args, "-i") {
+		t.Error("expected -i flag")
+	}
+	if !argsContain(call.args, "500") {
+		t.Error("expected limit 500")
+	}
+	if !argsContain(call.args, "report") {
+		t.Error("expected seed 'report' in args")
+	}
+	ddIdx := argIndex(call.args, "--")
+	seedIdx := argIndex(call.args, "report")
+	if ddIdx < 0 {
+		t.Fatal("expected -- in args")
+	}
+	if ddIdx >= seedIdx {
+		t.Error("-- must appear before the seed")
+	}
+}
+
+func TestPlocate_ORQuery_TwoInvocations(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "alpha.txt")
+	f2 := filepath.Join(dir, "beta.txt")
+	writeTestFile(t, f1)
+	writeTestFile(t, f2)
+
+	fr := &fakeRunner{stdouts: []string{f1 + "\n", f2 + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse("alpha | beta", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+
+	if len(fr.calls) != 2 {
+		t.Fatalf("expected 2 runner calls (one per OR branch), got %d", len(fr.calls))
+	}
+	// Seeds should be "alpha" and "beta" in some order.
+	seed0 := fr.calls[0].args[len(fr.calls[0].args)-1]
+	seed1 := fr.calls[1].args[len(fr.calls[1].args)-1]
+	if (seed0 != "alpha" || seed1 != "beta") && (seed0 != "beta" || seed1 != "alpha") {
+		t.Errorf("unexpected seeds %q, %q; want alpha and beta", seed0, seed1)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (union of branches), got %d", len(results))
+	}
+}
+
+func TestPlocate_MissingPathsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.txt")
+	writeTestFile(t, real)
+
+	stale := "/nonexistent/path/stale_entry_12345.txt"
+	fr := &fakeRunner{stdouts: []string{real + "\n" + stale + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse("real", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (stale skipped), got %d", len(results))
+	}
+	if results[0].Path != real {
+		t.Errorf("path=%q want %q", results[0].Path, real)
+	}
+}
+
+func TestPlocate_DeduplicatePaths(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "shared.txt")
+	writeTestFile(t, f)
+
+	// Both OR branches return the same path.
+	fr := &fakeRunner{stdouts: []string{f + "\n", f + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse("shared | shared", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 deduplicated result, got %d", len(results))
+	}
+}
+
+func TestPlocate_PureNegation_NoRunnerCall(t *testing.T) {
+	fr := &fakeRunner{}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse("-foo", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for pure-negation branch, got %d", len(fr.calls))
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestPlocate_BlankLinesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "note.txt")
+	writeTestFile(t, f)
+
+	// stdout with leading/trailing blank lines and whitespace-only line.
+	stdout := "\n  \n" + f + "\n\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse("note", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+}
+
+func TestPlocate_ResultsNeverNil(t *testing.T) {
+	fr := &fakeRunner{stdouts: []string{""}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse("anything", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if results == nil {
+		t.Error("results must never be nil")
+	}
+}

--- a/companion/internal/index/plocate_test.go
+++ b/companion/internal/index/plocate_test.go
@@ -2,6 +2,7 @@ package index_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,13 +22,18 @@ type runCall struct {
 // fakeRunner records calls and returns pre-canned stdout strings in order.
 // Once the stdouts slice is exhausted, the last element is repeated.
 // An empty stdouts slice always returns nil output.
+// If returnErr is non-nil it is returned from every Run call (no output).
 type fakeRunner struct {
-	calls   []runCall
-	stdouts []string
+	calls     []runCall
+	stdouts   []string
+	returnErr error
 }
 
 func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	f.calls = append(f.calls, runCall{name: name, args: args})
+	if f.returnErr != nil {
+		return nil, f.returnErr
+	}
 	if len(f.stdouts) == 0 {
 		return nil, nil
 	}
@@ -102,20 +108,22 @@ func TestPlocate_IDAndName(t *testing.T) {
 }
 
 func TestPlocate_RegexMode_Command(t *testing.T) {
+	// inv.*\.pdf → longest required literal run is ".pdf" (4); seed not the raw pattern.
 	dir := t.TempDir()
 	f := filepath.Join(dir, "invoice.pdf")
 	writeTestFile(t, f)
 
 	fr := &fakeRunner{stdouts: []string{f + "\n"}}
 	idx := index.NewPlocateIndexer(fr)
+	idx.Bin = "plocate" // set explicitly so the assertion is deterministic in CI
 
 	ast, _ := query.Parse(`inv.*\.pdf`, query.ModeRegex)
 	results, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
-	if degraded {
-		t.Error("expected degraded=false for regex mode")
+	if !degraded {
+		t.Error("expected degraded=true for regex mode (candidate set + post-filter)")
 	}
 	if len(results) != 1 {
 		t.Fatalf("got %d results, want 1", len(results))
@@ -126,11 +134,11 @@ func TestPlocate_RegexMode_Command(t *testing.T) {
 	}
 	call := fr.calls[0]
 
-	if call.name != idx.Bin {
-		t.Errorf("binary: got %q, want %q", call.name, idx.Bin)
+	if call.name != "plocate" {
+		t.Errorf("binary: got %q, want plocate", call.name)
 	}
-	if !argsContain(call.args, "--regexp") {
-		t.Error("expected --regexp flag in regex mode")
+	if argsContain(call.args, "--regexp") {
+		t.Error("regex mode must NOT use --regexp (RE2 vs BRE incompatibility)")
 	}
 	if !argsContain(call.args, "-i") {
 		t.Error("expected -i (case-insensitive) flag")
@@ -139,15 +147,16 @@ func TestPlocate_RegexMode_Command(t *testing.T) {
 		t.Error("expected limit 500")
 	}
 	ddIdx := argIndex(call.args, "--")
-	patIdx := argIndex(call.args, `inv.*\.pdf`)
 	if ddIdx < 0 {
 		t.Fatal("expected -- in args")
 	}
-	if patIdx < 0 {
-		t.Fatal("expected regex pattern in args")
+	// Seed must come after -- and must NOT be the raw RE2 pattern.
+	lastArg := call.args[len(call.args)-1]
+	if lastArg == `inv.*\.pdf` {
+		t.Errorf("raw RE2 pattern passed to plocate (BRE incompatible): %q", lastArg)
 	}
-	if ddIdx >= patIdx {
-		t.Error("-- must appear before the pattern")
+	if argIndex(call.args, lastArg) <= ddIdx {
+		t.Error("seed must appear after --")
 	}
 }
 
@@ -317,5 +326,117 @@ func TestPlocate_ResultsNeverNil(t *testing.T) {
 	}
 	if results == nil {
 		t.Error("results must never be nil")
+	}
+}
+
+func TestPlocate_RegexMode_BroadFallback(t *testing.T) {
+	// ^.*$ has no required literal ≥ 2 chars → broad → "/" whole-index scan.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "anything.txt")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+	idx.Bin = "plocate"
+
+	ast, _ := query.Parse(`^.*$`, query.ModeRegex)
+	_, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !degraded {
+		t.Error("expected degraded=true for broad regex fallback")
+	}
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+	lastArg := call.args[len(call.args)-1]
+	if lastArg != "/" {
+		t.Errorf("broad fallback must query '/', got %q", lastArg)
+	}
+	if argsContain(call.args, "--regexp") {
+		t.Error("broad fallback must NOT use --regexp")
+	}
+}
+
+func TestPlocate_RegexMode_AlternationSeeds(t *testing.T) {
+	// foo|bar → two seeds → two substring queries, results unioned.
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "foo.txt")
+	f2 := filepath.Join(dir, "bar.txt")
+	writeTestFile(t, f1)
+	writeTestFile(t, f2)
+
+	fr := &fakeRunner{stdouts: []string{f1 + "\n", f2 + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+	idx.Bin = "plocate"
+
+	ast, _ := query.Parse(`foo|bar`, query.ModeRegex)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !degraded {
+		t.Error("expected degraded=true for regex alternation mode")
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("expected 2 runner calls (one per alternation seed), got %d", len(fr.calls))
+	}
+	seed0 := fr.calls[0].args[len(fr.calls[0].args)-1]
+	seed1 := fr.calls[1].args[len(fr.calls[1].args)-1]
+	if (seed0 != "foo" || seed1 != "bar") && (seed0 != "bar" || seed1 != "foo") {
+		t.Errorf("expected seeds foo and bar, got %q and %q", seed0, seed1)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (union of branches), got %d", len(results))
+	}
+}
+
+func TestPlocate_RegexMode_DegradedTrue(t *testing.T) {
+	// Any regex query returns degraded=true regardless of seed extraction.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "report.pdf")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n"}}
+	idx := index.NewPlocateIndexer(fr)
+
+	ast, _ := query.Parse(`report`, query.ModeRegex)
+	_, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !degraded {
+		t.Error("expected degraded=true for all regex mode queries")
+	}
+}
+
+func TestPlocate_RunnerError_RegexMode(t *testing.T) {
+	// Runner errors in regex mode must propagate to the caller.
+	fr := &fakeRunner{returnErr: errors.New("plocate: database not found")}
+	idx := index.NewPlocateIndexer(fr)
+	idx.Bin = "plocate"
+
+	ast, _ := query.Parse(`report`, query.ModeRegex)
+	_, _, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err == nil {
+		t.Error("expected runner error to propagate in regex mode")
+	}
+}
+
+func TestPlocate_RunnerError_SubstringMode(t *testing.T) {
+	// Runner errors in substring mode are silently skipped (branch skipped → empty results).
+	fr := &fakeRunner{returnErr: errors.New("plocate: database not found")}
+	idx := index.NewPlocateIndexer(fr)
+	idx.Bin = "plocate"
+
+	ast, _ := query.Parse("report", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Errorf("substring mode swallows runner errors; got unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results when runner errors; got %d", len(results))
 	}
 }

--- a/companion/internal/index/plocate_test.go
+++ b/companion/internal/index/plocate_test.go
@@ -3,8 +3,10 @@ package index_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
@@ -438,5 +440,30 @@ func TestPlocate_RunnerError_SubstringMode(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Errorf("expected 0 results when runner errors; got %d", len(results))
+	}
+}
+
+// TestPlocate_CapHit_Degraded verifies Bug C: when plocate returns exactly the
+// candidate cap (500 lines), degraded is set to true because the result set may
+// be incomplete. Paths are non-existent on disk (stale entries silently skipped
+// by Normalize), but degraded must still be true.
+func TestPlocate_CapHit_Degraded(t *testing.T) {
+	// Build a stdout with exactly 500 non-existent path lines.
+	var sb strings.Builder
+	for i := range 500 {
+		fmt.Fprintf(&sb, "/nonexistent/cap_test/file%04d.txt\n", i)
+	}
+
+	fr := &fakeRunner{stdouts: []string{sb.String()}}
+	idx := index.NewPlocateIndexer(fr)
+	idx.Bin = "plocate"
+
+	ast, _ := query.Parse("file", query.ModeSimple)
+	_, degraded, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !degraded {
+		t.Error("expected degraded=true when backend returns exactly the candidate cap (500 paths)")
 	}
 }

--- a/companion/internal/index/registry.go
+++ b/companion/internal/index/registry.go
@@ -75,6 +75,8 @@ func Detect(runner Runner, preferred string) *Registry {
 		NewBalooIndexer(runner),
 		NewTrackerIndexer(runner),
 		NewPlocateIndexer(runner),
+		NewEverythingIndexer(runner),
+		NewWindowsSearchIndexer(runner),
 	}, preferred)
 }
 

--- a/companion/internal/index/registry.go
+++ b/companion/internal/index/registry.go
@@ -1,0 +1,142 @@
+package index
+
+import (
+	"context"
+	"errors"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// ErrNoIndexer is returned by Registry.Search when no file indexer is available
+// on the host. The HTTP server maps this to the indexer_unavailable error code.
+var ErrNoIndexer = errors.New("no file indexer available")
+
+// priorityOrder is the canonical backend preference list, most preferred first.
+// Only IDs in this list are eligible for automatic default selection and appear
+// in Infos(); backends with IDs outside this list are stored but never ordered.
+var priorityOrder = []string{"baloo", "tracker", "plocate", "everything", "wsearch", "mediastore"}
+
+// Registry holds the set of known indexer backends, selects the default, and
+// routes Search requests — including regex-mode routing to a regex-capable backend.
+type Registry struct {
+	byID       map[string]Indexer
+	ordered    []Indexer // known backends present in byID, in priority order
+	defaultIdx Indexer   // nil when no available indexer
+}
+
+// NewRegistry is a pure, testable constructor. It stores the given indexers,
+// builds a priority-ordered view, and chooses the default:
+//
+//  1. If preferred is non-empty and names an available indexer, use it.
+//  2. Otherwise, use the first available indexer in priorityOrder.
+//  3. If none is available, default is nil.
+//
+// Fake indexers (e.g. MemIndexer) can be passed in tests so that no real
+// binaries are consulted.
+func NewRegistry(indexers []Indexer, preferred string) *Registry {
+	byID := make(map[string]Indexer, len(indexers))
+	for _, idx := range indexers {
+		byID[idx.ID()] = idx
+	}
+
+	// Build ordered slice: backends present in byID, in priority order.
+	ordered := make([]Indexer, 0, len(priorityOrder))
+	for _, id := range priorityOrder {
+		if idx, ok := byID[id]; ok {
+			ordered = append(ordered, idx)
+		}
+	}
+
+	// Choose default.
+	var defaultIdx Indexer
+	if preferred != "" {
+		if idx, ok := byID[preferred]; ok && idx.Available() {
+			defaultIdx = idx
+		}
+	}
+	if defaultIdx == nil {
+		for _, idx := range ordered {
+			if idx.Available() {
+				defaultIdx = idx
+				break
+			}
+		}
+	}
+
+	return &Registry{byID: byID, ordered: ordered, defaultIdx: defaultIdx}
+}
+
+// Detect is the thin system-wiring constructor. It creates the real backends
+// using the supplied runner and delegates all selection logic to NewRegistry.
+// preferred will later come from companion config; pass "" to use priority order.
+func Detect(runner Runner, preferred string) *Registry {
+	return NewRegistry([]Indexer{
+		NewBalooIndexer(runner),
+		NewTrackerIndexer(runner),
+		NewPlocateIndexer(runner),
+	}, preferred)
+}
+
+// Infos returns one IndexerInfo per known backend present in this registry,
+// ordered by the priority list. Both available and unavailable backends are
+// included so clients can show capability-gating information.
+func (r *Registry) Infos() []protocol.IndexerInfo {
+	infos := make([]protocol.IndexerInfo, 0, len(r.ordered))
+	for _, idx := range r.ordered {
+		infos = append(infos, protocol.IndexerInfo{
+			ID:           idx.ID(),
+			Name:         idx.Name(),
+			Available:    idx.Available(),
+			Capabilities: idx.Capabilities(),
+		})
+	}
+	return infos
+}
+
+// Default returns the selected default indexer, or nil if no indexer is available.
+func (r *Registry) Default() Indexer {
+	return r.defaultIdx
+}
+
+// Search executes the request with automatic backend selection.
+//
+// If no indexer is available, it returns ErrNoIndexer (mapped to
+// indexer_unavailable by the HTTP server).
+//
+// Regex routing: for a regex-mode request, the first available regex-capable
+// backend in priority order is used (typically plocate). If no regex-capable
+// backend is available, the request falls back to the default backend and
+// resp.Degraded is forced true to signal that results are a candidate superset,
+// not a true regex index match.
+func (r *Registry) Search(ctx context.Context, req protocol.SearchRequest) (protocol.SearchResponse, error) {
+	if r.defaultIdx == nil {
+		return protocol.SearchResponse{}, ErrNoIndexer
+	}
+
+	var noNativeRegex bool
+	serving := r.defaultIdx
+
+	if req.QueryMode == query.ModeRegex {
+		// Find the first available regex-capable backend in priority order.
+		for _, idx := range r.ordered {
+			if idx.Available() && idx.Capabilities().Regex {
+				serving = idx
+				break
+			}
+		}
+		// If the serving backend can't handle regex natively, mark for degraded override.
+		if !serving.Capabilities().Regex {
+			noNativeRegex = true
+		}
+	}
+
+	resp, err := Search(ctx, serving, req)
+	if err != nil {
+		return resp, err
+	}
+	if noNativeRegex {
+		resp.Degraded = true
+	}
+	return resp, nil
+}

--- a/companion/internal/index/registry_test.go
+++ b/companion/internal/index/registry_test.go
@@ -1,0 +1,231 @@
+package index_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// --- Registry tests ---
+//
+// All tests use NewRegistry with fake MemIndexers so they never touch real PATH
+// binaries. Only the indexer ID, availability, and capabilities matter for routing.
+
+// makeIdx builds a MemIndexer with the given identity and availability.
+func makeIdx(id, name string, available bool, caps protocol.Capabilities) *index.MemIndexer {
+	return &index.MemIndexer{
+		IDVal:        id,
+		NameVal:      name,
+		AvailableVal: available,
+		Caps:         caps,
+	}
+}
+
+// Canonical capability sets matching each backend's real implementation.
+var (
+	capsBaloo = protocol.Capabilities{
+		BooleanOps: true, PrefixWildcard: true, InfixWildcard: true,
+		Regex: false, PathScope: true, Content: true,
+	}
+	capsTracker = protocol.Capabilities{
+		BooleanOps: false, PrefixWildcard: true, InfixWildcard: false,
+		Regex: false, PathScope: false, Content: true,
+	}
+	capsPlocate = protocol.Capabilities{
+		BooleanOps: false, PrefixWildcard: true, InfixWildcard: true,
+		Regex: true, PathScope: true, Content: false,
+	}
+)
+
+func TestRegistry_DefaultSelection_PriorityOrder(t *testing.T) {
+	// Baloo and tracker both available; baloo is first in priority → default.
+	baloo := makeIdx("baloo", "KDE Baloo", true, capsBaloo)
+	tracker := makeIdx("tracker", "GNOME Tracker", true, capsTracker)
+	plocate := makeIdx("plocate", "plocate", false, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{baloo, tracker, plocate}, "")
+	if reg.Default() == nil {
+		t.Fatal("Default() must not be nil when baloo is available")
+	}
+	if reg.Default().ID() != "baloo" {
+		t.Errorf("Default()=%q want baloo (highest priority)", reg.Default().ID())
+	}
+}
+
+func TestRegistry_DefaultSelection_TrackerBeforePlocate(t *testing.T) {
+	// Only tracker and plocate available; tracker precedes plocate in priority order.
+	tracker := makeIdx("tracker", "GNOME Tracker", true, capsTracker)
+	plocate := makeIdx("plocate", "plocate", true, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{tracker, plocate}, "")
+	if reg.Default() == nil {
+		t.Fatal("Default() must not be nil")
+	}
+	if reg.Default().ID() != "tracker" {
+		t.Errorf("Default()=%q want tracker", reg.Default().ID())
+	}
+}
+
+func TestRegistry_DefaultSelection_Preferred(t *testing.T) {
+	// preferred="plocate" overrides priority; plocate is available → chosen.
+	baloo := makeIdx("baloo", "KDE Baloo", true, capsBaloo)
+	plocate := makeIdx("plocate", "plocate", true, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{baloo, plocate}, "plocate")
+	if reg.Default() == nil {
+		t.Fatal("Default() must not be nil")
+	}
+	if reg.Default().ID() != "plocate" {
+		t.Errorf("Default()=%q want plocate (preferred)", reg.Default().ID())
+	}
+}
+
+func TestRegistry_DefaultSelection_PreferredUnavailable_FallsBackToPriority(t *testing.T) {
+	// preferred="plocate" but plocate is unavailable; falls back to baloo.
+	baloo := makeIdx("baloo", "KDE Baloo", true, capsBaloo)
+	plocate := makeIdx("plocate", "plocate", false, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{baloo, plocate}, "plocate")
+	if reg.Default() == nil {
+		t.Fatal("Default() must not be nil when baloo is available")
+	}
+	if reg.Default().ID() != "baloo" {
+		t.Errorf("Default()=%q want baloo (preferred plocate unavailable)", reg.Default().ID())
+	}
+}
+
+func TestRegistry_DefaultSelection_NilWhenNoneAvailable(t *testing.T) {
+	baloo := makeIdx("baloo", "KDE Baloo", false, capsBaloo)
+	plocate := makeIdx("plocate", "plocate", false, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{baloo, plocate}, "")
+	if reg.Default() != nil {
+		t.Errorf("Default() should be nil when no indexer is available, got %q", reg.Default().ID())
+	}
+}
+
+func TestRegistry_Infos_OrderAndContent(t *testing.T) {
+	// Pass in reverse order; Infos must return priority order (baloo, tracker, plocate).
+	baloo := makeIdx("baloo", "KDE Baloo", true, capsBaloo)
+	tracker := makeIdx("tracker", "GNOME Tracker", false, capsTracker)
+	plocate := makeIdx("plocate", "plocate", true, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{plocate, tracker, baloo}, "")
+	infos := reg.Infos()
+
+	if len(infos) != 3 {
+		t.Fatalf("Infos() len=%d want 3", len(infos))
+	}
+
+	// Priority: baloo[0] < tracker[1] < plocate[2].
+	if infos[0].ID != "baloo" {
+		t.Errorf("infos[0].ID=%q want baloo", infos[0].ID)
+	}
+	if !infos[0].Available {
+		t.Error("baloo must be available")
+	}
+	if infos[1].ID != "tracker" {
+		t.Errorf("infos[1].ID=%q want tracker", infos[1].ID)
+	}
+	if infos[1].Available {
+		t.Error("tracker must not be available in this fixture")
+	}
+	if infos[2].ID != "plocate" {
+		t.Errorf("infos[2].ID=%q want plocate", infos[2].ID)
+	}
+	if !infos[2].Available {
+		t.Error("plocate must be available")
+	}
+
+	// Capabilities are forwarded from the indexer unchanged.
+	if !infos[0].Capabilities.BooleanOps {
+		t.Error("baloo.Capabilities.BooleanOps should be true")
+	}
+	if infos[0].Capabilities.Regex {
+		t.Error("baloo.Capabilities.Regex should be false")
+	}
+	if !infos[2].Capabilities.Regex {
+		t.Error("plocate.Capabilities.Regex should be true")
+	}
+}
+
+func TestRegistry_Search_ErrNoIndexer(t *testing.T) {
+	// No available indexers → ErrNoIndexer.
+	baloo := makeIdx("baloo", "KDE Baloo", false, capsBaloo)
+	reg := index.NewRegistry([]index.Indexer{baloo}, "")
+
+	_, err := reg.Search(context.Background(), protocol.SearchRequest{
+		Query: "hello", QueryMode: query.ModeSimple, PageSize: 10,
+	})
+	if !errors.Is(err, index.ErrNoIndexer) {
+		t.Errorf("expected ErrNoIndexer, got %v", err)
+	}
+}
+
+func TestRegistry_Search_SubstringMode_UsesDefault(t *testing.T) {
+	// Substring query routes to the default indexer (baloo).
+	baloo := makeIdx("baloo", "KDE Baloo", true, capsBaloo)
+	plocate := makeIdx("plocate", "plocate", true, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{baloo, plocate}, "")
+	resp, err := reg.Search(context.Background(), protocol.SearchRequest{
+		Query: "hello", QueryMode: query.ModeSimple, PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if resp.Indexer != "baloo" {
+		t.Errorf("resp.Indexer=%q want baloo (default for non-regex)", resp.Indexer)
+	}
+}
+
+func TestRegistry_Search_RegexRouting_ToPlocate(t *testing.T) {
+	// Default is baloo (no regex), plocate is available + regex-capable.
+	// A regex-mode query must be routed to plocate.
+	baloo := makeIdx("baloo", "KDE Baloo", true, capsBaloo)
+	plocate := makeIdx("plocate", "plocate", true, capsPlocate)
+
+	reg := index.NewRegistry([]index.Indexer{baloo, plocate}, "")
+	if reg.Default().ID() != "baloo" {
+		t.Fatalf("precondition: Default should be baloo, got %q", reg.Default().ID())
+	}
+
+	resp, err := reg.Search(context.Background(), protocol.SearchRequest{
+		Query: "report", QueryMode: query.ModeRegex, PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if resp.Indexer != "plocate" {
+		t.Errorf("resp.Indexer=%q want plocate (regex routing)", resp.Indexer)
+	}
+	// noNativeRegex is false (plocate IS regex-capable), so the registry must
+	// NOT force Degraded. (MemIndexer.DegradedVal is false by default.)
+	if resp.Degraded {
+		t.Error("resp.Degraded must be false when a regex-capable backend is available")
+	}
+}
+
+func TestRegistry_Search_RegexRouting_NoRegexCapable_FallsBackDegraded(t *testing.T) {
+	// No regex-capable backend; regex request falls back to default (baloo) + Degraded=true.
+	baloo := makeIdx("baloo", "KDE Baloo", true, capsBaloo)
+	tracker := makeIdx("tracker", "GNOME Tracker", true, capsTracker)
+
+	reg := index.NewRegistry([]index.Indexer{baloo, tracker}, "")
+	resp, err := reg.Search(context.Background(), protocol.SearchRequest{
+		Query: "report", QueryMode: query.ModeRegex, PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if resp.Indexer != "baloo" {
+		t.Errorf("resp.Indexer=%q want baloo (fallback when no regex-capable backend)", resp.Indexer)
+	}
+	if !resp.Degraded {
+		t.Error("resp.Degraded must be true when no regex-capable backend is available")
+	}
+}

--- a/companion/internal/index/tracker.go
+++ b/companion/internal/index/tracker.go
@@ -11,8 +11,12 @@ import (
 	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
 )
 
-// trackerLimit caps the number of index candidates requested per invocation.
-const trackerLimit = "500"
+// trackerLimit is the candidate cap passed to tracker as a CLI argument.
+// trackerLimitN is the numeric equivalent used to detect a cap hit (Bug C).
+const (
+	trackerLimit  = "500"
+	trackerLimitN = 500
+)
 
 // TrackerIndexer queries the GNOME Tracker (TinySPARQL) file index via the
 // tracker3 or tracker CLI. tracker3 is preferred; tracker is the legacy fallback.
@@ -85,6 +89,7 @@ func (t *TrackerIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode
 	}
 
 	var all []string
+	degraded := false
 	for _, branch := range ORBranches(ast) {
 		seed, ok := PositiveSeed(branch)
 		if !ok {
@@ -95,9 +100,15 @@ func (t *TrackerIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode
 		if err != nil {
 			continue
 		}
-		all = append(all, parseTrackerOutput(out)...)
+		paths := parseTrackerOutput(out)
+		if len(paths) >= trackerLimitN {
+			// Cap hit: the index returned exactly the limit, so results may be
+			// incomplete. Signal degraded so the count is not presented as exact.
+			degraded = true
+		}
+		all = append(all, paths...)
 	}
-	return normalizeAndDedupe(all), false, nil
+	return normalizeAndDedupe(all), degraded, nil
 }
 
 // parseTrackerOutput extracts filesystem paths from tracker search --files stdout.

--- a/companion/internal/index/tracker.go
+++ b/companion/internal/index/tracker.go
@@ -1,0 +1,128 @@
+package index
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// trackerLimit caps the number of index candidates requested per invocation.
+const trackerLimit = "500"
+
+// TrackerIndexer queries the GNOME Tracker (TinySPARQL) file index via the
+// tracker3 or tracker CLI. tracker3 is preferred; tracker is the legacy fallback.
+type TrackerIndexer struct {
+	runner Runner
+	// Bin is the resolved binary path selected at construction time.
+	// Exported so callers and tests can verify which binary was chosen.
+	Bin   string
+	avail bool
+}
+
+// NewTrackerIndexer creates a TrackerIndexer using r for command execution.
+// It resolves the binary once at construction (tracker3 preferred over tracker);
+// Available() returns false if neither is on PATH.
+func NewTrackerIndexer(r Runner) *TrackerIndexer {
+	bin, ok := LookPath("tracker3")
+	if !ok {
+		bin, ok = LookPath("tracker")
+	}
+	return &TrackerIndexer{runner: r, Bin: bin, avail: ok}
+}
+
+func (t *TrackerIndexer) ID() string      { return "tracker" }
+func (t *TrackerIndexer) Name() string    { return "GNOME Tracker" }
+func (t *TrackerIndexer) Available() bool { return t.avail }
+
+// Capabilities for Tracker:
+//   - BooleanOps: false  — tracker search handles one pattern at a time
+//   - PrefixWildcard: true — tracker supports prefix/stemmed matching
+//   - InfixWildcard: false — no infix glob wildcard support
+//   - Regex: false         — no native regex support
+//   - PathScope: false     — Tracker is a content index, not a path-name index
+//   - Content: true        — Tracker indexes file content
+func (t *TrackerIndexer) Capabilities() protocol.Capabilities {
+	return protocol.Capabilities{
+		BooleanOps:     false,
+		PrefixWildcard: true,
+		InfixWildcard:  false,
+		Regex:          false,
+		PathScope:      false,
+		Content:        true,
+	}
+}
+
+// Query returns candidate FileResults from the GNOME Tracker index.
+//
+// Regex mode is not supported by tracker. If the AST is a regex node,
+// Query returns (nil, true, nil) — degraded, no error — so the registry
+// can route the query elsewhere.
+//
+// Otherwise, for each OR branch with a positive literal seed, issues one
+// `<bin> search --files --limit 500 -- <seed>` call and unions the results.
+//
+// tracker3 search --files output format (the canned format our tests assert against):
+//
+//	Results:
+//	  file:///home/user/Documents/report.pdf
+//	  file:///home/user/Pictures/vacation%20photo.png
+//
+//	  2 results found.
+//
+// The "Results:" header, blank lines, and trailing count line are silently
+// ignored — only lines containing a "file://" token are processed. The URL is
+// percent-decoded via net/url, converted to a filesystem path, and normalized;
+// stale entries that fail Normalize are silently dropped.
+func (t *TrackerIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
+	if _, ok := RegexPattern(ast); ok {
+		// Tracker has no native regex; signal degraded so the registry routes elsewhere.
+		return nil, true, nil
+	}
+
+	var all []string
+	for _, branch := range ORBranches(ast) {
+		seed, ok := PositiveSeed(branch)
+		if !ok {
+			// No positive literal anchor (e.g. pure negation); skip this branch.
+			continue
+		}
+		out, err := t.runner.Run(ctx, t.Bin, "search", "--files", "--limit", trackerLimit, "--", seed)
+		if err != nil {
+			continue
+		}
+		all = append(all, parseTrackerOutput(out)...)
+	}
+	return normalizeAndDedupe(all), false, nil
+}
+
+// parseTrackerOutput extracts filesystem paths from tracker search --files stdout.
+// Tracker outputs file:// URLs, typically indented two spaces and preceded by a
+// "Results:" header line and followed by a trailing count line. Any line that
+// contains a "file://" token has the URL extracted from that position, trimmed,
+// percent-decoded via net/url, and converted to an absolute filesystem path.
+// Lines with no "file://" token (header, blank, count) are silently ignored.
+func parseTrackerOutput(out []byte) []string {
+	var paths []string
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	for sc.Scan() {
+		line := sc.Text()
+		idx := strings.Index(line, "file://")
+		if idx < 0 {
+			continue
+		}
+		// Extract from "file://" to end of line (trim trailing whitespace).
+		rawURL := strings.TrimSpace(line[idx:])
+		u, err := url.Parse(rawURL)
+		if err != nil || u.Scheme != "file" || u.Path == "" {
+			continue
+		}
+		// u.Path is already percent-decoded by net/url.
+		paths = append(paths, u.Path)
+	}
+	return paths
+}

--- a/companion/internal/index/tracker_test.go
+++ b/companion/internal/index/tracker_test.go
@@ -1,0 +1,293 @@
+package index_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// --- TrackerIndexer tests ---
+//
+// Canned tracker3 search --files output format (what the parser must handle):
+//
+//	Results:
+//	  file:///abs/path/to/report.pdf
+//	  file:///abs/path/to/vacation%20photo.png
+//
+//	  2 results found.
+//
+// Rules:
+//   - Any line containing a "file://" token has the URL extracted (from "file://" to end of line).
+//   - The URL is percent-decoded via net/url so "vacation%20photo.png" → "vacation photo.png".
+//   - Lines with no "file://" token (header "Results:", blank, count "N results found.") are ignored.
+
+func TestTracker_Capabilities(t *testing.T) {
+	idx := index.NewTrackerIndexer(&fakeRunner{})
+	caps := idx.Capabilities()
+	if caps.BooleanOps {
+		t.Error("BooleanOps should be false")
+	}
+	if !caps.PrefixWildcard {
+		t.Error("PrefixWildcard should be true")
+	}
+	if caps.InfixWildcard {
+		t.Error("InfixWildcard should be false")
+	}
+	if caps.Regex {
+		t.Error("Regex should be false")
+	}
+	if caps.PathScope {
+		t.Error("PathScope should be false")
+	}
+	if !caps.Content {
+		t.Error("Content should be true")
+	}
+}
+
+func TestTracker_IDAndName(t *testing.T) {
+	idx := index.NewTrackerIndexer(&fakeRunner{})
+	if idx.ID() != "tracker" {
+		t.Errorf("ID=%q want tracker", idx.ID())
+	}
+	if idx.Name() != "GNOME Tracker" {
+		t.Errorf("Name=%q want 'GNOME Tracker'", idx.Name())
+	}
+}
+
+func TestTracker_RegexMode_Degraded(t *testing.T) {
+	fr := &fakeRunner{}
+	idx := index.NewTrackerIndexer(fr)
+
+	ast, _ := query.Parse(`inv.*\.pdf`, query.ModeRegex)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !degraded {
+		t.Error("expected degraded=true for regex mode (Tracker has no native regex)")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for degraded regex, got %d", len(results))
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for regex mode, got %d", len(fr.calls))
+	}
+}
+
+func TestTracker_SubstringMode_Command(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "report.pdf")
+	writeTestFile(t, f)
+
+	// Canned tracker3 output: header + indented file:// URL + blank + count.
+	stdout := "Results:\n  file://" + f + "\n\n  1 results found.\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewTrackerIndexer(fr)
+	idx.Bin = "tracker3" // set explicitly; tracker3 is not installed on this host
+
+	ast, _ := query.Parse("report", query.ModeSimple)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false for substring mode")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Path != f {
+		t.Errorf("path=%q want %q", results[0].Path, f)
+	}
+
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+	if call.name != "tracker3" {
+		t.Errorf("binary=%q want tracker3", call.name)
+	}
+	if !argsContain(call.args, "search") {
+		t.Error("expected 'search' subcommand in args")
+	}
+	if !argsContain(call.args, "--files") {
+		t.Error("expected --files flag")
+	}
+	if !argsContain(call.args, "--limit") {
+		t.Error("expected --limit flag")
+	}
+	if !argsContain(call.args, "500") {
+		t.Error("expected limit 500")
+	}
+	if !argsContain(call.args, "report") {
+		t.Error("expected seed 'report' in args")
+	}
+	ddIdx := argIndex(call.args, "--")
+	seedIdx := argIndex(call.args, "report")
+	if ddIdx < 0 {
+		t.Fatal("expected -- in args")
+	}
+	if ddIdx >= seedIdx {
+		t.Error("-- must appear before the seed")
+	}
+}
+
+func TestTracker_PercentDecoding(t *testing.T) {
+	dir := t.TempDir()
+	// File with a space in the name; tracker outputs it as %20 in the file:// URL.
+	f := filepath.Join(dir, "vacation photo.png")
+	writeTestFile(t, f)
+
+	// Simulate tracker3 percent-encoding spaces as %20.
+	encoded := "file://" + dir + "/vacation%20photo.png"
+	stdout := "Results:\n  " + encoded + "\n\n  1 results found.\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewTrackerIndexer(fr)
+	idx.Bin = "tracker3"
+
+	ast, _ := query.Parse("vacation", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Path != f {
+		t.Errorf("path=%q want %q (percent-decoding failed)", results[0].Path, f)
+	}
+}
+
+func TestTracker_HeaderAndCountLinesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "photo.png")
+	writeTestFile(t, f)
+
+	// Output with "Results:" header, blank line, and count trailer.
+	stdout := "Results:\n  file://" + f + "\n\n  1 results found.\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewTrackerIndexer(fr)
+	idx.Bin = "tracker3"
+
+	ast, _ := query.Parse("photo", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (header and count lines ignored), got %d", len(results))
+	}
+	if results[0].Path != f {
+		t.Errorf("path=%q want %q", results[0].Path, f)
+	}
+}
+
+func TestTracker_MissingPathsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "exists.txt")
+	writeTestFile(t, real)
+
+	stale := "file:///nonexistent/path/stale_tracker_entry_99.txt"
+	stdout := "Results:\n  file://" + real + "\n  " + stale + "\n\n  2 results found.\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewTrackerIndexer(fr)
+	idx.Bin = "tracker3"
+
+	ast, _ := query.Parse("exists", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (stale entry skipped), got %d", len(results))
+	}
+	if results[0].Path != real {
+		t.Errorf("path=%q want %q", results[0].Path, real)
+	}
+}
+
+func TestTracker_ORQuery_TwoInvocations(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "doc1.txt")
+	f2 := filepath.Join(dir, "doc2.txt")
+	writeTestFile(t, f1)
+	writeTestFile(t, f2)
+
+	fr := &fakeRunner{stdouts: []string{
+		"Results:\n  file://" + f1 + "\n\n  1 results found.\n",
+		"Results:\n  file://" + f2 + "\n\n  1 results found.\n",
+	}}
+	idx := index.NewTrackerIndexer(fr)
+	idx.Bin = "tracker3"
+
+	ast, _ := query.Parse("doc1 | doc2", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("expected 2 runner calls (one per OR branch), got %d", len(fr.calls))
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (union), got %d", len(results))
+	}
+}
+
+func TestTracker_DeduplicatePaths(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "dup.txt")
+	writeTestFile(t, f)
+
+	// Both branches return the same path.
+	fr := &fakeRunner{stdouts: []string{
+		"Results:\n  file://" + f + "\n\n  1 results found.\n",
+		"Results:\n  file://" + f + "\n\n  1 results found.\n",
+	}}
+	idx := index.NewTrackerIndexer(fr)
+	idx.Bin = "tracker3"
+
+	ast, _ := query.Parse("dup | dup", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 deduplicated result, got %d", len(results))
+	}
+}
+
+func TestTracker_PureNegation_NoCall(t *testing.T) {
+	fr := &fakeRunner{}
+	idx := index.NewTrackerIndexer(fr)
+
+	ast, _ := query.Parse("-foo", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for pure-negation branch, got %d", len(fr.calls))
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestTracker_ResultsNeverNil(t *testing.T) {
+	fr := &fakeRunner{stdouts: []string{"Results:\n\n  0 results found.\n"}}
+	idx := index.NewTrackerIndexer(fr)
+	idx.Bin = "tracker3"
+
+	ast, _ := query.Parse("anything", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if results == nil {
+		t.Error("results must never be nil")
+	}
+}

--- a/companion/internal/index/wsearch.go
+++ b/companion/internal/index/wsearch.go
@@ -1,0 +1,150 @@
+package index
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// wsearchLimit caps the number of index candidates requested per invocation.
+const wsearchLimit = 500
+
+// WindowsSearchIndexer queries the Windows Search index via PowerShell ADO
+// (ADODB.Connection against Provider=Search.CollatorDSO). It is inert on
+// non-Windows hosts where PowerShell is not on PATH.
+type WindowsSearchIndexer struct {
+	runner Runner
+	// Bin is the resolved powershell binary path, selected at construction time.
+	// Exported so tests can set it explicitly without PATH lookups.
+	Bin   string
+	avail bool
+}
+
+// NewWindowsSearchIndexer creates a WindowsSearchIndexer using r for command
+// execution. It resolves powershell / powershell.exe at construction time;
+// Available() returns false if neither is on PATH (e.g. on Linux/macOS).
+func NewWindowsSearchIndexer(r Runner) *WindowsSearchIndexer {
+	bin, ok := LookPath("powershell")
+	if !ok {
+		bin, ok = LookPath("powershell.exe")
+	}
+	return &WindowsSearchIndexer{runner: r, Bin: bin, avail: ok}
+}
+
+func (w *WindowsSearchIndexer) ID() string      { return "wsearch" }
+func (w *WindowsSearchIndexer) Name() string    { return "Windows Search" }
+func (w *WindowsSearchIndexer) Available() bool { return w.avail }
+
+// Capabilities for Windows Search:
+//   - BooleanOps: true          — WSearch SQL supports AND/OR/NOT operators
+//   - PrefixWildcard: true      — LIKE 'foo%' supported
+//   - InfixWildcard: true       — LIKE '%foo%' supported
+//   - Regex: false              — no native regex in WSearch SQL
+//   - PathScope: true           — queries target file path properties
+//   - Content: true             — WSearch indexes file content via IFilter
+func (w *WindowsSearchIndexer) Capabilities() protocol.Capabilities {
+	return protocol.Capabilities{
+		BooleanOps:     true,
+		PrefixWildcard: true,
+		InfixWildcard:  true,
+		Regex:          false,
+		PathScope:      true,
+		Content:        true,
+	}
+}
+
+// buildWSearchCommand returns the powershell args for querying the Windows
+// Search index for files whose name contains seed (LIKE '%seed%').
+//
+// This is a pure string builder with no side effects; tests call it
+// indirectly via Query and inspect fr.calls to assert the generated
+// command without executing real PowerShell.
+//
+// Escaping — two layers applied to seed:
+//  1. SQL: ' → '' so the LIKE predicate sees a literal single-quote.
+//  2. PowerShell single-quoted string: ' → '' for the $q = '...' assignment.
+//
+// When PowerShell parses the single-quoted $q assignment, layer 2 is undone,
+// yielding the SQL-escaped value. The ADODB Execute call then sees correct SQL
+// where '' is a literal '. Together the layers prevent SQL injection even when
+// the seed contains single-quotes or SQL metacharacters.
+//
+// Generated one-liner (seed="report", limit=500):
+//
+//	$q = 'report';
+//	$conn = New-Object -ComObject ADODB.Connection;
+//	$conn.Open('Provider=Search.CollatorDSO;Extended Properties=''Application=Windows''');
+//	$sql = 'SELECT TOP 500 System.ItemPathDisplay FROM SystemIndex WHERE System.FileName LIKE ''%' + $q + '%''';
+//	$rs = $conn.Execute($sql);
+//	while (-not $rs.EOF) { Write-Output $rs.Fields.Item('System.ItemPathDisplay').Value; $rs.MoveNext() };
+//	$conn.Close()
+func buildWSearchCommand(seed string, limit int) []string {
+	// Layer 1: SQL escaping — prevent injection in the LIKE predicate.
+	sqlSafe := strings.ReplaceAll(seed, "'", "''")
+	// Layer 2: PowerShell single-quoted string escaping for the $q assignment.
+	// After PowerShell evaluates $q = '...', it undoes this layer, leaving the
+	// SQL-escaped value in $q for safe concatenation into the SQL string.
+	psSafe := strings.ReplaceAll(sqlSafe, "'", "''")
+	script := fmt.Sprintf(
+		"$q = '%s'; "+
+			"$conn = New-Object -ComObject ADODB.Connection; "+
+			"$conn.Open('Provider=Search.CollatorDSO;Extended Properties=''Application=Windows'''); "+
+			"$sql = 'SELECT TOP %d System.ItemPathDisplay FROM SystemIndex WHERE System.FileName LIKE ''%%' + $q + '%%'''; "+
+			"$rs = $conn.Execute($sql); "+
+			"while (-not $rs.EOF) { Write-Output $rs.Fields.Item('System.ItemPathDisplay').Value; $rs.MoveNext() }; "+
+			"$conn.Close()",
+		psSafe, limit)
+	return []string{"-NoProfile", "-NonInteractive", "-Command", script}
+}
+
+// Query returns candidate FileResults from the Windows Search index.
+//
+// Regex mode is not supported by Windows Search SQL. If the AST is a regex
+// node, Query returns (nil, true, nil) — degraded, no error — so the registry
+// can route the query to a regex-capable backend.
+//
+// Otherwise, for each OR branch with a positive literal seed, issues one
+// PowerShell invocation (via buildWSearchCommand) and unions the results.
+// Stdout is expected to contain one absolute Windows path per line.
+func (w *WindowsSearchIndexer) Query(ctx context.Context, ast query.Node, _ query.Mode, _ protocol.SearchRequest) ([]protocol.FileResult, bool, error) {
+	if _, ok := RegexPattern(ast); ok {
+		// Windows Search has no native regex; signal degraded so the registry
+		// routes the query to a regex-capable backend.
+		return nil, true, nil
+	}
+
+	var all []string
+	for _, branch := range ORBranches(ast) {
+		seed, ok := PositiveSeed(branch)
+		if !ok {
+			// No positive literal anchor (e.g. pure negation); skip this branch.
+			continue
+		}
+		args := buildWSearchCommand(seed, wsearchLimit)
+		out, err := w.runner.Run(ctx, w.Bin, args...)
+		if err != nil {
+			continue
+		}
+		all = append(all, parseWinPaths(out)...)
+	}
+	return normalizeAndDedupe(all), false, nil
+}
+
+// parseWinPaths reads one-path-per-line stdout (Windows Search ADO or es).
+// Blank and whitespace-only lines are silently ignored.
+func parseWinPaths(out []byte) []string {
+	var paths []string
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
+}

--- a/companion/internal/index/wsearch.go
+++ b/companion/internal/index/wsearch.go
@@ -119,6 +119,7 @@ func (w *WindowsSearchIndexer) Query(ctx context.Context, ast query.Node, _ quer
 	}
 
 	var all []string
+	degraded := false
 	for _, branch := range ORBranches(ast) {
 		seed, ok := PositiveSeed(branch)
 		if !ok {
@@ -130,9 +131,15 @@ func (w *WindowsSearchIndexer) Query(ctx context.Context, ast query.Node, _ quer
 		if err != nil {
 			continue
 		}
-		all = append(all, parseWinPaths(out)...)
+		paths := parseWinPaths(out)
+		if len(paths) >= wsearchLimit {
+			// Cap hit: the index returned exactly the limit, so results may be
+			// incomplete. Signal degraded so the count is not presented as exact.
+			degraded = true
+		}
+		all = append(all, paths...)
 	}
-	return normalizeAndDedupe(all), false, nil
+	return normalizeAndDedupe(all), degraded, nil
 }
 
 // parseWinPaths reads one-path-per-line stdout (Windows Search ADO or es).

--- a/companion/internal/index/wsearch_test.go
+++ b/companion/internal/index/wsearch_test.go
@@ -1,0 +1,295 @@
+package index_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// --- WindowsSearchIndexer tests ---
+//
+// WindowsSearch queries via PowerShell ADO against the Windows Search index.
+// On Linux (CI), powershell is absent so Available()=false. All tests use a
+// fakeRunner so no real PowerShell is invoked.
+//
+// The generated PowerShell one-liner (for seed="report", limit=500):
+//
+//	$q = 'report';
+//	$conn = New-Object -ComObject ADODB.Connection;
+//	$conn.Open('Provider=Search.CollatorDSO;Extended Properties=''Application=Windows''');
+//	$sql = 'SELECT TOP 500 System.ItemPathDisplay FROM SystemIndex WHERE System.FileName LIKE ''%' + $q + '%''';
+//	$rs = $conn.Execute($sql);
+//	while (-not $rs.EOF) { Write-Output $rs.Fields.Item('System.ItemPathDisplay').Value; $rs.MoveNext() };
+//	$conn.Close()
+
+func TestWSearch_Capabilities(t *testing.T) {
+	idx := index.NewWindowsSearchIndexer(&fakeRunner{})
+	caps := idx.Capabilities()
+	if !caps.BooleanOps {
+		t.Error("BooleanOps should be true")
+	}
+	if !caps.PrefixWildcard {
+		t.Error("PrefixWildcard should be true")
+	}
+	if !caps.InfixWildcard {
+		t.Error("InfixWildcard should be true")
+	}
+	if caps.Regex {
+		t.Error("Regex should be false")
+	}
+	if !caps.PathScope {
+		t.Error("PathScope should be true")
+	}
+	if !caps.Content {
+		t.Error("Content should be true")
+	}
+}
+
+func TestWSearch_IDAndName(t *testing.T) {
+	idx := index.NewWindowsSearchIndexer(&fakeRunner{})
+	if idx.ID() != "wsearch" {
+		t.Errorf("ID=%q want wsearch", idx.ID())
+	}
+	if idx.Name() != "Windows Search" {
+		t.Errorf("Name=%q want 'Windows Search'", idx.Name())
+	}
+}
+
+func TestWSearch_RegexMode_DegradedNoCall(t *testing.T) {
+	// Windows Search has no native regex; must return (nil, true, nil) without
+	// issuing any runner call.
+	fr := &fakeRunner{}
+	idx := index.NewWindowsSearchIndexer(fr)
+
+	ast, _ := query.Parse(`inv.*\.pdf`, query.ModeRegex)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeRegex, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !degraded {
+		t.Error("expected degraded=true for regex mode (WSearch has no native regex)")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for degraded regex, got %d", len(results))
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for regex mode, got %d", len(fr.calls))
+	}
+}
+
+func TestWSearch_SubstringMode_Command(t *testing.T) {
+	// Verify the generated powershell invocation structure.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "report.pdf")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n"}}
+	idx := index.NewWindowsSearchIndexer(fr)
+	idx.Bin = "powershell"
+
+	ast, _ := query.Parse("report", query.ModeSimple)
+	results, degraded, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if degraded {
+		t.Error("expected degraded=false for substring mode")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Path != f {
+		t.Errorf("path=%q want %q", results[0].Path, f)
+	}
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+
+	call := fr.calls[0]
+	if call.name != "powershell" {
+		t.Errorf("binary=%q want powershell", call.name)
+	}
+	if !argsContain(call.args, "-NoProfile") {
+		t.Error("expected -NoProfile flag")
+	}
+	if !argsContain(call.args, "-NonInteractive") {
+		t.Error("expected -NonInteractive flag")
+	}
+	cmdIdx := argIndex(call.args, "-Command")
+	if cmdIdx < 0 {
+		t.Fatal("expected -Command flag")
+	}
+	if cmdIdx+1 >= len(call.args) {
+		t.Fatal("-Command must be followed by the script argument")
+	}
+	script := call.args[cmdIdx+1]
+	if !strings.Contains(script, "ADODB.Connection") {
+		t.Error("script must reference ADODB.Connection")
+	}
+	if !strings.Contains(script, "SystemIndex") {
+		t.Error("script must query SystemIndex")
+	}
+	if !strings.Contains(script, "report") {
+		t.Error("script must embed the seed 'report'")
+	}
+	if !strings.Contains(script, "500") {
+		t.Error("script must embed limit 500")
+	}
+	if !strings.Contains(script, "System.ItemPathDisplay") {
+		t.Error("script must select System.ItemPathDisplay")
+	}
+	if !strings.Contains(script, "Write-Output") {
+		t.Error("script must emit results via Write-Output")
+	}
+}
+
+func TestWSearch_BuildCommand_SQLEscape(t *testing.T) {
+	// A seed with a single-quote must not cause SQL injection in the generated script.
+	fr := &fakeRunner{stdouts: []string{""}}
+	idx := index.NewWindowsSearchIndexer(fr)
+	idx.Bin = "powershell"
+
+	ast, _ := query.Parse("O'Brien", query.ModeSimple)
+	_, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(fr.calls))
+	}
+	script := fr.calls[0].args[len(fr.calls[0].args)-1]
+	// The raw seed "O'Brien" must not appear as a bare unescaped single-quote
+	// in a position that could break the SQL string literal.
+	// The escaped form should use doubled single-quotes ('' at each layer).
+	if strings.Contains(script, "$q = 'O'Brien'") {
+		t.Error("seed single-quote must be escaped; unescaped form found in $q assignment")
+	}
+	// There must be doubled single-quotes representing the escaped seed.
+	if !strings.Contains(script, "''") {
+		t.Error("expected escaped single-quotes ('') in generated script")
+	}
+}
+
+func TestWSearch_MissingPathsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "exists.txt")
+	writeTestFile(t, real)
+
+	// Simulate a stale Windows path mixed with the real Linux temp path.
+	stdout := real + "\nC:\\Windows\\stale_wsearch_entry_99.txt\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewWindowsSearchIndexer(fr)
+	idx.Bin = "powershell"
+
+	ast, _ := query.Parse("exists", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (stale entry skipped), got %d", len(results))
+	}
+	if results[0].Path != real {
+		t.Errorf("path=%q want %q", results[0].Path, real)
+	}
+}
+
+func TestWSearch_ORQuery_TwoInvocations(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "doc1.txt")
+	f2 := filepath.Join(dir, "doc2.txt")
+	writeTestFile(t, f1)
+	writeTestFile(t, f2)
+
+	fr := &fakeRunner{stdouts: []string{f1 + "\n", f2 + "\n"}}
+	idx := index.NewWindowsSearchIndexer(fr)
+	idx.Bin = "powershell"
+
+	ast, _ := query.Parse("doc1 | doc2", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("expected 2 runner calls (one per OR branch), got %d", len(fr.calls))
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (union), got %d", len(results))
+	}
+}
+
+func TestWSearch_DeduplicatePaths(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "dup.txt")
+	writeTestFile(t, f)
+
+	fr := &fakeRunner{stdouts: []string{f + "\n", f + "\n"}}
+	idx := index.NewWindowsSearchIndexer(fr)
+	idx.Bin = "powershell"
+
+	ast, _ := query.Parse("dup | dup", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 deduplicated result, got %d", len(results))
+	}
+}
+
+func TestWSearch_PureNegation_NoCall(t *testing.T) {
+	fr := &fakeRunner{}
+	idx := index.NewWindowsSearchIndexer(fr)
+
+	ast, _ := query.Parse("-foo", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("expected no runner calls for pure-negation branch, got %d", len(fr.calls))
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestWSearch_ResultsNeverNil(t *testing.T) {
+	fr := &fakeRunner{stdouts: []string{""}}
+	idx := index.NewWindowsSearchIndexer(fr)
+	idx.Bin = "powershell"
+
+	ast, _ := query.Parse("anything", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if results == nil {
+		t.Error("results must never be nil")
+	}
+}
+
+func TestWSearch_BlankLinesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "note.txt")
+	writeTestFile(t, f)
+
+	stdout := "\n  \n" + f + "\n\n"
+	fr := &fakeRunner{stdouts: []string{stdout}}
+	idx := index.NewWindowsSearchIndexer(fr)
+	idx.Bin = "powershell"
+
+	ast, _ := query.Parse("note", query.ModeSimple)
+	results, _, err := idx.Query(context.Background(), ast, query.ModeSimple, protocol.SearchRequest{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+}

--- a/companion/internal/index/wsearch_test.go
+++ b/companion/internal/index/wsearch_test.go
@@ -74,8 +74,8 @@ func TestWSearch_RegexMode_DegradedNoCall(t *testing.T) {
 	if !degraded {
 		t.Error("expected degraded=true for regex mode (WSearch has no native regex)")
 	}
-	if len(results) != 0 {
-		t.Errorf("expected 0 results for degraded regex, got %d", len(results))
+	if results != nil {
+		t.Errorf("expected nil results for degraded regex (contract: nil, true, nil), got %v", results)
 	}
 	if len(fr.calls) != 0 {
 		t.Errorf("expected no runner calls for regex mode, got %d", len(fr.calls))
@@ -169,9 +169,11 @@ func TestWSearch_BuildCommand_SQLEscape(t *testing.T) {
 	if strings.Contains(script, "$q = 'O'Brien'") {
 		t.Error("seed single-quote must be escaped; unescaped form found in $q assignment")
 	}
-	// There must be doubled single-quotes representing the escaped seed.
-	if !strings.Contains(script, "''") {
-		t.Error("expected escaped single-quotes ('') in generated script")
+	// For "O'Brien": layer-1 SQL escape gives O''Brien; layer-2 PS escape doubles
+	// each of those quotes giving O''''Brien. The four-quote sequence '''' must
+	// appear in the generated script.
+	if !strings.Contains(script, "''''") {
+		t.Error("expected four-quote escaped form ('''' ) in generated script for single-quote input")
 	}
 }
 

--- a/companion/internal/pairing/pairing.go
+++ b/companion/internal/pairing/pairing.go
@@ -1,0 +1,255 @@
+// Package pairing implements the companion daemon's security boundary.
+//
+// It mints and persists a 256-bit bearer token, enforces an Origin allowlist
+// for auto-pairing, and manages a time-bounded pairing window that the user
+// must explicitly open before an unknown extension can pair. All data endpoints
+// must call Authorize; arbitrary local pages that never paired cannot obtain
+// a token and therefore cannot read the user's files.
+package pairing
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// ErrPairingClosed is returned by Pair when the pairing window is closed and
+// the caller's origin is not on the configured allowlist.
+var ErrPairingClosed = errors.New("pairing closed")
+
+// persistedState is the JSON representation written to pairing.json.
+type persistedState struct {
+	Token          string   `json:"token"`
+	AllowedOrigins []string `json:"allowedOrigins"`
+	ClientName     string   `json:"clientName"`
+}
+
+// Manager holds the pairing state for a companion daemon instance.
+// All exported methods are safe for concurrent use.
+type Manager struct {
+	mu              sync.Mutex
+	configDir       string
+	configAllowlist []string // origins from New args (never changes)
+	now             func() time.Time
+
+	// Fields below are guarded by mu.
+	token         string
+	pairedOrigins []string // origins that have been granted this token
+	clientName    string
+	windowExpiry  time.Time // zero → closed
+}
+
+// New loads any persisted pairing state from configDir and returns a Manager.
+// allowedOrigins is the Origin allowlist for auto-pair (e.g.
+// []string{"chrome-extension://<id>"}); may be nil. A missing pairing.json is
+// treated as unpaired; a malformed file is also treated as unpaired (no crash).
+func New(configDir string, allowedOrigins []string) (*Manager, error) {
+	return NewWithClock(configDir, allowedOrigins, time.Now)
+}
+
+// NewWithClock is like New but accepts an injectable clock so that
+// pairing-window-expiry tests are deterministic and fast.
+func NewWithClock(configDir string, allowedOrigins []string, now func() time.Time) (*Manager, error) {
+	m := &Manager{
+		configDir:       configDir,
+		configAllowlist: allowedOrigins,
+		now:             now,
+	}
+	if err := m.load(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// Paired reports whether a token has been issued (i.e. at least one origin has
+// successfully paired).
+func (m *Manager) Paired() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.token != ""
+}
+
+// PairingOpen reports whether the pairing window is currently open.
+func (m *Manager) PairingOpen() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.windowOpenLocked()
+}
+
+// OpenPairingWindow opens the pairing window for duration d from now. Used on
+// first run (when unpaired) and when the user clicks "Open pairing" on the
+// setup page.
+func (m *Manager) OpenPairingWindow(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.windowExpiry = m.now().Add(d)
+}
+
+// ClosePairingWindow closes the pairing window immediately.
+func (m *Manager) ClosePairingWindow() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.windowExpiry = time.Time{}
+}
+
+// Authorize reports whether a data request bearing token from origin is
+// permitted. Both conditions must hold: the token must exactly match the stored
+// token (constant-time comparison) AND origin must be a previously paired
+// origin. Returns false immediately when unpaired.
+func (m *Manager) Authorize(origin, token string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.token == "" {
+		return false
+	}
+	// Constant-time compare — length mismatch safely returns 0.
+	if subtle.ConstantTimeCompare([]byte(token), []byte(m.token)) != 1 {
+		return false
+	}
+	return m.hasPairedOrigin(origin)
+}
+
+// Pair grants a token to a caller. It succeeds only when PairingOpen() == true
+// OR origin is on the configured allowlist. On success it:
+//   - generates a 256-bit token if one does not already exist (re-pairing the
+//     same origin is idempotent: the existing token is reused),
+//   - records origin in the set of paired origins (deduplicated),
+//   - persists state to disk,
+//   - closes the pairing window, and
+//   - returns the token.
+//
+// On failure it returns ("", ErrPairingClosed). No token is leaked in error
+// messages.
+func (m *Manager) Pair(origin, clientName string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.windowOpenLocked() && !m.isAllowlisted(origin) {
+		return "", ErrPairingClosed
+	}
+
+	// Mint a token on first pair; reuse the existing one thereafter so that
+	// multiple browsers share the same token and re-pairing is idempotent.
+	if m.token == "" {
+		tok, err := generateToken()
+		if err != nil {
+			return "", err
+		}
+		m.token = tok
+		m.clientName = clientName
+	}
+
+	// Record origin (deduplicated).
+	if !m.hasPairedOrigin(origin) {
+		m.pairedOrigins = append(m.pairedOrigins, origin)
+	}
+
+	// Close the window — a deliberate user action is consumed on success.
+	m.windowExpiry = time.Time{}
+
+	if err := m.save(); err != nil {
+		return "", err
+	}
+	return m.token, nil
+}
+
+// Unpair clears the token, paired origins, and removes the persisted file.
+// Calling Unpair on an already-unpaired Manager is a no-op (no error).
+func (m *Manager) Unpair() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.token = ""
+	m.pairedOrigins = nil
+	m.clientName = ""
+	m.windowExpiry = time.Time{}
+
+	path := filepath.Join(m.configDir, "pairing.json")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (all called with m.mu held unless noted)
+// ---------------------------------------------------------------------------
+
+func (m *Manager) windowOpenLocked() bool {
+	return !m.windowExpiry.IsZero() && m.now().Before(m.windowExpiry)
+}
+
+func (m *Manager) isAllowlisted(origin string) bool {
+	for _, o := range m.configAllowlist {
+		if o == origin {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) hasPairedOrigin(origin string) bool {
+	for _, o := range m.pairedOrigins {
+		if o == origin {
+			return true
+		}
+	}
+	return false
+}
+
+// load reads pairing.json from configDir. Missing → unpaired (no error).
+// Malformed → unpaired (no error, no crash).
+func (m *Manager) load() error {
+	path := filepath.Join(m.configDir, "pairing.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var s persistedState
+	if err := json.Unmarshal(data, &s); err != nil {
+		// Malformed file: treat as unpaired.
+		return nil
+	}
+	if s.Token != "" {
+		m.token = s.Token
+		m.pairedOrigins = s.AllowedOrigins
+		m.clientName = s.ClientName
+	}
+	return nil
+}
+
+// save writes current state to pairing.json with 0600 permissions.
+// Must be called with m.mu held.
+func (m *Manager) save() error {
+	if err := os.MkdirAll(m.configDir, 0700); err != nil {
+		return err
+	}
+	s := persistedState{
+		Token:          m.token,
+		AllowedOrigins: m.pairedOrigins,
+		ClientName:     m.clientName,
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(m.configDir, "pairing.json"), data, 0600)
+}
+
+// generateToken returns a cryptographically random 256-bit token encoded as
+// lowercase hex (64 characters).
+func generateToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/companion/internal/pairing/pairing.go
+++ b/companion/internal/pairing/pairing.go
@@ -134,6 +134,14 @@ func (m *Manager) Pair(origin, clientName string) (string, error) {
 		return "", ErrPairingClosed
 	}
 
+	// Snapshot mutable fields so we can restore them atomically if save fails.
+	// This ensures a disk error cannot silently consume the pairing window or
+	// leave an in-memory token that was never persisted.
+	snapToken := m.token
+	snapClientName := m.clientName
+	snapOrigins := m.pairedOrigins
+	snapWindowExpiry := m.windowExpiry
+
 	// Mint a token on first pair; reuse the existing one thereafter so that
 	// multiple browsers share the same token and re-pairing is idempotent.
 	if m.token == "" {
@@ -154,6 +162,12 @@ func (m *Manager) Pair(origin, clientName string) (string, error) {
 	m.windowExpiry = time.Time{}
 
 	if err := m.save(); err != nil {
+		// Roll back all mutations so the Manager is exactly as it was before
+		// this call: PairingOpen()/Paired()/Authorize() must be unchanged.
+		m.token = snapToken
+		m.clientName = snapClientName
+		m.pairedOrigins = snapOrigins
+		m.windowExpiry = snapWindowExpiry
 		return "", err
 	}
 	return m.token, nil

--- a/companion/internal/pairing/pairing_test.go
+++ b/companion/internal/pairing/pairing_test.go
@@ -189,6 +189,10 @@ func TestAllowlistOriginPairsWithoutWindow(t *testing.T) {
 	if !m.Paired() {
 		t.Error("must be paired after successful auto-pair")
 	}
+	// End-to-end: allowlist-pair → authorize must work.
+	if !m.Authorize(allowed, tok) {
+		t.Error("expected Authorize true for allowlisted origin after pairing")
+	}
 }
 
 func TestUnknownOriginFailsWithAllowlistPresent(t *testing.T) {
@@ -332,19 +336,32 @@ func TestPersistenceRoundTrip(t *testing.T) {
 }
 
 func TestPersistenceFileMode(t *testing.T) {
-	dir := t.TempDir()
+	// Use a subdirectory that does not yet exist so that save() creates it via
+	// MkdirAll and we can verify the permissions our code sets, not the OS default.
+	dir := filepath.Join(t.TempDir(), "configdir")
 	m := newManager(t, dir, nil)
 	m.OpenPairingWindow(time.Minute)
 	_, err := m.Pair("chrome-extension://abc", "Browser A")
 	if err != nil {
 		t.Fatalf("Pair: %v", err)
 	}
+
+	// File must be 0600.
 	info, err := os.Stat(filepath.Join(dir, "pairing.json"))
 	if err != nil {
 		t.Fatalf("stat pairing.json: %v", err)
 	}
 	if mode := info.Mode().Perm(); mode != 0600 {
 		t.Errorf("expected file mode 0600, got %04o", mode)
+	}
+
+	// Config dir must be 0700.
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat config dir: %v", err)
+	}
+	if mode := dirInfo.Mode().Perm(); mode != 0700 {
+		t.Errorf("expected dir mode 0700, got %04o", mode)
 	}
 }
 
@@ -407,5 +424,44 @@ func TestUnpairIdempotent(t *testing.T) {
 	// Unpair when already unpaired must not error.
 	if err := m.Unpair(); err != nil {
 		t.Errorf("Unpair on unpaired Manager must not error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rollback on save failure
+// ---------------------------------------------------------------------------
+
+// TestPairRollsBackStateOnSaveFailure verifies that a Pair call that succeeds
+// in-memory but fails to persist leaves the Manager exactly as it was before
+// the call: the pairing window is not consumed and Paired() remains false.
+//
+// The save failure is forced by pre-creating pairing.json as a directory so
+// that os.WriteFile returns an error (is a directory).
+func TestPairRollsBackStateOnSaveFailure(t *testing.T) {
+	dir := t.TempDir()
+	m, err := pairing.NewWithClock(dir, nil, time.Now)
+	if err != nil {
+		t.Fatalf("NewWithClock: %v", err)
+	}
+	m.OpenPairingWindow(time.Minute)
+
+	// Pre-create pairing.json as a directory so WriteFile will fail.
+	pairingPath := filepath.Join(dir, "pairing.json")
+	if err := os.Mkdir(pairingPath, 0700); err != nil {
+		t.Fatalf("setup mkdir pairing.json: %v", err)
+	}
+
+	_, pairErr := m.Pair("chrome-extension://abc", "Browser A")
+	if pairErr == nil {
+		t.Fatal("expected Pair to return an error when save fails")
+	}
+
+	// Pairing window must NOT have been consumed — state rolled back.
+	if !m.PairingOpen() {
+		t.Error("PairingOpen() must still be true after save failure (window not consumed)")
+	}
+	// Token must NOT have been set — no in-memory token without persistence.
+	if m.Paired() {
+		t.Error("Paired() must be false after save failure (rollback)")
 	}
 }

--- a/companion/internal/pairing/pairing_test.go
+++ b/companion/internal/pairing/pairing_test.go
@@ -1,0 +1,411 @@
+package pairing_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/pairing"
+)
+
+// helper: New with the real clock, fatal on error.
+func newManager(t *testing.T, configDir string, allowedOrigins []string) *pairing.Manager {
+	t.Helper()
+	m, err := pairing.New(configDir, allowedOrigins)
+	if err != nil {
+		t.Fatalf("pairing.New: %v", err)
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// Token properties
+// ---------------------------------------------------------------------------
+
+func TestTokenUniqueness(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	m1 := newManager(t, dir1, nil)
+	m1.OpenPairingWindow(time.Minute)
+	tok1, err := m1.Pair("chrome-extension://aaa", "Browser A")
+	if err != nil {
+		t.Fatalf("m1.Pair: %v", err)
+	}
+
+	m2 := newManager(t, dir2, nil)
+	m2.OpenPairingWindow(time.Minute)
+	tok2, err := m2.Pair("chrome-extension://aaa", "Browser A")
+	if err != nil {
+		t.Fatalf("m2.Pair: %v", err)
+	}
+
+	if tok1 == tok2 {
+		t.Errorf("tokens must be unique across managers, both = %q", tok1)
+	}
+}
+
+func TestTokenStabilityWithinManager(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	origin := "chrome-extension://abc"
+
+	tok1, err := m.Pair(origin, "Browser A")
+	if err != nil {
+		t.Fatalf("first Pair: %v", err)
+	}
+	if tok1 == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	// Re-open window and pair same origin again — must reuse token (idempotent).
+	m.OpenPairingWindow(time.Minute)
+	tok2, err := m.Pair(origin, "Browser A")
+	if err != nil {
+		t.Fatalf("second Pair: %v", err)
+	}
+	if tok1 != tok2 {
+		t.Errorf("token must be stable within a Manager: got %q then %q", tok1, tok2)
+	}
+}
+
+func TestTokenFormat(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	tok, _ := m.Pair("origin", "name")
+
+	// 32 bytes → 64 hex chars.
+	if len(tok) != 64 {
+		t.Errorf("expected 64-char hex token (256-bit), got len=%d: %q", len(tok), tok)
+	}
+	for _, c := range tok {
+		if !('0' <= c && c <= '9') && !('a' <= c && c <= 'f') {
+			t.Errorf("token contains non-lowercase-hex character %q", c)
+			break
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pairing window
+// ---------------------------------------------------------------------------
+
+func TestPairFailsWhenWindowClosed(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	// Window never opened; no allowlist.
+	_, err := m.Pair("chrome-extension://unknown", "Browser A")
+	if !errors.Is(err, pairing.ErrPairingClosed) {
+		t.Fatalf("expected ErrPairingClosed, got %v", err)
+	}
+	if m.Paired() {
+		t.Error("must not be paired after failed Pair")
+	}
+}
+
+func TestPairSucceedsWhenWindowOpen(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	if !m.PairingOpen() {
+		t.Fatal("expected pairing window to be open")
+	}
+
+	tok, err := m.Pair("chrome-extension://any", "Browser A")
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+	if tok == "" {
+		t.Error("expected non-empty token")
+	}
+	if !m.Paired() {
+		t.Error("must be paired after successful Pair")
+	}
+	if m.PairingOpen() {
+		t.Error("pairing window must close after successful Pair")
+	}
+}
+
+func TestPairingWindowAutoExpiresInjectableClock(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	m, err := pairing.NewWithClock(dir, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("NewWithClock: %v", err)
+	}
+
+	m.OpenPairingWindow(5 * time.Minute)
+	if !m.PairingOpen() {
+		t.Fatal("expected pairing window open immediately after OpenPairingWindow")
+	}
+
+	// Advance clock past expiry.
+	now = now.Add(6 * time.Minute)
+	if m.PairingOpen() {
+		t.Error("expected pairing window closed after clock advances past expiry")
+	}
+
+	_, err = m.Pair("chrome-extension://x", "Browser")
+	if !errors.Is(err, pairing.ErrPairingClosed) {
+		t.Errorf("expected ErrPairingClosed after window expiry, got %v", err)
+	}
+}
+
+func TestClosePairingWindowManually(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Hour)
+	m.ClosePairingWindow()
+
+	if m.PairingOpen() {
+		t.Error("expected window closed after ClosePairingWindow")
+	}
+	_, err := m.Pair("chrome-extension://x", "Browser")
+	if !errors.Is(err, pairing.ErrPairingClosed) {
+		t.Errorf("expected ErrPairingClosed, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Origin allowlist auto-pair
+// ---------------------------------------------------------------------------
+
+func TestAllowlistOriginPairsWithoutWindow(t *testing.T) {
+	dir := t.TempDir()
+	allowed := "chrome-extension://abc123"
+	m := newManager(t, dir, []string{allowed})
+	// Window closed; origin is allowlisted → should succeed.
+	tok, err := m.Pair(allowed, "Browser A")
+	if err != nil {
+		t.Fatalf("Pair with allowlisted origin: %v", err)
+	}
+	if tok == "" {
+		t.Error("expected non-empty token")
+	}
+	if !m.Paired() {
+		t.Error("must be paired after successful auto-pair")
+	}
+}
+
+func TestUnknownOriginFailsWithAllowlistPresent(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, []string{"chrome-extension://abc123"})
+	_, err := m.Pair("chrome-extension://other", "Browser B")
+	if !errors.Is(err, pairing.ErrPairingClosed) {
+		t.Errorf("expected ErrPairingClosed for unknown origin, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Authorize
+// ---------------------------------------------------------------------------
+
+func TestAuthorizeCorrectTokenAndOrigin(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	origin := "chrome-extension://abc"
+	tok, err := m.Pair(origin, "Browser A")
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+	if !m.Authorize(origin, tok) {
+		t.Error("expected Authorize true for correct token+origin")
+	}
+}
+
+func TestAuthorizeWrongToken(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	origin := "chrome-extension://abc"
+	_, err := m.Pair(origin, "Browser A")
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+	if m.Authorize(origin, "wrongtoken") {
+		t.Error("expected Authorize false for wrong token")
+	}
+}
+
+func TestAuthorizeWrongOrigin(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	tok, err := m.Pair("chrome-extension://abc", "Browser A")
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+	if m.Authorize("chrome-extension://other", tok) {
+		t.Error("expected Authorize false for wrong origin")
+	}
+}
+
+func TestAuthorizeWhenUnpaired(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	if m.Authorize("chrome-extension://abc", "sometoken") {
+		t.Error("expected Authorize false when unpaired")
+	}
+}
+
+func TestAuthorizeMultipleOriginsSameToken(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+
+	origin1 := "chrome-extension://aaa"
+	origin2 := "chrome-extension://bbb"
+
+	m.OpenPairingWindow(time.Hour)
+	tok1, err := m.Pair(origin1, "Browser A")
+	if err != nil {
+		t.Fatalf("Pair origin1: %v", err)
+	}
+
+	// Re-open window to allow second pairing.
+	m.OpenPairingWindow(time.Hour)
+	tok2, err := m.Pair(origin2, "Browser B")
+	if err != nil {
+		t.Fatalf("Pair origin2: %v", err)
+	}
+
+	if tok1 != tok2 {
+		t.Errorf("expected same token for both origins: got %q and %q", tok1, tok2)
+	}
+	if !m.Authorize(origin1, tok1) {
+		t.Error("origin1 must be authorized")
+	}
+	if !m.Authorize(origin2, tok1) {
+		t.Error("origin2 must be authorized")
+	}
+}
+
+// Verify that Authorize uses constant-time comparison (call it with empty vs
+// non-empty token to exercise the code path; timing is not measured here).
+func TestAuthorizeConstantTimeCompareIsUsed(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	origin := "chrome-extension://abc"
+	tok, _ := m.Pair(origin, "Browser A")
+
+	// Empty string must not panic and must return false.
+	if m.Authorize(origin, "") {
+		t.Error("expected Authorize false for empty token")
+	}
+	// Correct token must still pass.
+	if !m.Authorize(origin, tok) {
+		t.Error("expected Authorize true for correct token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+func TestPersistenceRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	origin := "chrome-extension://abc"
+
+	m1 := newManager(t, dir, nil)
+	m1.OpenPairingWindow(time.Minute)
+	tok, err := m1.Pair(origin, "Browser A")
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+
+	// Load a fresh Manager from the same dir.
+	m2, err := pairing.New(dir, nil)
+	if err != nil {
+		t.Fatalf("New (reload): %v", err)
+	}
+	if !m2.Paired() {
+		t.Error("expected Paired() true after reload")
+	}
+	if !m2.Authorize(origin, tok) {
+		t.Error("expected Authorize to succeed after reload")
+	}
+}
+
+func TestPersistenceFileMode(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	_, err := m.Pair("chrome-extension://abc", "Browser A")
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "pairing.json"))
+	if err != nil {
+		t.Fatalf("stat pairing.json: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("expected file mode 0600, got %04o", mode)
+	}
+}
+
+func TestMalformedFileTreatedAsUnpaired(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pairing.json"), []byte("not-json{{{{"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	m, err := pairing.New(dir, nil)
+	if err != nil {
+		t.Fatalf("New with malformed file must not error: %v", err)
+	}
+	if m.Paired() {
+		t.Error("expected unpaired after malformed file")
+	}
+}
+
+func TestMissingFileTreatedAsUnpaired(t *testing.T) {
+	dir := t.TempDir()
+	m, err := pairing.New(dir, nil)
+	if err != nil {
+		t.Fatalf("New with missing file must not error: %v", err)
+	}
+	if m.Paired() {
+		t.Error("expected unpaired when file missing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unpair
+// ---------------------------------------------------------------------------
+
+func TestUnpairClearsStateAndRemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	m.OpenPairingWindow(time.Minute)
+	tok, err := m.Pair("chrome-extension://abc", "Browser A")
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+
+	if err := m.Unpair(); err != nil {
+		t.Fatalf("Unpair: %v", err)
+	}
+	if m.Paired() {
+		t.Error("expected unpaired after Unpair")
+	}
+	if m.Authorize("chrome-extension://abc", tok) {
+		t.Error("expected Authorize false after Unpair")
+	}
+	_, err = os.Stat(filepath.Join(dir, "pairing.json"))
+	if !os.IsNotExist(err) {
+		t.Errorf("expected pairing.json removed after Unpair, stat returned: %v", err)
+	}
+}
+
+func TestUnpairIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	m := newManager(t, dir, nil)
+	// Unpair when already unpaired must not error.
+	if err := m.Unpair(); err != nil {
+		t.Errorf("Unpair on unpaired Manager must not error: %v", err)
+	}
+}

--- a/companion/internal/protocol/types.go
+++ b/companion/internal/protocol/types.go
@@ -1,0 +1,159 @@
+// Package protocol defines the Go structs that mirror the Fast Travel companion
+// wire contract (shared/companion-protocol/protocol.schema.json).
+// JSON field names match the schema exactly.
+package protocol
+
+import "github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+
+// ProtocolVersion is the current protocol schema version.
+const ProtocolVersion = 1
+
+// FileType is a broad file-type category.
+type FileType string
+
+const (
+	FileTypeDocument FileType = "document"
+	FileTypeImage    FileType = "image"
+	FileTypeVideo    FileType = "video"
+	FileTypeAudio    FileType = "audio"
+	FileTypeArchive  FileType = "archive"
+	FileTypeCode     FileType = "code"
+	FileTypeFolder   FileType = "folder"
+	FileTypeOther    FileType = "other"
+)
+
+// OS identifies the operating system running the companion daemon.
+type OS string
+
+const (
+	OSLinux   OS = "linux"
+	OSWindows OS = "windows"
+	OSMacOS   OS = "macos"
+	OSAndroid OS = "android"
+)
+
+// FileResult is a single file match returned by /v1/search.
+type FileResult struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Path       string   `json:"path"`
+	Dir        string   `json:"dir"`
+	Ext        string   `json:"ext"`
+	Mime       string   `json:"mime"`
+	Type       FileType `json:"type"`
+	Size       int64    `json:"size"`
+	CreatedAt  int64    `json:"createdAt"`
+	ModifiedAt int64    `json:"modifiedAt"`
+	Score      float64  `json:"score"`
+	IconHint   string   `json:"iconHint,omitempty"`
+}
+
+// Sort describes the sort order for search results.
+type Sort struct {
+	Field string `json:"field"`
+	Dir   string `json:"dir"`
+}
+
+// DateRange is an inclusive range in epoch milliseconds. Either bound may be omitted.
+type DateRange struct {
+	From int64 `json:"from,omitempty"`
+	To   int64 `json:"to,omitempty"`
+}
+
+// Filters are optional server-side filters applied before pagination.
+type Filters struct {
+	Types         []FileType  `json:"types,omitempty"`
+	CreatedRange  *DateRange  `json:"createdRange,omitempty"`
+	ModifiedRange *DateRange  `json:"modifiedRange,omitempty"`
+	PathPrefix    string      `json:"pathPrefix,omitempty"`
+	TitleOnly     bool        `json:"titleOnly,omitempty"`
+	Content       bool        `json:"content,omitempty"`
+}
+
+// SearchRequest is the body of POST /v1/search.
+type SearchRequest struct {
+	Query     string      `json:"query"`
+	QueryMode query.Mode  `json:"queryMode"`
+	Sort      Sort        `json:"sort"`
+	Filters   Filters     `json:"filters"`
+	Page      int         `json:"page"`
+	PageSize  int         `json:"pageSize"`
+	History   []string    `json:"history,omitempty"`
+}
+
+// SearchResponse is the successful response from POST /v1/search.
+type SearchResponse struct {
+	Results  []FileResult `json:"results"`
+	Total    int          `json:"total"`
+	Page     int          `json:"page"`
+	TookMs   int64        `json:"tookMs"`
+	Indexer  string       `json:"indexer"`
+	Degraded bool         `json:"degraded,omitempty"`
+}
+
+// Capabilities describes what an indexer supports natively.
+type Capabilities struct {
+	BooleanOps      bool `json:"booleanOps"`
+	PrefixWildcard  bool `json:"prefixWildcard"`
+	InfixWildcard   bool `json:"infixWildcard"`
+	Regex           bool `json:"regex"`
+	PathScope       bool `json:"pathScope"`
+	Content         bool `json:"content"`
+}
+
+// IndexerInfo describes one search indexer available on the host.
+type IndexerInfo struct {
+	ID           string       `json:"id"`
+	Name         string       `json:"name"`
+	Available    bool         `json:"available"`
+	Capabilities Capabilities `json:"capabilities"`
+}
+
+// PingResponse is the response from GET /v1/ping.
+type PingResponse struct {
+	Name           string        `json:"name"`
+	Version        string        `json:"version"`
+	ProtocolVersion int          `json:"protocolVersion"`
+	OS             OS            `json:"os"`
+	Paired         bool          `json:"paired"`
+	PairingOpen    bool          `json:"pairingOpen"`
+	DefaultIndexer string        `json:"defaultIndexer"`
+	Indexers       []IndexerInfo `json:"indexers"`
+}
+
+// PairRequest is the body of POST /v1/pair.
+type PairRequest struct {
+	ClientName string `json:"clientName"`
+}
+
+// PairResponse is the successful response from POST /v1/pair.
+type PairResponse struct {
+	Token string `json:"token"`
+}
+
+// OpenRequest is the body of POST /v1/open.
+type OpenRequest struct {
+	Path   string `json:"path"`
+	Reveal bool   `json:"reveal,omitempty"`
+}
+
+// OpenResponse is the successful response from POST /v1/open.
+type OpenResponse struct {
+	OK bool `json:"ok"`
+}
+
+// Error code constants matching the schema enum.
+const (
+	ErrUnauthorized       = "unauthorized"
+	ErrPairingClosed      = "pairing_closed"
+	ErrBadRequest         = "bad_request"
+	ErrIndexerUnavailable = "indexer_unavailable"
+	ErrUnsupportedMode    = "unsupported_mode"
+	ErrInternal           = "internal"
+)
+
+// ErrorResponse is returned by any endpoint on failure.
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}

--- a/companion/internal/protocol/types.go
+++ b/companion/internal/protocol/types.go
@@ -72,13 +72,15 @@ type Filters struct {
 
 // SearchRequest is the body of POST /v1/search.
 type SearchRequest struct {
-	Query     string      `json:"query"`
-	QueryMode query.Mode  `json:"queryMode"`
-	Sort      Sort        `json:"sort"`
-	Filters   Filters     `json:"filters"`
-	Page      int         `json:"page"`
-	PageSize  int         `json:"pageSize"`
-	History   []string    `json:"history,omitempty"`
+	Query         string      `json:"query"`
+	QueryMode     query.Mode  `json:"queryMode"`
+	Sort          Sort        `json:"sort"`
+	Filters       Filters     `json:"filters"`
+	Page          int         `json:"page"`
+	PageSize      int         `json:"pageSize"`
+	History       []string    `json:"history,omitempty"`
+	CaseSensitive bool        `json:"caseSensitive,omitempty"`
+	ExactPhrase   bool        `json:"exactPhrase,omitempty"`
 }
 
 // SearchResponse is the successful response from POST /v1/search.

--- a/companion/internal/protocol/types_test.go
+++ b/companion/internal/protocol/types_test.go
@@ -1,0 +1,87 @@
+package protocol_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+)
+
+func searchExamplesPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// thisFile: .../companion/internal/protocol/types_test.go
+	// fixture:  .../shared/companion-protocol/fixtures/search-examples.json
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "shared", "companion-protocol", "fixtures", "search-examples.json")
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	return abs
+}
+
+type searchExample struct {
+	Name     string          `json:"name"`
+	Request  json.RawMessage `json:"request"`
+	Response json.RawMessage `json:"response"`
+}
+
+type searchExamplesFile struct {
+	Cases []searchExample `json:"cases"`
+}
+
+// TestSearchExamples_RoundTrip unmarshals each fixture case's request/response
+// into the Go protocol structs using DisallowUnknownFields.  A decode error
+// means the struct definitions diverge from the wire contract.
+func TestSearchExamples_RoundTrip(t *testing.T) {
+	data, err := os.ReadFile(searchExamplesPath(t))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var f searchExamplesFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("unmarshal fixture file: %v", err)
+	}
+	if len(f.Cases) == 0 {
+		t.Fatal("fixture has no cases")
+	}
+
+	for _, c := range f.Cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			// Decode request with strict decoder.
+			var req protocol.SearchRequest
+			dec := json.NewDecoder(bytes.NewReader(c.Request))
+			dec.DisallowUnknownFields()
+			if err := dec.Decode(&req); err != nil {
+				t.Errorf("decode SearchRequest: %v", err)
+			}
+
+			// Decode response with strict decoder.
+			var resp protocol.SearchResponse
+			dec = json.NewDecoder(bytes.NewReader(c.Response))
+			dec.DisallowUnknownFields()
+			if err := dec.Decode(&resp); err != nil {
+				t.Errorf("decode SearchResponse: %v", err)
+			}
+
+			// Spot-check the regex/degraded case.
+			if c.Name == "regex mode – degraded via plocate fallback" {
+				if !resp.Degraded {
+					t.Errorf("expected Degraded==true for regex/plocate case")
+				}
+				if resp.Indexer != "plocate" {
+					t.Errorf("expected Indexer==\"plocate\", got %q", resp.Indexer)
+				}
+			}
+		})
+	}
+}

--- a/companion/internal/query/ast.go
+++ b/companion/internal/query/ast.go
@@ -1,0 +1,33 @@
+// Package query implements the Fast Travel query mini-syntax parser.
+// It turns a raw query string + a Mode into a canonical AST that is
+// identical across the Go companion and future Kotlin Android implementation.
+package query
+
+// Mode controls how the query string is parsed.
+type Mode string
+
+const (
+	ModeSimple   Mode = "simple"
+	ModeWildcard Mode = "wildcard"
+	ModeRegex    Mode = "regex"
+)
+
+// Node is a single AST node. Its JSON serialisation matches the shared
+// companion-protocol fixture schema exactly.
+//
+//   - op "and"/"or":  Nodes holds the children; Node/Field/Value/Wildcard are zero.
+//   - op "not":       Node holds the single child; Nodes/Field/Value/Wildcard are zero.
+//   - op "term":      Field, Value, Wildcard set; Nodes/Node are zero.
+//   - op "phrase":    Field, Value set; Wildcard nil; Nodes/Node are zero.
+//   - op "regex":     Field, Value set; Wildcard nil; Nodes/Node are zero.
+type Node struct {
+	Op       string  `json:"op"`
+	Nodes    []Node  `json:"nodes,omitempty"`    // and / or
+	Node     *Node   `json:"node,omitempty"`     // not
+	Field    string  `json:"field,omitempty"`    // term / phrase / regex
+	Value    string  `json:"value,omitempty"`    // term / phrase / regex
+	Wildcard *bool   `json:"wildcard,omitempty"` // term only (pointer so false serialises)
+}
+
+// boolPtr is a small helper to take the address of a bool literal.
+func boolPtr(b bool) *bool { return &b }

--- a/companion/internal/query/parse.go
+++ b/companion/internal/query/parse.go
@@ -2,6 +2,8 @@ package query
 
 import (
 	"errors"
+	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -13,7 +15,11 @@ func Parse(query string, mode Mode) (Node, error) {
 	}
 
 	if mode == ModeRegex {
-		return parseRegex(query), nil
+		n, err := parseRegex(query)
+		if err != nil {
+			return Node{}, err
+		}
+		return n, nil
 	}
 
 	tokens := tokenize(query, mode)
@@ -22,14 +28,20 @@ func Parse(query string, mode Mode) (Node, error) {
 
 // --- regex mode -----------------------------------------------------------
 
-func parseRegex(query string) Node {
+// parseRegex builds a regex AST node, validating the pattern compiles as RE2.
+// Returns an error (Bug A) when the pattern is invalid so callers can surface
+// a useful 400 bad_request to the client.
+func parseRegex(query string) (Node, error) {
 	field := "name"
 	value := query
 	if strings.HasPrefix(query, "path:") {
 		field = "path"
 		value = query[len("path:"):]
 	}
-	return Node{Op: "regex", Field: field, Value: value}
+	if _, err := regexp.Compile(value); err != nil {
+		return Node{}, fmt.Errorf("invalid regular expression: %w", err)
+	}
+	return Node{Op: "regex", Field: field, Value: value}, nil
 }
 
 // --- tokenizer ------------------------------------------------------------

--- a/companion/internal/query/parse.go
+++ b/companion/internal/query/parse.go
@@ -1,0 +1,191 @@
+package query
+
+import (
+	"errors"
+	"strings"
+)
+
+// Parse turns a raw query string and a Mode into the canonical AST Node.
+// It returns an error for empty or whitespace-only input.
+func Parse(query string, mode Mode) (Node, error) {
+	if strings.TrimSpace(query) == "" {
+		return Node{}, errors.New("query: empty input")
+	}
+
+	if mode == ModeRegex {
+		return parseRegex(query), nil
+	}
+
+	tokens := tokenize(query, mode)
+	return buildAST(tokens), nil
+}
+
+// --- regex mode -----------------------------------------------------------
+
+func parseRegex(query string) Node {
+	field := "name"
+	value := query
+	if strings.HasPrefix(query, "path:") {
+		field = "path"
+		value = query[len("path:"):]
+	}
+	return Node{Op: "regex", Field: field, Value: value}
+}
+
+// --- tokenizer ------------------------------------------------------------
+
+// tok is an internal token produced by tokenize.
+type tok struct {
+	isOR   bool // OR separator (|, or standalone OR keyword)
+	negate bool // true when the token was preceded by - or !
+	leaf   Node // the leaf node (term or phrase); zero when isOR == true
+}
+
+// tokenize scans the query string and produces a flat list of toks.
+func tokenize(query string, mode Mode) []tok {
+	var toks []tok
+	i := 0
+	n := len(query)
+
+	for i < n {
+		// skip whitespace
+		if query[i] == ' ' || query[i] == '\t' {
+			i++
+			continue
+		}
+
+		// bare pipe → OR separator
+		if query[i] == '|' {
+			toks = append(toks, tok{isOR: true})
+			i++
+			continue
+		}
+
+		// negation prefix
+		negate := false
+		if i < n && (query[i] == '-' || query[i] == '!') {
+			// only treat as negation if followed by a non-space character
+			if i+1 < n && query[i+1] != ' ' && query[i+1] != '\t' {
+				negate = true
+				i++
+			}
+		}
+
+		// path: prefix
+		field := "name"
+		if strings.HasPrefix(query[i:], "path:") {
+			field = "path"
+			i += len("path:")
+		}
+
+		if i >= n {
+			continue
+		}
+
+		// quoted phrase
+		if query[i] == '"' {
+			i++ // skip opening quote
+			start := i
+			for i < n && query[i] != '"' {
+				i++
+			}
+			value := query[start:i]
+			if i < n {
+				i++ // skip closing quote
+			}
+			leaf := Node{Op: "phrase", Field: field, Value: value}
+			toks = append(toks, tok{negate: negate, leaf: leaf})
+			continue
+		}
+
+		// regular term: read until whitespace or pipe
+		start := i
+		for i < n && query[i] != ' ' && query[i] != '\t' && query[i] != '|' {
+			i++
+		}
+		value := query[start:i]
+		if value == "" {
+			continue
+		}
+
+		// standalone OR keyword (only when no negate and no field scope)
+		if !negate && field == "name" && strings.EqualFold(value, "or") {
+			toks = append(toks, tok{isOR: true})
+			continue
+		}
+
+		wc := boolPtr(false)
+		if mode == ModeWildcard && containsWildcard(value) {
+			wc = boolPtr(true)
+		}
+
+		leaf := Node{Op: "term", Field: field, Value: value, Wildcard: wc}
+		toks = append(toks, tok{negate: negate, leaf: leaf})
+	}
+
+	return toks
+}
+
+func containsWildcard(s string) bool {
+	return strings.ContainsAny(s, "*?")
+}
+
+// --- AST builder ----------------------------------------------------------
+
+// buildAST turns a flat token list into the canonical AST Node.
+// Top-level precedence: OR binds looser than AND.
+func buildAST(toks []tok) Node {
+	// split at OR separators → one slice per AND-segment
+	segments := splitByOR(toks)
+
+	segNodes := make([]Node, 0, len(segments))
+	for _, seg := range segments {
+		if len(seg) == 0 {
+			continue
+		}
+		segNodes = append(segNodes, buildSegment(seg))
+	}
+
+	switch len(segNodes) {
+	case 0:
+		return Node{} // shouldn't reach here after empty-input guard
+	case 1:
+		return segNodes[0]
+	default:
+		return Node{Op: "or", Nodes: segNodes}
+	}
+}
+
+// splitByOR partitions toks into slices separated by OR tokens.
+func splitByOR(toks []tok) [][]tok {
+	var segments [][]tok
+	current := []tok{}
+	for _, t := range toks {
+		if t.isOR {
+			segments = append(segments, current)
+			current = []tok{}
+		} else {
+			current = append(current, t)
+		}
+	}
+	segments = append(segments, current)
+	return segments
+}
+
+// buildSegment turns one AND-group of tokens into a Node.
+func buildSegment(toks []tok) Node {
+	nodes := make([]Node, 0, len(toks))
+	for _, t := range toks {
+		leaf := t.leaf
+		if t.negate {
+			inner := leaf
+			leaf = Node{Op: "not", Node: &inner}
+		}
+		nodes = append(nodes, leaf)
+	}
+
+	if len(nodes) == 1 {
+		return nodes[0]
+	}
+	return Node{Op: "and", Nodes: nodes}
+}

--- a/companion/internal/query/parse_test.go
+++ b/companion/internal/query/parse_test.go
@@ -39,6 +39,16 @@ type fixtureCase struct {
 	AST       json.RawMessage `json:"ast"`
 }
 
+// TestParse_InvalidRegex_Error verifies that an invalid regex pattern returns a
+// descriptive error rather than silently producing empty results (Bug A).
+func TestParse_InvalidRegex_Error(t *testing.T) {
+	// "[" is an unclosed character class — invalid in RE2.
+	_, err := query.Parse("[", query.ModeRegex)
+	if err == nil {
+		t.Fatal("expected error for invalid regex pattern '[', got nil")
+	}
+}
+
 func TestParse_Fixtures(t *testing.T) {
 	path := fixtureFile(t)
 	data, err := os.ReadFile(path)

--- a/companion/internal/query/parse_test.go
+++ b/companion/internal/query/parse_test.go
@@ -1,0 +1,79 @@
+package query_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// fixtureFile locates query-parsing.json relative to this test file's directory.
+func fixtureFile(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// thisFile: .../companion/internal/query/parse_test.go
+	// fixture: .../shared/companion-protocol/fixtures/query-parsing.json
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "shared", "companion-protocol", "fixtures", "query-parsing.json")
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	return abs
+}
+
+type fixtureFile_ struct {
+	Cases []fixtureCase `json:"cases"`
+}
+
+type fixtureCase struct {
+	Name      string          `json:"name"`
+	Query     string          `json:"query"`
+	QueryMode string          `json:"queryMode"`
+	AST       json.RawMessage `json:"ast"`
+}
+
+func TestParse_Fixtures(t *testing.T) {
+	path := fixtureFile(t)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var f fixtureFile_
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	if len(f.Cases) == 0 {
+		t.Fatal("fixture has no cases")
+	}
+
+	for _, c := range f.Cases {
+		c := c // capture
+		t.Run(c.Name, func(t *testing.T) {
+			var want query.Node
+			if err := json.Unmarshal(c.AST, &want); err != nil {
+				t.Fatalf("unmarshal expected AST: %v", err)
+			}
+
+			got, err := query.Parse(c.Query, query.Mode(c.QueryMode))
+			if err != nil {
+				t.Fatalf("Parse(%q, %q) error: %v", c.Query, c.QueryMode, err)
+			}
+
+			if !reflect.DeepEqual(got, want) {
+				gotJSON, _ := json.MarshalIndent(got, "", "  ")
+				wantJSON, _ := json.MarshalIndent(want, "", "  ")
+				t.Errorf("Parse(%q, %q) mismatch:\ngot:\n%s\nwant:\n%s",
+					c.Query, c.QueryMode, gotJSON, wantJSON)
+			}
+		})
+	}
+}

--- a/companion/internal/server/handlers.go
+++ b/companion/internal/server/handlers.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/pairing"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/query"
+)
+
+// handlePing serves GET /v1/ping.
+// No authentication required. Returns companion metadata and indexer/pairing
+// state so the extension can decide whether setup is needed.
+func (s *Server) handlePing(w http.ResponseWriter, r *http.Request) {
+	defaultID := ""
+	if d := s.deps.Registry.Default(); d != nil {
+		defaultID = d.ID()
+	}
+
+	indexers := s.deps.Registry.Infos()
+	if indexers == nil {
+		indexers = []protocol.IndexerInfo{}
+	}
+
+	writeJSON(w, http.StatusOK, protocol.PingResponse{
+		Name:            s.deps.Name,
+		Version:         s.deps.Version,
+		ProtocolVersion: protocol.ProtocolVersion,
+		OS:              s.deps.OS,
+		Paired:          s.deps.Pairing.Paired(),
+		PairingOpen:     s.deps.Pairing.PairingOpen(),
+		DefaultIndexer:  defaultID,
+		Indexers:        indexers,
+	})
+}
+
+// handlePair serves POST /v1/pair.
+// No bearer token is required — pairing IS how the extension obtains one.
+// Reads the Origin header and a PairRequest body.
+// Success → 200 PairResponse{Token}.
+// ErrPairingClosed → 403 pairing_closed.
+// Bad JSON → 400 bad_request.
+func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
+	var req protocol.PairRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, protocol.ErrBadRequest, "invalid JSON body")
+		return
+	}
+
+	origin := r.Header.Get("Origin")
+	token, err := s.deps.Pairing.Pair(origin, req.ClientName)
+	if err != nil {
+		if errors.Is(err, pairing.ErrPairingClosed) {
+			writeErr(w, http.StatusForbidden, protocol.ErrPairingClosed, "pairing window is closed")
+			return
+		}
+		writeErr(w, http.StatusInternalServerError, protocol.ErrInternal, "pairing failed")
+		return
+	}
+	// Token is returned only in the response body — never written to a log.
+	writeJSON(w, http.StatusOK, protocol.PairResponse{Token: token})
+}
+
+// handlePairingOpen serves POST /v1/pairing/open.
+// No authentication required — this endpoint is triggered from the localhost
+// /setup page only. It opens the pairing window for 5 minutes.
+//
+// Security note: opening the window alone grants nothing. A deliberate POST
+// /v1/pair from the browser extension (with its Origin) is still required to
+// obtain a token.
+func (s *Server) handlePairingOpen(w http.ResponseWriter, r *http.Request) {
+	s.deps.Pairing.OpenPairingWindow(5 * time.Minute)
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// handleSearch serves POST /v1/search.
+// Auth required: Authorization: Bearer <token> + matching Origin header.
+//
+// The query is pre-validated with query.Parse before calling the provider so
+// that parse failures surface as 400 bad_request rather than 500 internal.
+// Error mapping:
+//
+//	parse error      → 400 bad_request
+//	ErrNoIndexer     → 503 indexer_unavailable
+//	other errors     → 500 internal
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuth(w, r) {
+		return
+	}
+
+	var req protocol.SearchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, protocol.ErrBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Pre-validate the query to catch parse errors before calling the provider.
+	if _, err := query.Parse(req.Query, req.QueryMode); err != nil {
+		writeErr(w, http.StatusBadRequest, protocol.ErrBadRequest, err.Error())
+		return
+	}
+
+	resp, err := s.deps.Registry.Search(r.Context(), req)
+	if err != nil {
+		switch {
+		case errors.Is(err, index.ErrNoIndexer):
+			writeErr(w, http.StatusServiceUnavailable, protocol.ErrIndexerUnavailable, "no file indexer available")
+		default:
+			writeErr(w, http.StatusInternalServerError, protocol.ErrInternal, "search failed")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleOpen serves POST /v1/open.
+// Auth required. Rejects with 400 if Path is empty or does not exist on disk.
+// Calls Opener.Open or Opener.Reveal according to the Reveal field.
+// Success → 200 OpenResponse{OK: true}.
+// Opener error → 500 internal.
+func (s *Server) handleOpen(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuth(w, r) {
+		return
+	}
+
+	var req protocol.OpenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, protocol.ErrBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Path == "" {
+		writeErr(w, http.StatusBadRequest, protocol.ErrBadRequest, "path is required")
+		return
+	}
+
+	if _, err := os.Stat(req.Path); err != nil {
+		writeErr(w, http.StatusBadRequest, protocol.ErrBadRequest, "path does not exist or is not accessible")
+		return
+	}
+
+	var err error
+	if req.Reveal {
+		err = s.deps.Opener.Reveal(req.Path)
+	} else {
+		err = s.deps.Opener.Open(req.Path)
+	}
+
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, protocol.ErrInternal, "open failed")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, protocol.OpenResponse{OK: true})
+}

--- a/companion/internal/server/handlers.go
+++ b/companion/internal/server/handlers.go
@@ -73,7 +73,19 @@ func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
 // Security note: opening the window alone grants nothing. A deliberate POST
 // /v1/pair from the browser extension (with its Origin) is still required to
 // obtain a token.
+//
+// Cross-origin guard (defense-in-depth): when Sec-Fetch-Site is present and
+// is neither "same-origin" nor "none", reject with 403. This prevents
+// arbitrary web pages from silently triggering the pairing UI via a
+// cross-origin POST. Non-browser callers (curl, first-run setup flow) omit
+// Sec-Fetch-Site entirely and are allowed through for compatibility. The
+// /setup page's own fetch('/v1/pairing/open') is same-origin (both served
+// from 127.0.0.1) so it is unaffected.
 func (s *Server) handlePairingOpen(w http.ResponseWriter, r *http.Request) {
+	if sfs := r.Header.Get("Sec-Fetch-Site"); sfs != "" && sfs != "same-origin" && sfs != "none" {
+		writeErr(w, http.StatusForbidden, protocol.ErrUnauthorized, "cross-site requests are not allowed")
+		return
+	}
 	s.deps.Pairing.OpenPairingWindow(5 * time.Minute)
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }

--- a/companion/internal/server/open.go
+++ b/companion/internal/server/open.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"os/exec"
+	"path/filepath"
+)
+
+// Opener opens or reveals a file using the host OS's default mechanism.
+// It is injectable so tests can supply a fake without spawning real processes.
+type Opener interface {
+	Open(path string) error   // open the file in its default application
+	Reveal(path string) error // show the file's parent directory in the file manager
+}
+
+// XDGOpener is the Linux implementation of Opener using xdg-open.
+var _ Opener = (*XDGOpener)(nil)
+
+// XDGOpener uses xdg-open to open files and directories.
+type XDGOpener struct{}
+
+// Open opens path in its default application via xdg-open.
+func (o *XDGOpener) Open(path string) error {
+	return exec.Command("xdg-open", path).Run()
+}
+
+// Reveal opens the parent directory of path via xdg-open. A future revision
+// may use a desktop-specific "select and highlight file" command.
+func (o *XDGOpener) Reveal(path string) error {
+	return exec.Command("xdg-open", filepath.Dir(path)).Run()
+}

--- a/companion/internal/server/open.go
+++ b/companion/internal/server/open.go
@@ -3,6 +3,7 @@ package server
 import (
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 // Opener opens or reveals a file using the host OS's default mechanism.
@@ -12,19 +13,52 @@ type Opener interface {
 	Reveal(path string) error // show the file's parent directory in the file manager
 }
 
-// XDGOpener is the Linux implementation of Opener using xdg-open.
-var _ Opener = (*XDGOpener)(nil)
-
-// XDGOpener uses xdg-open to open files and directories.
-type XDGOpener struct{}
-
-// Open opens path in its default application via xdg-open.
-func (o *XDGOpener) Open(path string) error {
-	return exec.Command("xdg-open", path).Run()
+// openCommand returns the name and args to open (reveal=false) or reveal
+// (reveal=true) path on goos. It is a pure function — no side effects — so
+// it can be tested on any platform.
+func openCommand(goos, path string, reveal bool) (name string, args []string) {
+	switch goos {
+	case "windows":
+		if reveal {
+			// explorer /select,<path> highlights the file in Explorer.
+			return "explorer", []string{"/select," + path}
+		}
+		// cmd /c start "" <path> opens with the default application.
+		// The empty string is the window title (required by start).
+		return "cmd", []string{"/c", "start", "", path}
+	case "darwin":
+		if reveal {
+			// open -R reveals (selects) the file in Finder.
+			return "open", []string{"-R", path}
+		}
+		return "open", []string{path}
+	default: // linux and unknown OSes
+		if reveal {
+			// xdg-open the parent directory (closest Linux equivalent).
+			return "xdg-open", []string{filepath.Dir(path)}
+		}
+		return "xdg-open", []string{path}
+	}
 }
 
-// Reveal opens the parent directory of path via xdg-open. A future revision
-// may use a desktop-specific "select and highlight file" command.
-func (o *XDGOpener) Reveal(path string) error {
-	return exec.Command("xdg-open", filepath.Dir(path)).Run()
+// OSOpener is an Opener that dispatches on runtime.GOOS.
+type OSOpener struct{}
+
+var _ Opener = (*OSOpener)(nil)
+
+// Open opens path in its default application for the current OS.
+func (o *OSOpener) Open(path string) error {
+	name, args := openCommand(runtime.GOOS, path, false)
+	return exec.Command(name, args...).Run()
+}
+
+// Reveal shows path's location in the host file manager for the current OS.
+func (o *OSOpener) Reveal(path string) error {
+	name, args := openCommand(runtime.GOOS, path, true)
+	return exec.Command(name, args...).Run()
+}
+
+// NewOpener returns an Opener appropriate for the current OS.
+func NewOpener() Opener {
+	return &OSOpener{}
 }

--- a/companion/internal/server/open_test.go
+++ b/companion/internal/server/open_test.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenCommand tests the pure openCommand builder for every OS × open/reveal
+// combination. These tests run on any platform (no exec side-effects).
+
+func TestOpenCommand_Linux_Open(t *testing.T) {
+	name, args := openCommand("linux", "/home/user/file.txt", false)
+	if name != "xdg-open" {
+		t.Errorf("name: got %q, want %q", name, "xdg-open")
+	}
+	if len(args) != 1 || args[0] != "/home/user/file.txt" {
+		t.Errorf("args: got %v, want [/home/user/file.txt]", args)
+	}
+}
+
+func TestOpenCommand_Linux_Reveal(t *testing.T) {
+	path := "/home/user/docs/file.txt"
+	name, args := openCommand("linux", path, true)
+	if name != "xdg-open" {
+		t.Errorf("name: got %q, want %q", name, "xdg-open")
+	}
+	want := filepath.Dir(path)
+	if len(args) != 1 || args[0] != want {
+		t.Errorf("args: got %v, want [%s]", args, want)
+	}
+}
+
+func TestOpenCommand_Windows_Open(t *testing.T) {
+	path := `C:\Users\user\Documents\file.txt`
+	name, args := openCommand("windows", path, false)
+	if name != "cmd" {
+		t.Errorf("name: got %q, want %q", name, "cmd")
+	}
+	// Expect: cmd /c start "" <path>
+	if len(args) != 4 {
+		t.Fatalf("args length: got %d, want 4; args=%v", len(args), args)
+	}
+	if args[0] != "/c" || args[1] != "start" || args[2] != "" || args[3] != path {
+		t.Errorf("args: got %v, want [/c start \"\" %s]", args, path)
+	}
+}
+
+func TestOpenCommand_Windows_Reveal(t *testing.T) {
+	path := `C:\Users\user\Documents\file.txt`
+	name, args := openCommand("windows", path, true)
+	if name != "explorer" {
+		t.Errorf("name: got %q, want %q", name, "explorer")
+	}
+	// Expect: explorer /select,<path>
+	want := "/select," + path
+	if len(args) != 1 || args[0] != want {
+		t.Errorf("args: got %v, want [%s]", args, want)
+	}
+}
+
+func TestOpenCommand_Darwin_Open(t *testing.T) {
+	path := "/Users/user/Documents/file.txt"
+	name, args := openCommand("darwin", path, false)
+	if name != "open" {
+		t.Errorf("name: got %q, want %q", name, "open")
+	}
+	if len(args) != 1 || args[0] != path {
+		t.Errorf("args: got %v, want [%s]", args, path)
+	}
+}
+
+func TestOpenCommand_Darwin_Reveal(t *testing.T) {
+	path := "/Users/user/Documents/file.txt"
+	name, args := openCommand("darwin", path, true)
+	if name != "open" {
+		t.Errorf("name: got %q, want %q", name, "open")
+	}
+	// Expect: open -R <path>
+	if len(args) != 2 || args[0] != "-R" || args[1] != path {
+		t.Errorf("args: got %v, want [-R %s]", args, path)
+	}
+}
+
+func TestOpenCommand_Unknown_Open(t *testing.T) {
+	// Unknown OS falls through to the linux/xdg-open default.
+	name, args := openCommand("freebsd", "/home/user/file.txt", false)
+	if name != "xdg-open" {
+		t.Errorf("name: got %q, want %q (unknown OS should use xdg-open)", name, "xdg-open")
+	}
+	if len(args) != 1 || args[0] != "/home/user/file.txt" {
+		t.Errorf("args: got %v", args)
+	}
+}
+
+func TestOpenCommand_Unknown_Reveal(t *testing.T) {
+	path := "/home/user/file.txt"
+	name, args := openCommand("freebsd", path, true)
+	if name != "xdg-open" {
+		t.Errorf("name: got %q, want %q (unknown OS should use xdg-open)", name, "xdg-open")
+	}
+	want := filepath.Dir(path)
+	if len(args) != 1 || args[0] != want {
+		t.Errorf("args: got %v, want [%s]", args, want)
+	}
+}

--- a/companion/internal/server/port.go
+++ b/companion/internal/server/port.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"fmt"
+	"net"
+)
+
+// ListenLoopback tries to bind 127.0.0.1:preferred. If that port is
+// unavailable it scans preferred+1 through preferred+10. It returns the first
+// successful net.Listener and the chosen port number.
+//
+// Only 127.0.0.1 is ever used — never 0.0.0.0 or [::1].
+func ListenLoopback(preferred int) (net.Listener, int, error) {
+	for port := preferred; port <= preferred+10; port++ {
+		addr := fmt.Sprintf("127.0.0.1:%d", port)
+		l, err := net.Listen("tcp", addr)
+		if err == nil {
+			return l, port, nil
+		}
+	}
+	return nil, 0, fmt.Errorf("server: no available loopback port in range %d..%d", preferred, preferred+10)
+}

--- a/companion/internal/server/port_test.go
+++ b/companion/internal/server/port_test.go
@@ -1,0 +1,75 @@
+package server_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/server"
+)
+
+func TestListenLoopback_BindsLoopback(t *testing.T) {
+	l, port, err := server.ListenLoopback(7333)
+	if err != nil {
+		t.Fatalf("ListenLoopback(7333): %v", err)
+	}
+	defer l.Close()
+
+	if port < 7333 || port > 7343 {
+		t.Errorf("port %d out of expected range 7333..7343", port)
+	}
+
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener addr is not *net.TCPAddr: %T", l.Addr())
+	}
+	if !addr.IP.IsLoopback() {
+		t.Errorf("listener IP %v is not loopback", addr.IP)
+	}
+	if addr.Port != port {
+		t.Errorf("reported port %d != listener port %d", port, addr.Port)
+	}
+}
+
+func TestListenLoopback_FallsThrough(t *testing.T) {
+	// Grab a free port from the OS, then keep it occupied.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("cannot bind test port: %v", err)
+	}
+	defer occupied.Close()
+
+	preferredPort := occupied.Addr().(*net.TCPAddr).Port
+
+	// ListenLoopback must skip the occupied port and bind the next one.
+	l, gotPort, err := server.ListenLoopback(preferredPort)
+	if err != nil {
+		t.Fatalf("ListenLoopback(%d): %v", preferredPort, err)
+	}
+	defer l.Close()
+
+	if gotPort == preferredPort {
+		t.Errorf("expected fallthrough to a different port, got %d == preferred %d", gotPort, preferredPort)
+	}
+	if gotPort < preferredPort || gotPort > preferredPort+10 {
+		t.Errorf("fallthrough port %d not in range [%d, %d+10]", gotPort, preferredPort, preferredPort)
+	}
+}
+
+func TestListenLoopback_ClosedListenerCanBeRebound(t *testing.T) {
+	l, port, err := server.ListenLoopback(7335)
+	if err != nil {
+		t.Fatalf("first ListenLoopback: %v", err)
+	}
+	l.Close()
+
+	// After closing, the same port should be bindable again.
+	l2, port2, err := server.ListenLoopback(port)
+	if err != nil {
+		t.Fatalf("second ListenLoopback: %v", err)
+	}
+	defer l2.Close()
+
+	if port2 != port {
+		t.Errorf("expected same port %d after rebind, got %d", port, port2)
+	}
+}

--- a/companion/internal/server/server.go
+++ b/companion/internal/server/server.go
@@ -1,0 +1,116 @@
+// Package server implements the Fast Travel companion daemon's loopback HTTP
+// server. It wires the indexer Registry and the pairing Manager into a set of
+// JSON REST endpoints served on 127.0.0.1 only.
+//
+// WebSocket /v1/stream is planned but not yet implemented. Go's stdlib has no
+// WebSocket server and we want a dependency-free static binary for v1. A fast
+// synchronous POST /v1/search is provided instead.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+)
+
+// SearchProvider is the interface the server calls on the file-indexer registry.
+// The real *index.Registry satisfies this structurally without any changes to
+// that package.
+type SearchProvider interface {
+	Search(ctx context.Context, req protocol.SearchRequest) (protocol.SearchResponse, error)
+	Infos() []protocol.IndexerInfo
+	Default() index.Indexer // nil when no indexer is available
+}
+
+// Authorizer is the interface the server calls on the pairing manager.
+// The real *pairing.Manager satisfies this structurally without any changes to
+// that package.
+type Authorizer interface {
+	Paired() bool
+	PairingOpen() bool
+	OpenPairingWindow(d time.Duration)
+	Pair(origin, clientName string) (string, error)
+	Authorize(origin, token string) bool
+}
+
+// Deps groups all injectable dependencies for the server. Using Deps means
+// tests can supply fakes for every dependency without touching real backends.
+type Deps struct {
+	Registry SearchProvider
+	Pairing  Authorizer
+	Opener   Opener
+	Name     string      // e.g. "fast-travel-companion"
+	Version  string
+	OS       protocol.OS // e.g. "linux"
+	Port     int         // chosen listen port, shown on /setup page (0 = unknown)
+}
+
+// Server is the companion HTTP server.
+type Server struct {
+	deps Deps
+}
+
+// New creates a Server with the given dependencies.
+func New(d Deps) *Server {
+	return &Server{deps: d}
+}
+
+// Handler builds and returns the HTTP mux with all companion routes registered.
+// Uses Go 1.22+ method-prefixed pattern syntax.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/ping", s.handlePing)
+	mux.HandleFunc("POST /v1/pair", s.handlePair)
+	mux.HandleFunc("POST /v1/pairing/open", s.handlePairingOpen)
+	mux.HandleFunc("POST /v1/search", s.handleSearch)
+	mux.HandleFunc("POST /v1/open", s.handleOpen)
+	mux.HandleFunc("GET /setup", s.handleSetup)
+	return mux
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// writeJSON writes v encoded as JSON with the given HTTP status code.
+// Sets Content-Type: application/json.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeErr writes an ErrorResponse JSON body with the given HTTP status.
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, protocol.ErrorResponse{Error: code, Message: msg})
+}
+
+// bearerToken extracts the token from "Authorization: Bearer <token>".
+// Returns "" if the header is absent or has an unexpected format.
+// The token value is never logged.
+func bearerToken(r *http.Request) string {
+	const prefix = "Bearer "
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, prefix) {
+		return ""
+	}
+	return auth[len(prefix):]
+}
+
+// requireAuth checks that the request carries a valid bearer token for the
+// request's Origin. It writes a 401 response and returns false on failure.
+// Tokens are never logged.
+func (s *Server) requireAuth(w http.ResponseWriter, r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	token := bearerToken(r)
+	if !s.deps.Pairing.Authorize(origin, token) {
+		writeErr(w, http.StatusUnauthorized, protocol.ErrUnauthorized, "invalid or missing credentials")
+		return false
+	}
+	return true
+}

--- a/companion/internal/server/server_test.go
+++ b/companion/internal/server/server_test.go
@@ -1,0 +1,479 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/index"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/pairing"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/protocol"
+	"github.com/DoubleGremlin181/fast-travel-app/companion/internal/server"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeSearch implements server.SearchProvider.
+type fakeSearch struct {
+	resp  protocol.SearchResponse
+	err   error
+	infos []protocol.IndexerInfo
+	dflt  index.Indexer // returned by Default(); nil = no default
+}
+
+func (f *fakeSearch) Search(_ context.Context, _ protocol.SearchRequest) (protocol.SearchResponse, error) {
+	return f.resp, f.err
+}
+
+func (f *fakeSearch) Infos() []protocol.IndexerInfo {
+	if f.infos == nil {
+		return []protocol.IndexerInfo{}
+	}
+	return f.infos
+}
+
+func (f *fakeSearch) Default() index.Indexer { return f.dflt }
+
+// fakeOpener implements server.Opener and records calls.
+type fakeOpener struct {
+	openCalled   string
+	revealCalled string
+}
+
+func (f *fakeOpener) Open(path string) error   { f.openCalled = path; return nil }
+func (f *fakeOpener) Reveal(path string) error { f.revealCalled = path; return nil }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newTestServer creates a server with a real pairing.Manager (backed by TempDir)
+// and the supplied fake Search/Opener. Returns the handler and the manager so
+// tests can drive the pairing state directly.
+func newTestServer(t *testing.T, fs *fakeSearch, fo *fakeOpener) (http.Handler, *pairing.Manager) {
+	t.Helper()
+	m, err := pairing.New(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("pairing.New: %v", err)
+	}
+	s := server.New(server.Deps{
+		Registry: fs,
+		Pairing:  m,
+		Opener:   fo,
+		Name:     "fast-travel-companion",
+		Version:  "test",
+		OS:       "linux",
+		Port:     7333,
+	})
+	return s.Handler(), m
+}
+
+// doRequest fires a request against h and returns the recorder.
+func doRequest(h http.Handler, method, path string, body []byte, headers map[string]string) *httptest.ResponseRecorder {
+	var r *http.Request
+	if body != nil {
+		r = httptest.NewRequest(method, path, bytes.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	return rec
+}
+
+// pairAndGetToken opens the pairing window on m, then POSTs /v1/pair to h and
+// returns the token. Panics the test on failure.
+func pairAndGetToken(t *testing.T, h http.Handler, m *pairing.Manager) (token, origin string) {
+	t.Helper()
+	origin = "chrome-extension://testtest"
+	m.OpenPairingWindow(5 * time.Minute)
+
+	body := mustMarshal(t, protocol.PairRequest{ClientName: "test-browser"})
+	rec := doRequest(h, "POST", "/v1/pair", body, map[string]string{
+		"Content-Type": "application/json",
+		"Origin":       origin,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pairAndGetToken: got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var resp protocol.PairResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &resp)
+	if resp.Token == "" {
+		t.Fatal("pairAndGetToken: empty token")
+	}
+	return resp.Token, origin
+}
+
+// authHeaders returns headers with Bearer auth and the given origin.
+func authHeaders(token, origin string) map[string]string {
+	return map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer " + token,
+		"Origin":        origin,
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func mustUnmarshal(t *testing.T, data []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %s)", err, data)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/ping
+// ---------------------------------------------------------------------------
+
+func TestPing_Shape(t *testing.T) {
+	fs := &fakeSearch{
+		infos: []protocol.IndexerInfo{
+			{ID: "mem", Name: "In-memory", Available: true},
+		},
+	}
+	h, _ := newTestServer(t, fs, &fakeOpener{})
+
+	rec := doRequest(h, "GET", "/v1/ping", nil, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ping: got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: %q, want application/json", ct)
+	}
+
+	var resp protocol.PingResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &resp)
+
+	if resp.ProtocolVersion != protocol.ProtocolVersion {
+		t.Errorf("ProtocolVersion: got %d, want %d", resp.ProtocolVersion, protocol.ProtocolVersion)
+	}
+	if len(resp.Indexers) != 1 || resp.Indexers[0].ID != "mem" {
+		t.Errorf("Indexers: got %v", resp.Indexers)
+	}
+	if resp.Paired {
+		t.Error("Paired: want false initially")
+	}
+	if resp.PairingOpen {
+		t.Error("PairingOpen: want false initially")
+	}
+	if resp.Name != "fast-travel-companion" {
+		t.Errorf("Name: %q", resp.Name)
+	}
+}
+
+func TestPing_ReflectsPairedState(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+	pairAndGetToken(t, h, m) // side-effect: m is now paired
+
+	rec := doRequest(h, "GET", "/v1/ping", nil, nil)
+	var resp protocol.PingResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &resp)
+
+	if !resp.Paired {
+		t.Error("Paired: want true after pairing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/pair
+// ---------------------------------------------------------------------------
+
+func TestPair_WindowOpen_ReturnsToken(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+	m.OpenPairingWindow(5 * time.Minute)
+
+	body := mustMarshal(t, protocol.PairRequest{ClientName: "my-browser"})
+	rec := doRequest(h, "POST", "/v1/pair", body, map[string]string{
+		"Content-Type": "application/json",
+		"Origin":       "chrome-extension://abc",
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pair: got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var resp protocol.PairResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &resp)
+	if resp.Token == "" {
+		t.Error("pair: token is empty")
+	}
+}
+
+func TestPair_WindowClosed_Returns403(t *testing.T) {
+	h, _ := newTestServer(t, &fakeSearch{}, &fakeOpener{}) // window never opened
+
+	body := mustMarshal(t, protocol.PairRequest{ClientName: "my-browser"})
+	rec := doRequest(h, "POST", "/v1/pair", body, map[string]string{
+		"Content-Type": "application/json",
+		"Origin":       "chrome-extension://xyz",
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("pair closed: got %d, want 403", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrPairingClosed {
+		t.Errorf("pair closed error code: got %q, want %q", errResp.Error, protocol.ErrPairingClosed)
+	}
+}
+
+func TestPair_BadJSON_Returns400(t *testing.T) {
+	h, _ := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	rec := doRequest(h, "POST", "/v1/pair", []byte("{not-json"), map[string]string{
+		"Content-Type": "application/json",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("pair bad json: got %d, want 400", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrBadRequest {
+		t.Errorf("pair bad json error: got %q, want %q", errResp.Error, protocol.ErrBadRequest)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/search
+// ---------------------------------------------------------------------------
+
+func TestSearch_NoToken_Returns401(t *testing.T) {
+	h, _ := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	body := mustMarshal(t, protocol.SearchRequest{Query: "hello"})
+	rec := doRequest(h, "POST", "/v1/search", body, map[string]string{
+		"Content-Type": "application/json",
+	})
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("search no auth: got %d, want 401", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrUnauthorized {
+		t.Errorf("error code: got %q, want %q", errResp.Error, protocol.ErrUnauthorized)
+	}
+}
+
+func TestSearch_InvalidToken_Returns401(t *testing.T) {
+	h, _ := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	body := mustMarshal(t, protocol.SearchRequest{Query: "hello"})
+	rec := doRequest(h, "POST", "/v1/search", body, map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer totallyinvalidtoken",
+		"Origin":        "chrome-extension://fake",
+	})
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("search invalid token: got %d, want 401", rec.Code)
+	}
+}
+
+func TestSearch_ValidToken_ReturnsCannedResults(t *testing.T) {
+	canned := protocol.SearchResponse{
+		Results: []protocol.FileResult{
+			{ID: "1", Name: "report.pdf", Path: "/home/user/report.pdf"},
+		},
+		Total:   1,
+		Indexer: "mem",
+	}
+	fs := &fakeSearch{resp: canned}
+	h, m := newTestServer(t, fs, &fakeOpener{})
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.SearchRequest{Query: "report", QueryMode: "simple"})
+	rec := doRequest(h, "POST", "/v1/search", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("search valid: got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var resp protocol.SearchResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &resp)
+	if len(resp.Results) != 1 || resp.Results[0].ID != "1" {
+		t.Errorf("results: got %v", resp.Results)
+	}
+}
+
+func TestSearch_ErrNoIndexer_Returns503(t *testing.T) {
+	fs := &fakeSearch{err: index.ErrNoIndexer}
+	h, m := newTestServer(t, fs, &fakeOpener{})
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.SearchRequest{Query: "anything", QueryMode: "simple"})
+	rec := doRequest(h, "POST", "/v1/search", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("search no indexer: got %d, want 503", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrIndexerUnavailable {
+		t.Errorf("error code: got %q, want %q", errResp.Error, protocol.ErrIndexerUnavailable)
+	}
+}
+
+func TestSearch_EmptyQuery_Returns400(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+	token, origin := pairAndGetToken(t, h, m)
+
+	// Empty query triggers query.Parse failure → bad_request.
+	body := mustMarshal(t, protocol.SearchRequest{Query: "", QueryMode: "simple"})
+	rec := doRequest(h, "POST", "/v1/search", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("search empty query: got %d, want 400", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrBadRequest {
+		t.Errorf("error code: got %q, want %q", errResp.Error, protocol.ErrBadRequest)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/open
+// ---------------------------------------------------------------------------
+
+func TestOpen_NoAuth_Returns401(t *testing.T) {
+	h, _ := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	body := mustMarshal(t, protocol.OpenRequest{Path: "/tmp/x"})
+	rec := doRequest(h, "POST", "/v1/open", body, map[string]string{
+		"Content-Type": "application/json",
+	})
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("open no auth: got %d, want 401", rec.Code)
+	}
+}
+
+func TestOpen_EmptyPath_Returns400(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.OpenRequest{Path: ""})
+	rec := doRequest(h, "POST", "/v1/open", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("open empty path: got %d, want 400", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrBadRequest {
+		t.Errorf("error code: got %q, want %q", errResp.Error, protocol.ErrBadRequest)
+	}
+}
+
+func TestOpen_NonexistentPath_Returns400(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.OpenRequest{Path: "/absolutely/no/such/file/exists/here.txt"})
+	rec := doRequest(h, "POST", "/v1/open", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("open nonexistent: got %d, want 400", rec.Code)
+	}
+}
+
+func TestOpen_ValidPath_CallsOpener(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "ftc-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	fo := &fakeOpener{}
+	h, m := newTestServer(t, &fakeSearch{}, fo)
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.OpenRequest{Path: f.Name(), Reveal: false})
+	rec := doRequest(h, "POST", "/v1/open", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("open valid: got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var resp protocol.OpenResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &resp)
+	if !resp.OK {
+		t.Error("open: OK should be true")
+	}
+	if fo.openCalled != f.Name() {
+		t.Errorf("Open called with %q, want %q", fo.openCalled, f.Name())
+	}
+	if fo.revealCalled != "" {
+		t.Errorf("Reveal should not have been called, got %q", fo.revealCalled)
+	}
+}
+
+func TestOpen_ValidPath_Reveal(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "ftc-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	fo := &fakeOpener{}
+	h, m := newTestServer(t, &fakeSearch{}, fo)
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.OpenRequest{Path: f.Name(), Reveal: true})
+	rec := doRequest(h, "POST", "/v1/open", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("open reveal: got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	if fo.revealCalled != f.Name() {
+		t.Errorf("Reveal called with %q, want %q", fo.revealCalled, f.Name())
+	}
+	if fo.openCalled != "" {
+		t.Errorf("Open should not have been called, got %q", fo.openCalled)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/pairing/open
+// ---------------------------------------------------------------------------
+
+func TestPairingOpen_SetsWindowOpen(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	if m.PairingOpen() {
+		t.Error("PairingOpen: should be false initially")
+	}
+
+	rec := doRequest(h, "POST", "/v1/pairing/open", nil, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pairing/open: got %d, want 200", rec.Code)
+	}
+	var body map[string]bool
+	mustUnmarshal(t, rec.Body.Bytes(), &body)
+	if !body["ok"] {
+		t.Error("pairing/open response: ok should be true")
+	}
+	if !m.PairingOpen() {
+		t.Error("PairingOpen: should be true after POST /v1/pairing/open")
+	}
+}

--- a/companion/internal/server/server_test.go
+++ b/companion/internal/server/server_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,13 +44,15 @@ func (f *fakeSearch) Infos() []protocol.IndexerInfo {
 func (f *fakeSearch) Default() index.Indexer { return f.dflt }
 
 // fakeOpener implements server.Opener and records calls.
+// If err is non-nil, Open and Reveal return it instead of succeeding.
 type fakeOpener struct {
 	openCalled   string
 	revealCalled string
+	err          error
 }
 
-func (f *fakeOpener) Open(path string) error   { f.openCalled = path; return nil }
-func (f *fakeOpener) Reveal(path string) error { f.revealCalled = path; return nil }
+func (f *fakeOpener) Open(path string) error   { f.openCalled = path; return f.err }
+func (f *fakeOpener) Reveal(path string) error { f.revealCalled = path; return f.err }
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -475,5 +479,112 @@ func TestPairingOpen_SetsWindowOpen(t *testing.T) {
 	}
 	if !m.PairingOpen() {
 		t.Error("PairingOpen: should be true after POST /v1/pairing/open")
+	}
+}
+
+func TestPairingOpen_CrossSite_Returns403(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	rec := doRequest(h, "POST", "/v1/pairing/open", nil, map[string]string{
+		"Sec-Fetch-Site": "cross-site",
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("pairing/open cross-site: got %d, want 403", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrUnauthorized {
+		t.Errorf("error code: got %q, want %q", errResp.Error, protocol.ErrUnauthorized)
+	}
+	// Window must NOT have been opened.
+	if m.PairingOpen() {
+		t.Error("PairingOpen: must remain closed when request is cross-site")
+	}
+}
+
+func TestPairingOpen_SameOrigin_Returns200(t *testing.T) {
+	h, m := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	rec := doRequest(h, "POST", "/v1/pairing/open", nil, map[string]string{
+		"Sec-Fetch-Site": "same-origin",
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pairing/open same-origin: got %d, want 200", rec.Code)
+	}
+	if !m.PairingOpen() {
+		t.Error("PairingOpen: should be true after same-origin POST")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET /setup
+// ---------------------------------------------------------------------------
+
+func TestSetup_Returns200HTML(t *testing.T) {
+	h, _ := newTestServer(t, &fakeSearch{}, &fakeOpener{})
+
+	rec := doRequest(h, "GET", "/setup", nil, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup: got %d, want 200", rec.Code)
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type: got %q, want prefix text/html", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "<html") {
+		t.Error("setup: response body does not contain <html>")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/search — generic provider error
+// ---------------------------------------------------------------------------
+
+func TestSearch_GenericError_Returns500(t *testing.T) {
+	fs := &fakeSearch{err: errors.New("boom")}
+	h, m := newTestServer(t, fs, &fakeOpener{})
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.SearchRequest{Query: "anything", QueryMode: "simple"})
+	rec := doRequest(h, "POST", "/v1/search", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("search generic error: got %d, want 500", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrInternal {
+		t.Errorf("error code: got %q, want %q", errResp.Error, protocol.ErrInternal)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/open — opener failure
+// ---------------------------------------------------------------------------
+
+func TestOpen_OpenerError_Returns500(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "ftc-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	fo := &fakeOpener{err: errors.New("xdg-open: no application found")}
+	h, m := newTestServer(t, &fakeSearch{}, fo)
+	token, origin := pairAndGetToken(t, h, m)
+
+	body := mustMarshal(t, protocol.OpenRequest{Path: f.Name(), Reveal: false})
+	rec := doRequest(h, "POST", "/v1/open", body, authHeaders(token, origin))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("open opener error: got %d, want 500", rec.Code)
+	}
+	var errResp protocol.ErrorResponse
+	mustUnmarshal(t, rec.Body.Bytes(), &errResp)
+	if errResp.Error != protocol.ErrInternal {
+		t.Errorf("error code: got %q, want %q", errResp.Error, protocol.ErrInternal)
 	}
 }

--- a/companion/internal/server/setup.go
+++ b/companion/internal/server/setup.go
@@ -1,0 +1,152 @@
+package server
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+)
+
+// setupTmpl is the template for GET /setup, rendered once per request with
+// current server state so the page always reflects live pairing/port status.
+var setupTmpl = template.Must(template.New("setup").Parse(setupHTML))
+
+// setupData holds the dynamic values injected into the setup page template.
+type setupData struct {
+	Paired  bool
+	Port    int
+	Name    string
+	Version string
+}
+
+// handleSetup serves GET /setup.
+// No authentication required — it is the entry point for the user to initiate
+// pairing. The page posts to /v1/pairing/open (JS fetch) and tells the user
+// to click "Pair" in the extension.
+func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	data := setupData{
+		Paired:  s.deps.Pairing.Paired(),
+		Port:    s.deps.Port,
+		Name:    s.deps.Name,
+		Version: s.deps.Version,
+	}
+	if err := setupTmpl.Execute(w, data); err != nil {
+		// Headers are already sent; append a comment and move on.
+		fmt.Fprintf(w, "<!-- template error: %v -->", err)
+	}
+}
+
+// setupHTML is the source for the /setup page. It uses html/template syntax
+// and contains no external asset dependencies.
+const setupHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fast Travel — Companion Setup</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 520px;
+      margin: 2.5rem auto;
+      padding: 0 1.25rem;
+      color: #1a1a1a;
+      background: #f9fafb;
+    }
+    h1 { font-size: 1.35rem; margin: 0 0 1.5rem; }
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 1rem;
+    }
+    .status-row { display: flex; align-items: center; gap: 0.5rem; }
+    .badge {
+      display: inline-block;
+      padding: 0.2rem 0.65rem;
+      border-radius: 9999px;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .badge-paired   { background: #d1fae5; color: #065f46; }
+    .badge-unpaired { background: #fef3c7; color: #92400e; }
+    .meta { font-size: 0.85rem; color: #6b7280; margin-top: 0.4rem; }
+    button {
+      display: inline-block;
+      margin-top: 0.75rem;
+      padding: 0.6rem 1.25rem;
+      border: none;
+      border-radius: 6px;
+      background: #2563eb;
+      color: #fff;
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    button:hover:not(:disabled) { background: #1d4ed8; }
+    button:disabled { opacity: 0.6; cursor: default; }
+    #msg { margin-top: 0.75rem; font-size: 0.9rem; color: #374151; min-height: 1.4rem; }
+    ol { padding-left: 1.3rem; margin: 0.5rem 0 0; }
+    ol li { margin-bottom: 0.3rem; font-size: 0.9rem; }
+    footer { margin-top: 2rem; font-size: 0.78rem; color: #9ca3af; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Fast Travel Companion</h1>
+
+  <div class="card">
+    <div class="status-row">
+      <span>Pairing status:</span>
+      {{if .Paired}}
+        <span class="badge badge-paired">Paired</span>
+      {{else}}
+        <span class="badge badge-unpaired">Not paired</span>
+      {{end}}
+    </div>
+    {{if .Port}}
+    <p class="meta">Listening on <code>127.0.0.1:{{.Port}}</code></p>
+    {{end}}
+  </div>
+
+  <div class="card">
+    <strong>Pair the browser extension</strong>
+    <ol>
+      <li>Click <strong>Open Pairing Window</strong> below.</li>
+      <li>Open the Fast Travel extension popup in your browser and click <strong>Pair</strong>.</li>
+      <li>The window stays open for 5 minutes — pair before it expires.</li>
+    </ol>
+    <button id="pairBtn" onclick="openPairingWindow()">Open Pairing Window</button>
+    <div id="msg"></div>
+  </div>
+
+  <footer>{{.Name}} v{{.Version}}</footer>
+
+  <script>
+    async function openPairingWindow() {
+      const btn = document.getElementById('pairBtn');
+      const msg = document.getElementById('msg');
+      btn.disabled = true;
+      btn.textContent = 'Opening…';
+      msg.textContent = '';
+      try {
+        const r = await fetch('/v1/pairing/open', { method: 'POST' });
+        if (r.ok) {
+          btn.textContent = 'Window open';
+          msg.textContent = 'Pairing window is open. Click Pair in the extension now.';
+        } else {
+          const j = await r.json().catch(() => ({}));
+          btn.textContent = 'Open Pairing Window';
+          btn.disabled = false;
+          msg.textContent = 'Failed: ' + (j.message || r.status);
+        }
+      } catch (e) {
+        btn.textContent = 'Open Pairing Window';
+        btn.disabled = false;
+        msg.textContent = 'Error: ' + e.message;
+      }
+    }
+  </script>
+</body>
+</html>`

--- a/companion/scripts/build.sh
+++ b/companion/scripts/build.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# companion/scripts/build.sh — Cross-compile the Fast Travel companion daemon.
+#
+# Usage: build.sh [VERSION]
+#   VERSION  Optional version string (e.g. "1.2.3"). Defaults to the output of
+#            `git describe --tags --always`, or "dev" if git is unavailable.
+#
+# Outputs static binaries into companion/dist/:
+#   fast-travel-companion-linux-amd64
+#   fast-travel-companion-linux-arm64
+#   fast-travel-companion-windows-amd64.exe
+#
+# Phase 4 follow-up: AppImage wrapping and the GitHub release workflow are not
+# handled here; add them separately when Windows packaging is ready.
+set -eu
+
+# Resolve the directory containing this script, then find the companion root
+# (one level up from scripts/).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPANION_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$COMPANION_DIR"
+
+# Determine VERSION.
+if [ -n "${1:-}" ]; then
+    VERSION="$1"
+elif git describe --tags --always >/dev/null 2>&1; then
+    VERSION="$(git describe --tags --always)"
+else
+    VERSION="dev"
+fi
+
+echo "Building fast-travel-companion $VERSION ..."
+
+mkdir -p dist
+
+LDFLAGS="-s -w -X main.version=$VERSION"
+PKG="./cmd/fast-travel-companion"
+
+# linux/amd64
+echo "  -> linux/amd64"
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "$LDFLAGS" -o dist/fast-travel-companion-linux-amd64 "$PKG"
+
+# linux/arm64
+echo "  -> linux/arm64"
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "$LDFLAGS" -o dist/fast-travel-companion-linux-arm64 "$PKG"
+
+# windows/amd64
+echo "  -> windows/amd64"
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "$LDFLAGS" -o dist/fast-travel-companion-windows-amd64.exe "$PKG"
+
+echo ""
+echo "Built:"
+ls -lh dist/

--- a/companion/scripts/build.sh
+++ b/companion/scripts/build.sh
@@ -24,8 +24,7 @@ cd "$COMPANION_DIR"
 # Determine VERSION.
 if [ -n "${1:-}" ]; then
     VERSION="$1"
-elif git describe --tags --always >/dev/null 2>&1; then
-    VERSION="$(git describe --tags --always)"
+elif VERSION="$(git describe --tags --always 2>/dev/null)"; then :
 else
     VERSION="dev"
 fi

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -14,6 +14,7 @@
   "host_permissions": [
     "https://*/*",
     "http://*/*",
+    "http://127.0.0.1/*",
     "*://fast-travel-omnibox.invalid/*"
   ],
   "content_security_policy": {

--- a/extension/src/core/companion-client.ts
+++ b/extension/src/core/companion-client.ts
@@ -28,6 +28,14 @@ export const DISCOVERY_PORTS: readonly number[] = [
 /** Per-port timeout for ping probes during discovery. */
 export const PING_TIMEOUT_MS = 500;
 
+/**
+ * Minimum protocolVersion accepted from the companion daemon.
+ * Companions advertising a lower version are treated as not found so that the
+ * settings UI shows "not connected / needs update" rather than silently
+ * operating against an incompatible protocol.
+ */
+export const MIN_PROTOCOL_VERSION = 1;
+
 // ── Error class ──────────────────────────────────────────────────────────────
 
 /**
@@ -104,7 +112,7 @@ export async function discover(): Promise<{ port: number; ping: PingResponse } |
   // Fast path: try the cached port first.
   if (prefs.port !== undefined) {
     const ping = await pingPort(prefs.port);
-    if (ping !== null) {
+    if (ping !== null && ping.protocolVersion >= MIN_PROTOCOL_VERSION) {
       return { port: prefs.port, ping };
     }
   }
@@ -114,7 +122,7 @@ export async function discover(): Promise<{ port: number; ping: PingResponse } |
     prefs.port !== undefined ? DISCOVERY_PORTS.filter((p) => p !== prefs.port) : DISCOVERY_PORTS;
   for (const port of portsToScan) {
     const ping = await pingPort(port);
-    if (ping !== null) {
+    if (ping !== null && ping.protocolVersion >= MIN_PROTOCOL_VERSION) {
       await setLocalSearchPrefs({ port });
       return { port, ping };
     }

--- a/extension/src/core/companion-client.ts
+++ b/extension/src/core/companion-client.ts
@@ -1,0 +1,253 @@
+/**
+ * HTTP client for the Fast Travel companion daemon.
+ *
+ * All network details (URL construction, auth headers, timeout) live here.
+ * Callers receive typed results or a CompanionError — never raw Response
+ * objects or URL strings.
+ *
+ * Token hygiene: the token is placed into the Authorization header only.
+ * It is never logged, thrown in error messages, or stored in this module.
+ */
+
+import type {
+  PingResponse,
+  SearchRequest,
+  SearchResponse,
+  ErrorCode,
+  ErrorResponse,
+} from "./companion-types.js";
+import { getLocalSearchPrefs, setLocalSearchPrefs } from "./local-search-store.js";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Port range scanned by discover(). Companion default is 7333; scans up to 7343. */
+export const DISCOVERY_PORTS: readonly number[] = [
+  7333, 7334, 7335, 7336, 7337, 7338, 7339, 7340, 7341, 7342, 7343,
+];
+
+/** Per-port timeout for ping probes during discovery. */
+export const PING_TIMEOUT_MS = 500;
+
+// ── Error class ──────────────────────────────────────────────────────────────
+
+/**
+ * Typed error thrown by all companion-client functions.
+ *
+ * - `code`: one of the protocol ErrorCode values, or `"network"` for
+ *   fetch/timeout failures where no HTTP response was received.
+ * - `errorResponse`: the parsed ErrorResponse body when the server returned one.
+ */
+export class CompanionError extends Error {
+  constructor(
+    public readonly code: ErrorCode | "network",
+    message: string,
+    public readonly errorResponse?: ErrorResponse,
+  ) {
+    super(message);
+    this.name = "CompanionError";
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function baseUrl(port: number): string {
+  return `http://127.0.0.1:${port}/v1`;
+}
+
+/**
+ * Attempt a single /v1/ping on the given port. Returns the PingResponse on
+ * success, or null if the port is unreachable, times out, or returns non-200.
+ */
+async function pingPort(port: number): Promise<PingResponse | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PING_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${baseUrl(port)}/ping`, { signal: controller.signal });
+    if (!res.ok) return null;
+    return (await res.json()) as PingResponse;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Parse the error body from a failed response, returning undefined if it
+ * cannot be read or is not a valid ErrorResponse shape.
+ */
+async function parseErrorBody(res: Response): Promise<ErrorResponse | undefined> {
+  try {
+    const body = await res.json();
+    if (body && typeof body.error === "string" && typeof body.message === "string") {
+      return body as ErrorResponse;
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Discover the companion daemon by probing ports 7333–7343.
+ *
+ * - Checks the last-known port (stored in local-search prefs) first.
+ * - Falls back to a full port scan if the cached port is absent or fails.
+ * - Caches the found port in prefs so subsequent calls are fast.
+ * - Returns null when no companion is running on any port.
+ */
+export async function discover(): Promise<{ port: number; ping: PingResponse } | null> {
+  const prefs = await getLocalSearchPrefs();
+
+  // Fast path: try the cached port first.
+  if (prefs.port !== undefined) {
+    const ping = await pingPort(prefs.port);
+    if (ping !== null) {
+      return { port: prefs.port, ping };
+    }
+  }
+
+  // Full scan: try every port in order.
+  for (const port of DISCOVERY_PORTS) {
+    const ping = await pingPort(port);
+    if (ping !== null) {
+      await setLocalSearchPrefs({ port });
+      return { port, ping };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Pair with the companion. Requires the companion's pairing window to be open.
+ *
+ * @param port       Active companion port (from discover).
+ * @param clientName Human-readable client label, e.g. "Fast Travel (Chrome)".
+ * @returns The Bearer token to use in subsequent authenticated calls.
+ * @throws CompanionError  code "pairing_closed" (403) | "network" | other ErrorCode.
+ */
+export async function pair(port: number, clientName: string): Promise<string> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl(port)}/pair`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clientName }),
+    });
+  } catch (e) {
+    throw new CompanionError("network", (e as Error).message);
+  }
+
+  if (!res.ok) {
+    const errBody = await parseErrorBody(res);
+    const code: ErrorCode =
+      errBody?.error ?? (res.status === 403 ? "pairing_closed" : "internal");
+    throw new CompanionError(code, errBody?.message ?? `HTTP ${res.status}`, errBody);
+  }
+
+  const body = (await res.json()) as { token: string };
+  return body.token;
+}
+
+/**
+ * Ask the companion to open its pairing confirmation window. The user must
+ * confirm on the companion side before pair() will succeed.
+ *
+ * @param port  Active companion port (from discover).
+ * @throws CompanionError on network failure or non-OK response.
+ */
+export async function openPairingWindow(port: number): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl(port)}/pairing/open`, { method: "POST" });
+  } catch (e) {
+    throw new CompanionError("network", (e as Error).message);
+  }
+
+  if (!res.ok) {
+    const errBody = await parseErrorBody(res);
+    const code: ErrorCode = errBody?.error ?? "internal";
+    throw new CompanionError(code, errBody?.message ?? `HTTP ${res.status}`, errBody);
+  }
+}
+
+/**
+ * Execute a file search against the companion.
+ *
+ * @param port   Active companion port.
+ * @param token  Bearer token from pair().
+ * @param req    Search parameters (query, mode, sort, filters, pagination).
+ * @throws CompanionError  code "unauthorized" (401 — re-pair required) | "network" | other ErrorCode.
+ */
+export async function search(
+  port: number,
+  token: string,
+  req: SearchRequest,
+): Promise<SearchResponse> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl(port)}/search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(req),
+    });
+  } catch (e) {
+    throw new CompanionError("network", (e as Error).message);
+  }
+
+  if (res.status === 401) {
+    const errBody = await parseErrorBody(res);
+    throw new CompanionError("unauthorized", errBody?.message ?? "Unauthorized", errBody);
+  }
+
+  if (!res.ok) {
+    const errBody = await parseErrorBody(res);
+    const code: ErrorCode = errBody?.error ?? "internal";
+    throw new CompanionError(code, errBody?.message ?? `HTTP ${res.status}`, errBody);
+  }
+
+  return (await res.json()) as SearchResponse;
+}
+
+/**
+ * Ask the companion to open (or reveal) a file in the OS file manager.
+ *
+ * @param port    Active companion port.
+ * @param token   Bearer token from pair().
+ * @param path    Absolute path of the file or folder to open.
+ * @param reveal  When true, reveal the item in the file manager rather than
+ *                opening it directly.
+ * @throws CompanionError on auth failure, network error, or other error code.
+ */
+export async function openFile(
+  port: number,
+  token: string,
+  path: string,
+  reveal = false,
+): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl(port)}/open`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(reveal ? { path, reveal } : { path }),
+    });
+  } catch (e) {
+    throw new CompanionError("network", (e as Error).message);
+  }
+
+  if (!res.ok) {
+    const errBody = await parseErrorBody(res);
+    const code: ErrorCode = errBody?.error ?? "internal";
+    throw new CompanionError(code, errBody?.message ?? `HTTP ${res.status}`, errBody);
+  }
+}

--- a/extension/src/core/companion-client.ts
+++ b/extension/src/core/companion-client.ts
@@ -109,8 +109,10 @@ export async function discover(): Promise<{ port: number; ping: PingResponse } |
     }
   }
 
-  // Full scan: try every port in order.
-  for (const port of DISCOVERY_PORTS) {
+  // Full scan: try every port in order, skipping the cached port we already tried.
+  const portsToScan =
+    prefs.port !== undefined ? DISCOVERY_PORTS.filter((p) => p !== prefs.port) : DISCOVERY_PORTS;
+  for (const port of portsToScan) {
     const ping = await pingPort(port);
     if (ping !== null) {
       await setLocalSearchPrefs({ port });
@@ -243,6 +245,11 @@ export async function openFile(
     });
   } catch (e) {
     throw new CompanionError("network", (e as Error).message);
+  }
+
+  if (res.status === 401) {
+    const errBody = await parseErrorBody(res);
+    throw new CompanionError("unauthorized", errBody?.message ?? "Unauthorized", errBody);
   }
 
   if (!res.ok) {

--- a/extension/src/core/companion-types.ts
+++ b/extension/src/core/companion-types.ts
@@ -99,6 +99,13 @@ export interface SearchRequest {
   page: number;
   pageSize: number;
   history?: string[];
+  /** When true, matching is case-sensitive. Default false (case-insensitive). */
+  caseSensitive?: boolean;
+  /**
+   * When true, the whole query string is treated as one ordered phrase.
+   * Ignored in regex mode. Default false (AND of individual terms).
+   */
+  exactPhrase?: boolean;
 }
 
 export interface FileResult {

--- a/extension/src/core/companion-types.ts
+++ b/extension/src/core/companion-types.ts
@@ -1,0 +1,140 @@
+/**
+ * TypeScript interfaces mirroring the Fast Travel companion daemon wire
+ * protocol. Field names match the JSON exactly — do not rename.
+ *
+ * Authoritative schema: shared/companion-protocol/protocol.schema.json
+ */
+
+// ── Enums / unions ──────────────────────────────────────────────────────────
+
+export type QueryMode = "simple" | "wildcard" | "regex";
+
+export type FileType =
+  | "document"
+  | "image"
+  | "video"
+  | "audio"
+  | "archive"
+  | "code"
+  | "folder"
+  | "other";
+
+export type SortField = "relevance" | "created" | "modified";
+export type SortDir = "asc" | "desc";
+
+export type CompanionOs = "linux" | "windows" | "macos" | "android";
+
+/** Machine-readable error codes returned in ErrorResponse.error. */
+export type ErrorCode =
+  | "unauthorized"
+  | "pairing_closed"
+  | "bad_request"
+  | "indexer_unavailable"
+  | "unsupported_mode"
+  | "internal";
+
+// ── Sub-objects ──────────────────────────────────────────────────────────────
+
+export interface Capabilities {
+  booleanOps: boolean;
+  prefixWildcard: boolean;
+  infixWildcard: boolean;
+  regex: boolean;
+  pathScope: boolean;
+  content: boolean;
+}
+
+export interface IndexerInfo {
+  id: string;
+  name: string;
+  available: boolean;
+  capabilities: Capabilities;
+}
+
+export interface Sort {
+  field: SortField;
+  dir: SortDir;
+}
+
+export interface DateRange {
+  from?: number;
+  to?: number;
+}
+
+export interface Filters {
+  types?: FileType[];
+  createdRange?: DateRange;
+  modifiedRange?: DateRange;
+  pathPrefix?: string;
+  titleOnly?: boolean;
+  content?: boolean;
+}
+
+// ── Request / Response shapes ────────────────────────────────────────────────
+
+export interface PingResponse {
+  name: string;
+  version: string;
+  protocolVersion: number;
+  os: CompanionOs;
+  paired: boolean;
+  pairingOpen: boolean;
+  defaultIndexer: string;
+  indexers: IndexerInfo[];
+}
+
+export interface PairRequest {
+  clientName: string;
+}
+
+export interface PairResponse {
+  token: string;
+}
+
+export interface SearchRequest {
+  query: string;
+  queryMode: QueryMode;
+  sort: Sort;
+  filters: Filters;
+  page: number;
+  pageSize: number;
+  history?: string[];
+}
+
+export interface FileResult {
+  id: string;
+  name: string;
+  path: string;
+  dir: string;
+  ext: string;
+  mime: string;
+  type: FileType;
+  size: number;
+  createdAt: number;
+  modifiedAt: number;
+  score: number;
+  iconHint?: string;
+}
+
+export interface SearchResponse {
+  results: FileResult[];
+  total: number;
+  page: number;
+  tookMs: number;
+  indexer: string;
+  degraded?: boolean;
+}
+
+export interface OpenRequest {
+  path: string;
+  reveal?: boolean;
+}
+
+export interface OpenResponse {
+  ok: true;
+}
+
+export interface ErrorResponse {
+  error: ErrorCode;
+  message: string;
+}

--- a/extension/src/core/local-search-capabilities.ts
+++ b/extension/src/core/local-search-capabilities.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared capability helpers derived from the companion ping response.
+ *
+ * Imported by both the options screen (settings defaults UI) and the local-search
+ * results view (toolbar capability gating) so the logic stays DRY.
+ */
+
+import type { PingResponse } from "./companion-types.js";
+
+/**
+ * Returns true if at least one *available* indexer in the ping response
+ * advertises `capabilities.regex === true`.
+ */
+export function regexAvailable(ping: PingResponse): boolean {
+  return ping.indexers.some((idx) => idx.available && idx.capabilities.regex);
+}
+
+/**
+ * Returns true if the *default* indexer is available and supports content
+ * search.
+ */
+export function contentAvailable(ping: PingResponse): boolean {
+  const def = ping.indexers.find((idx) => idx.id === ping.defaultIndexer);
+  return def !== undefined && def.available && def.capabilities.content;
+}

--- a/extension/src/core/local-search-store.ts
+++ b/extension/src/core/local-search-store.ts
@@ -22,6 +22,11 @@ export interface LocalSearchPrefs {
   filters: { types?: string[]; titleOnly?: boolean; content?: boolean };
   /** Results display style. Default "list". */
   view: "list" | "grid";
+  /**
+   * Capped list of recently-opened file ids (most-recent first, max 30).
+   * Passed as SearchRequest.history so the companion can recency-boost them.
+   */
+  recentlyOpened?: string[];
 }
 
 const STORE_KEY = "fast-travel-local-search-prefs";

--- a/extension/src/core/local-search-store.ts
+++ b/extension/src/core/local-search-store.ts
@@ -32,6 +32,13 @@ export interface LocalSearchPrefs {
   };
   /** Results display style. Default "list". */
   view: "list" | "grid";
+  /** When true, matching is case-sensitive. Default false. */
+  caseSensitive: boolean;
+  /**
+   * When true, the whole query string is treated as one ordered phrase
+   * (ignored in regex mode). Default false (AND of individual terms).
+   */
+  exactPhrase: boolean;
   /**
    * Capped list of recently-opened file ids (most-recent first, max 30).
    * Passed as SearchRequest.history so the companion can recency-boost them.
@@ -47,6 +54,8 @@ const DEFAULTS: LocalSearchPrefs = {
   sort: { field: "relevance", dir: "desc" },
   filters: {},
   view: "list",
+  caseSensitive: false,
+  exactPhrase: false,
 };
 
 /**

--- a/extension/src/core/local-search-store.ts
+++ b/extension/src/core/local-search-store.ts
@@ -19,7 +19,7 @@ export interface LocalSearchPrefs {
   /** Result sort order. Default relevance/desc. */
   sort: { field: "relevance" | "created" | "modified"; dir: "asc" | "desc" };
   /** Active filters. Minimal defaults; Phase 3 extends with more fields. */
-  filters: { types?: string[]; titleOnly?: boolean };
+  filters: { types?: string[]; titleOnly?: boolean; content?: boolean };
   /** Results display style. Default "list". */
   view: "list" | "grid";
 }

--- a/extension/src/core/local-search-store.ts
+++ b/extension/src/core/local-search-store.ts
@@ -18,8 +18,18 @@ export interface LocalSearchPrefs {
   queryMode: "simple" | "wildcard" | "regex";
   /** Result sort order. Default relevance/desc. */
   sort: { field: "relevance" | "created" | "modified"; dir: "asc" | "desc" };
-  /** Active filters. Minimal defaults; Phase 3 extends with more fields. */
-  filters: { types?: string[]; titleOnly?: boolean; content?: boolean };
+  /** Active filters. */
+  filters: {
+    types?: string[];
+    titleOnly?: boolean;
+    content?: boolean;
+    /** Path prefix filter — only return files under this directory. */
+    pathPrefix?: string;
+    /** Open-ended date range for file creation date (epoch ms). */
+    createdRange?: { from?: number; to?: number };
+    /** Open-ended date range for file modified date (epoch ms). */
+    modifiedRange?: { from?: number; to?: number };
+  };
   /** Results display style. Default "list". */
   view: "list" | "grid";
   /**

--- a/extension/src/core/local-search-store.ts
+++ b/extension/src/core/local-search-store.ts
@@ -1,0 +1,72 @@
+/**
+ * Device-local store for local-search settings. Mirrors the auto-ignore-store
+ * pattern: direct chrome.storage.local calls, no message passing, sane
+ * defaults applied on every read, partial-merge on write.
+ *
+ * Key: "fast-travel-local-search-prefs"
+ * Default: enabled=false so users opt in explicitly.
+ */
+
+export interface LocalSearchPrefs {
+  /** Whether the local-search feature is enabled. Default false — opt-in. */
+  enabled: boolean;
+  /** Bearer token obtained after pairing. Absent until paired. */
+  token?: string;
+  /** Last known companion port. Absent until a successful discover(). */
+  port?: number;
+  /** Query parsing mode sent to the companion. Default "simple". */
+  queryMode: "simple" | "wildcard" | "regex";
+  /** Result sort order. Default relevance/desc. */
+  sort: { field: "relevance" | "created" | "modified"; dir: "asc" | "desc" };
+  /** Active filters. Minimal defaults; Phase 3 extends with more fields. */
+  filters: { types?: string[]; titleOnly?: boolean };
+  /** Results display style. Default "list". */
+  view: "list" | "grid";
+}
+
+const STORE_KEY = "fast-travel-local-search-prefs";
+
+const DEFAULTS: LocalSearchPrefs = {
+  enabled: false,
+  queryMode: "simple",
+  sort: { field: "relevance", dir: "desc" },
+  filters: {},
+  view: "list",
+};
+
+/**
+ * Read the current local-search prefs, merging stored values over defaults.
+ * Always returns a fully-populated object — callers never need null checks.
+ */
+export async function getLocalSearchPrefs(): Promise<LocalSearchPrefs> {
+  const v = await chrome.storage.local.get(STORE_KEY);
+  const stored = v[STORE_KEY] as Partial<LocalSearchPrefs> | undefined;
+  if (!stored || typeof stored !== "object") {
+    return { ...DEFAULTS, filters: { ...DEFAULTS.filters }, sort: { ...DEFAULTS.sort } };
+  }
+  return {
+    ...DEFAULTS,
+    ...stored,
+    sort: { ...DEFAULTS.sort, ...(stored.sort ?? {}) },
+    filters: { ...DEFAULTS.filters, ...(stored.filters ?? {}) },
+  };
+}
+
+/**
+ * Merge `partial` into the current prefs and persist. Nested `sort` and
+ * `filters` are shallow-merged so callers can update one sub-field at a time.
+ * Returns the merged result.
+ */
+export async function setLocalSearchPrefs(
+  partial: Partial<LocalSearchPrefs>,
+): Promise<LocalSearchPrefs> {
+  const current = await getLocalSearchPrefs();
+  const next: LocalSearchPrefs = {
+    ...current,
+    ...partial,
+    sort: { ...current.sort, ...(partial.sort ?? {}) },
+    filters: { ...current.filters, ...(partial.filters ?? {}) },
+  };
+  await chrome.storage.local.set({ [STORE_KEY]: next });
+  return next;
+}

--- a/extension/src/core/local-search-store.ts
+++ b/extension/src/core/local-search-store.ts
@@ -69,18 +69,27 @@ export async function getLocalSearchPrefs(): Promise<LocalSearchPrefs> {
 
 /**
  * Merge `partial` into the current prefs and persist. Nested `sort` and
- * `filters` are shallow-merged so callers can update one sub-field at a time.
+ * `filters` are shallow-merged so callers can update one sub-field at a time
+ * (e.g. `{ sort: { field } }` without supplying `dir`).
  * Returns the merged result.
  */
 export async function setLocalSearchPrefs(
-  partial: Partial<LocalSearchPrefs>,
+  partial: Partial<Omit<LocalSearchPrefs, "sort" | "filters">> & {
+    sort?: Partial<LocalSearchPrefs["sort"]>;
+    filters?: Partial<LocalSearchPrefs["filters"]>;
+  },
 ): Promise<LocalSearchPrefs> {
   const current = await getLocalSearchPrefs();
+  // Destructure sort/filters before spreading so the rest is fully type-safe.
+  const { sort: partialSort, filters: partialFilters, ...rest } = partial;
   const next: LocalSearchPrefs = {
     ...current,
-    ...partial,
-    sort: { ...current.sort, ...(partial.sort ?? {}) },
-    filters: { ...current.filters, ...(partial.filters ?? {}) },
+    ...rest,
+    sort: {
+      field: partialSort?.field ?? current.sort.field,
+      dir: partialSort?.dir ?? current.sort.dir,
+    },
+    filters: { ...current.filters, ...(partialFilters ?? {}) },
   };
   await chrome.storage.local.set({ [STORE_KEY]: next });
   return next;

--- a/extension/src/newtab/file-type-icon.ts
+++ b/extension/src/newtab/file-type-icon.ts
@@ -1,0 +1,130 @@
+/**
+ * Per-file-type icon module for the local-search results view.
+ *
+ * Pure, side-effect-free exports (safe in Node/Vitest):
+ *   fileTypeIconDescriptor — maps type+ext to a stable { iconId, fillVar, fgVar }
+ *
+ * DOM export (requires document):
+ *   renderFileTypeIcon — populates a container element with a tinted icon,
+ *                        mirroring the renderFavicon pattern in ui/favicon.ts.
+ *
+ * No external icon library is used — paths are inline Feather-compatible SVGs.
+ */
+
+import type { FileType } from "../core/companion-types.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Stable descriptor returned by fileTypeIconDescriptor.
+ * Used by tests and by the DOM rendering helper.
+ */
+export interface FileTypeIconDescriptor {
+  /** Matches the resolved FileType category (unknown → "other"). */
+  iconId: FileType;
+  /** CSS custom property for the tinted background (from tokens.css). */
+  fillVar: string;
+  /** CSS custom property for the icon foreground color (from tokens.css). */
+  fgVar: string;
+}
+
+// ── Category → tint map ──────────────────────────────────────────────────────
+
+/**
+ * Per-category (fillVar, fgVar) pairs using the tint tokens from tokens.css.
+ * One entry per FileType — deliberately exhaustive so TypeScript catches gaps.
+ */
+const TINT_MAP: Record<FileType, { fillVar: string; fgVar: string }> = {
+  folder:   { fillVar: "var(--tint-amber-fill)",   fgVar: "var(--tint-amber-fg)" },
+  image:    { fillVar: "var(--tint-green-fill)",   fgVar: "var(--tint-green-fg)" },
+  video:    { fillVar: "var(--tint-purple-fill)",  fgVar: "var(--tint-purple-fg)" },
+  audio:    { fillVar: "var(--tint-cyan-fill)",    fgVar: "var(--tint-cyan-fg)" },
+  archive:  { fillVar: "var(--tint-orange-fill)",  fgVar: "var(--tint-orange-fg)" },
+  code:     { fillVar: "var(--tint-blue-fill)",    fgVar: "var(--tint-blue-fg)" },
+  document: { fillVar: "var(--tint-red-fill)",     fgVar: "var(--tint-red-fg)" },
+  other:    { fillVar: "var(--tint-neutral-fill)", fgVar: "var(--tint-neutral-fg)" },
+};
+
+// ── Category → SVG path data ─────────────────────────────────────────────────
+
+/**
+ * Inline Feather-compatible SVG path data (24×24 viewBox).
+ * The SVG wrapper is added at render time so tests can inspect just the paths.
+ */
+const SVG_PATHS: Record<FileType, string> = {
+  folder:
+    '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>',
+  image:
+    '<rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>' +
+    '<circle cx="8.5" cy="8.5" r="1.5"/>' +
+    '<polyline points="21 15 16 10 5 21"/>',
+  video:
+    '<polygon points="23 7 16 12 23 17 23 7"/>' +
+    '<rect x="1" y="5" width="15" height="14" rx="2" ry="2"/>',
+  audio:
+    '<path d="M9 18V5l12-2v13"/>' +
+    '<circle cx="6" cy="18" r="3"/>' +
+    '<circle cx="18" cy="16" r="3"/>',
+  archive:
+    '<polyline points="21 8 21 21 3 21 3 8"/>' +
+    '<rect x="1" y="3" width="22" height="5"/>' +
+    '<line x1="10" y1="12" x2="14" y2="12"/>',
+  code:
+    '<polyline points="16 18 22 12 16 6"/>' +
+    '<polyline points="8 6 2 12 8 18"/>',
+  document:
+    '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>' +
+    '<polyline points="14 2 14 8 20 8"/>' +
+    '<line x1="16" y1="13" x2="8" y2="13"/>' +
+    '<line x1="16" y1="17" x2="8" y2="17"/>',
+  other:
+    '<path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>' +
+    '<polyline points="13 2 13 9 20 9"/>',
+};
+
+// ── Pure function (exported + unit-tested) ────────────────────────────────────
+
+/**
+ * Return a stable descriptor for a file type (and optional extension).
+ * Unknown types resolve to "other".  Currently type-level only; future
+ * callers may refine by extension (e.g. ".py" within "code").
+ *
+ * Safe to call in Node/Vitest — no DOM access.
+ */
+export function fileTypeIconDescriptor(
+  type: string,
+  _ext?: string,
+): FileTypeIconDescriptor {
+  const resolved: FileType = (type in TINT_MAP) ? (type as FileType) : "other";
+  const { fillVar, fgVar } = TINT_MAP[resolved];
+  return { iconId: resolved, fillVar, fgVar };
+}
+
+// ── DOM helper ────────────────────────────────────────────────────────────────
+
+/**
+ * Populate `container` with a tinted SVG icon for the given file type.
+ * Mirrors the renderFavicon(container, opts) pattern:
+ *   - clears the container's children
+ *   - applies tint colours as inline styles (background + color)
+ *   - appends an SVG element that sizes itself to 60% of the container
+ *
+ * Container sizing is left to CSS (.ls-result-icon), so both list (32 px)
+ * and grid (52 px) contexts work without extra JS.
+ */
+export function renderFileTypeIcon(
+  container: HTMLElement,
+  type: string,
+  ext?: string,
+): void {
+  const { iconId, fillVar, fgVar } = fileTypeIconDescriptor(type, ext);
+  container.replaceChildren();
+  container.style.background = fillVar;
+  container.style.color = fgVar;
+  container.innerHTML =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" ' +
+    'aria-hidden="true" class="ls-type-icon-svg">' +
+    SVG_PATHS[iconId] +
+    "</svg>";
+}

--- a/extension/src/newtab/local-search-results.ts
+++ b/extension/src/newtab/local-search-results.ts
@@ -1,0 +1,619 @@
+/**
+ * Local-search results view + `s`-command intercept logic for the new-tab page.
+ *
+ * Pure, side-effect-free functions (shouldInterceptLocalSearch, buildSearchRequest,
+ * navDown, navUp) live at the top and are unit-tested. All DOM work is deferred
+ * behind initLocalSearch() / openLocalSearch() / closeLocalSearch() so module
+ * import is safe in the Vitest / Node environment.
+ */
+
+import type { FastTravelConfig } from "../core/types.js";
+import type { SearchRequest, Filters, FileResult } from "../core/companion-types.js";
+import type { LocalSearchPrefs } from "../core/local-search-store.js";
+import { getLocalSearchPrefs, setLocalSearchPrefs } from "../core/local-search-store.js";
+import { buildTriggerMap } from "../core/parser.js";
+import { search as companionSearch, openFile as companionOpenFile, CompanionError } from "../core/companion-client.js";
+import { renderFavicon } from "../ui/favicon.js";
+import { showSnackbar } from "../ui/snackbar.js";
+
+// ── Pure functions (exported + unit-tested) ───────────────────────────────────
+
+/**
+ * Decide whether to intercept the newtab submit and open the local-search view.
+ *
+ * Returns `{ intercept: true, query }` only when ALL of:
+ *   - prefs.enabled is true
+ *   - prefs.token is set (paired)
+ *   - the config does NOT define the `s` trigger (config command always wins)
+ *   - input matches `^s(\s+.*)?$` (the `s` command, optionally followed by a query)
+ *
+ * Everything else returns `{ intercept: false }` — a strict no-op.
+ */
+export function shouldInterceptLocalSearch(
+  input: string,
+  prefs: LocalSearchPrefs,
+  config: FastTravelConfig,
+): { intercept: false } | { intercept: true; query: string } {
+  if (!prefs.enabled || !prefs.token) return { intercept: false };
+  if (buildTriggerMap(config).has("s")) return { intercept: false };
+  const match = /^s(\s+(.*))?$/i.exec(input);
+  if (!match) return { intercept: false };
+  return { intercept: true, query: (match[2] ?? "").trim() };
+}
+
+/**
+ * Build a SearchRequest from current prefs + query + recently-opened ids.
+ * page is always 0; pageSize is always 50.
+ */
+export function buildSearchRequest(
+  prefs: LocalSearchPrefs,
+  query: string,
+  recentlyOpened: string[] = [],
+): SearchRequest {
+  return {
+    query,
+    queryMode: prefs.queryMode,
+    sort: prefs.sort,
+    filters: prefs.filters as Filters,
+    page: 0,
+    pageSize: 50,
+    ...(recentlyOpened.length > 0 ? { history: recentlyOpened } : {}),
+  };
+}
+
+/**
+ * Move selection down by one, clamping at the last item.
+ * Returns -1 when total is 0 (nothing to select).
+ */
+export function navDown(index: number, total: number): number {
+  if (total === 0) return -1;
+  return Math.min(index + 1, total - 1);
+}
+
+/**
+ * Move selection up by one, allowing deselection to -1 (above the list).
+ * Returns -1 when total is 0.
+ */
+export function navUp(index: number, total: number): number {
+  if (total === 0) return -1;
+  return Math.max(index - 1, -1);
+}
+
+// ── DOM state (module-level; reset on closeLocalSearch) ───────────────────────
+
+let isOpen = false;
+let activeIndex = -1;
+let currentResults: FileResult[] = [];
+/** Monotonically-increasing generation counter prevents stale responses from
+ * rendering after a newer search was started. */
+let searchGeneration = 0;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+// DOM refs — null until ensureContainer() runs
+let lsContainer: HTMLElement | null = null;
+let lsInput: HTMLInputElement | null = null;
+let lsStatus: HTMLElement | null = null;
+let lsList: HTMLElement | null = null;
+let lsFooter: HTMLElement | null = null;
+
+/** IDs of the normal newtab hero elements to hide while the results view is open. */
+const HERO_IDS = [
+  "search-container",
+  "chips-section",
+  "typo-container",
+  "onboarding-hint",
+] as const;
+
+// ── Initialization (called once from newtab.ts after DOM is ready) ────────────
+
+/**
+ * Register the document-level Escape handler. Call once from newtab.ts.
+ * Kept out of module-level scope so the module is safe to import in Node/tests.
+ */
+export function initLocalSearch(): void {
+  document.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (!isOpen) return;
+    if (e.key === "Escape") closeLocalSearch();
+  });
+}
+
+// ── DOM creation (lazy — first call to openLocalSearch) ───────────────────────
+
+function ensureContainer(): void {
+  if (lsContainer) return;
+  const app = document.getElementById("app");
+  if (!app) return;
+
+  lsContainer = document.createElement("div");
+  lsContainer.id = "ls-container";
+  lsContainer.className = "hidden";
+  lsContainer.setAttribute("role", "region");
+  lsContainer.setAttribute("aria-label", "Local file search");
+
+  // ── Header: back button + compact search input ──────────────────────────
+  const header = document.createElement("div");
+  header.id = "ls-header";
+
+  const backBtn = document.createElement("button");
+  backBtn.id = "ls-back";
+  backBtn.type = "button";
+  backBtn.setAttribute("aria-label", "Back to Fast Travel");
+  backBtn.innerHTML =
+    '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>';
+  backBtn.addEventListener("click", closeLocalSearch);
+  header.appendChild(backBtn);
+
+  const inputWrapper = document.createElement("div");
+  inputWrapper.id = "ls-input-wrapper";
+  lsInput = document.createElement("input");
+  lsInput.id = "ls-input";
+  lsInput.type = "text";
+  lsInput.autocomplete = "off";
+  lsInput.spellcheck = false;
+  lsInput.setAttribute("aria-label", "Search local files");
+  lsInput.placeholder = "Search files…";
+  inputWrapper.appendChild(lsInput);
+  header.appendChild(inputWrapper);
+
+  lsContainer.appendChild(header);
+
+  // ── Toolbar placeholder — 3b drops the Drive-style toolbar here ─────────
+  const toolbar = document.createElement("div");
+  toolbar.id = "ls-toolbar";
+  toolbar.setAttribute("aria-hidden", "true");
+  lsContainer.appendChild(toolbar);
+
+  // ── Status area: loading / empty / error / disconnected ─────────────────
+  lsStatus = document.createElement("div");
+  lsStatus.id = "ls-status";
+  lsStatus.className = "hidden";
+  lsStatus.setAttribute("role", "status");
+  lsStatus.setAttribute("aria-live", "polite");
+  lsContainer.appendChild(lsStatus);
+
+  // ── Results list ─────────────────────────────────────────────────────────
+  lsList = document.createElement("div");
+  lsList.id = "ls-list";
+  lsList.setAttribute("role", "listbox");
+  lsList.setAttribute("aria-label", "File search results");
+  lsContainer.appendChild(lsList);
+
+  // ── Footer: total + indexer + degraded note ──────────────────────────────
+  lsFooter = document.createElement("div");
+  lsFooter.id = "ls-footer";
+  lsFooter.className = "hidden";
+  lsContainer.appendChild(lsFooter);
+
+  app.appendChild(lsContainer);
+
+  // Wire keyboard navigation on the local search input
+  lsInput.addEventListener("keydown", handleInputKeydown);
+  lsInput.addEventListener("input", handleInputChange);
+}
+
+// ── Keyboard handling ─────────────────────────────────────────────────────────
+
+function handleInputKeydown(e: KeyboardEvent): void {
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    activeIndex = navDown(activeIndex, currentResults.length);
+    updateActiveRow();
+    scrollActiveRowIntoView();
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    activeIndex = navUp(activeIndex, currentResults.length);
+    updateActiveRow();
+    scrollActiveRowIntoView();
+  } else if (e.key === "Enter" && activeIndex >= 0) {
+    e.preventDefault();
+    if (e.shiftKey) {
+      void doReveal(activeIndex);
+    } else {
+      void doOpen(activeIndex);
+    }
+  } else if (e.key === "Escape") {
+    closeLocalSearch();
+  }
+}
+
+function handleInputChange(): void {
+  if (!lsInput) return;
+  const query = lsInput.value;
+  if (debounceTimer !== null) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    void runSearch(query);
+  }, 240);
+}
+
+// ── Open / close ──────────────────────────────────────────────────────────────
+
+/**
+ * Take over the new-tab view: hide the hero, show the results container, and
+ * run an initial search for `query`. Exported so newtab.ts can call it.
+ */
+export async function openLocalSearch(query: string): Promise<void> {
+  ensureContainer();
+  if (!lsContainer || !lsInput) return;
+
+  isOpen = true;
+  activeIndex = -1;
+  currentResults = [];
+
+  // Hide normal newtab elements
+  for (const id of HERO_IDS) {
+    document.getElementById(id)?.classList.add("ls-hidden");
+  }
+
+  lsContainer.classList.remove("hidden");
+  lsInput.value = query;
+  lsInput.focus();
+  lsInput.select();
+
+  if (query) {
+    await runSearch(query);
+  } else {
+    showEmptyQueryState();
+  }
+}
+
+/**
+ * Restore the normal launcher view. Called on Escape, back button, or from
+ * newtab.ts.
+ */
+export function closeLocalSearch(): void {
+  if (!isOpen) return;
+  isOpen = false;
+  searchGeneration++;
+
+  if (debounceTimer !== null) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+
+  lsContainer?.classList.add("hidden");
+  clearStatusAndList();
+
+  currentResults = [];
+  activeIndex = -1;
+
+  // Restore normal newtab elements
+  for (const id of HERO_IDS) {
+    document.getElementById(id)?.classList.remove("ls-hidden");
+  }
+
+  // Return focus to the main search bar
+  (document.getElementById("search-input") as HTMLInputElement | null)?.focus();
+}
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+async function runSearch(query: string): Promise<void> {
+  const gen = ++searchGeneration;
+  showLoading();
+
+  const prefs = await getLocalSearchPrefs();
+  if (gen !== searchGeneration || !isOpen) return;
+
+  if (!prefs.port || !prefs.token) {
+    showDisconnected();
+    return;
+  }
+
+  const req = buildSearchRequest(prefs, query, prefs.recentlyOpened ?? []);
+
+  try {
+    const resp = await companionSearch(prefs.port, prefs.token, req);
+    if (gen !== searchGeneration || !isOpen) return;
+    renderResults(resp.results, resp.total, resp.indexer, resp.degraded ?? false, query);
+  } catch (err) {
+    if (gen !== searchGeneration || !isOpen) return;
+    if (err instanceof CompanionError && err.code === "unauthorized") {
+      // Definitive 401 — clear the stale token so the settings screen re-prompts pairing
+      await setLocalSearchPrefs({ token: undefined });
+      showUnauthorized();
+    } else if (err instanceof CompanionError && err.code === "network") {
+      showDisconnected();
+    } else {
+      showError(err instanceof Error ? err.message : String(err), query);
+    }
+  }
+}
+
+// ── State renderers ───────────────────────────────────────────────────────────
+
+function clearStatusAndList(): void {
+  if (lsStatus) {
+    lsStatus.className = "hidden";
+    lsStatus.replaceChildren();
+  }
+  lsList?.replaceChildren();
+  if (lsFooter) lsFooter.className = "hidden";
+}
+
+function showLoading(): void {
+  if (!lsStatus || !lsList || !lsFooter) return;
+  lsList.replaceChildren();
+  lsFooter.className = "hidden";
+  lsStatus.className = "ls-status ls-status-loading";
+  lsStatus.replaceChildren();
+  const spinner = document.createElement("div");
+  spinner.className = "ls-spinner";
+  spinner.setAttribute("aria-hidden", "true");
+  lsStatus.appendChild(spinner);
+  const label = document.createElement("span");
+  label.textContent = "Searching…";
+  lsStatus.appendChild(label);
+}
+
+function showEmptyQueryState(): void {
+  if (!lsStatus || !lsList || !lsFooter) return;
+  lsList.replaceChildren();
+  lsFooter.className = "hidden";
+  lsStatus.className = "ls-status ls-status-empty";
+  lsStatus.textContent = "Type a query to search your local files.";
+}
+
+function showDisconnected(): void {
+  if (!lsStatus || !lsList || !lsFooter) return;
+  lsList.replaceChildren();
+  lsFooter.className = "hidden";
+  lsStatus.className = "ls-status ls-status-disconnected";
+  lsStatus.replaceChildren();
+  const msg = document.createElement("p");
+  msg.textContent = "Cannot reach the Fast Travel companion.";
+  lsStatus.appendChild(msg);
+  lsStatus.appendChild(makeSettingsLink("Check Local Search settings →"));
+}
+
+function showUnauthorized(): void {
+  if (!lsStatus || !lsList || !lsFooter) return;
+  lsList.replaceChildren();
+  lsFooter.className = "hidden";
+  lsStatus.className = "ls-status ls-status-disconnected";
+  lsStatus.replaceChildren();
+  const msg = document.createElement("p");
+  msg.textContent = "Authorization lost — re-pairing is required.";
+  lsStatus.appendChild(msg);
+  lsStatus.appendChild(makeSettingsLink("Re-pair in Local Search settings →"));
+}
+
+function showError(message: string, query: string): void {
+  if (!lsStatus || !lsList || !lsFooter) return;
+  lsList.replaceChildren();
+  lsFooter.className = "hidden";
+  lsStatus.className = "ls-status ls-status-error";
+  lsStatus.replaceChildren();
+  const msg = document.createElement("p");
+  msg.textContent = `Search error: ${message}`;
+  lsStatus.appendChild(msg);
+  const retryBtn = document.createElement("button");
+  retryBtn.type = "button";
+  retryBtn.className = "ls-retry-btn";
+  retryBtn.textContent = "Retry";
+  retryBtn.addEventListener("click", () => void runSearch(query));
+  lsStatus.appendChild(retryBtn);
+}
+
+function makeSettingsLink(text: string): HTMLParagraphElement {
+  const hint = document.createElement("p");
+  hint.className = "ls-status-hint";
+  const a = document.createElement("a");
+  a.href = "../options/options.html#/local-search";
+  a.target = "_blank";
+  a.rel = "noopener";
+  a.textContent = text;
+  hint.appendChild(a);
+  return hint;
+}
+
+// ── Results rendering ─────────────────────────────────────────────────────────
+
+function renderResults(
+  results: FileResult[],
+  total: number,
+  indexer: string,
+  degraded: boolean,
+  query: string,
+): void {
+  if (!lsStatus || !lsList || !lsFooter) return;
+
+  currentResults = results;
+  activeIndex = -1;
+
+  if (results.length === 0) {
+    lsStatus.className = "ls-status ls-status-empty";
+    lsStatus.textContent = query
+      ? `No files match “${query}”.`
+      : "No files found.";
+    lsList.replaceChildren();
+    lsFooter.className = "hidden";
+    return;
+  }
+
+  lsStatus.className = "hidden";
+  lsStatus.replaceChildren();
+
+  lsList.replaceChildren();
+  results.forEach((file, i) => {
+    lsList!.appendChild(buildResultRow(file, i));
+  });
+
+  // Footer: total count + indexer name + optional degraded badge
+  lsFooter.className = "ls-footer";
+  lsFooter.replaceChildren();
+  const countEl = document.createElement("span");
+  countEl.className = "ls-footer-count";
+  countEl.textContent = `${total.toLocaleString()} result${total !== 1 ? "s" : ""} · ${indexer}`;
+  lsFooter.appendChild(countEl);
+  if (degraded) {
+    const badge = document.createElement("span");
+    badge.className = "ls-degraded-badge";
+    badge.title = "Index may be incomplete — results are best-effort";
+    badge.textContent = "best-effort";
+    lsFooter.appendChild(badge);
+  }
+}
+
+function buildResultRow(file: FileResult, index: number): HTMLElement {
+  const row = document.createElement("div");
+  row.className = "ls-result-row";
+  row.setAttribute("role", "option");
+  row.setAttribute("aria-selected", "false");
+  row.dataset.index = String(index);
+
+  // File-type icon — monogram keyed on ext/type for now; rich per-type icons come in 3b
+  const iconEl = document.createElement("div");
+  iconEl.className = "ls-result-icon";
+  renderFavicon(iconEl, {
+    // Use the extension (e.g. ".pdf") or first letter of type as the monogram seed
+    trigger: file.ext ? `.${file.ext}` : file.type.charAt(0),
+    size: 20,
+  });
+  row.appendChild(iconEl);
+
+  // Primary name + secondary path
+  const textBlock = document.createElement("div");
+  textBlock.className = "ls-result-text";
+
+  const primary = document.createElement("span");
+  primary.className = "ls-result-primary";
+  primary.textContent = file.name;
+  textBlock.appendChild(primary);
+
+  const secondary = document.createElement("span");
+  secondary.className = "ls-result-secondary";
+  secondary.textContent = file.dir;
+  textBlock.appendChild(secondary);
+
+  row.appendChild(textBlock);
+
+  // Compact meta: date + size
+  const meta = document.createElement("div");
+  meta.className = "ls-result-meta";
+  const dateEl = document.createElement("span");
+  dateEl.textContent = formatDate(file.modifiedAt);
+  meta.appendChild(dateEl);
+  const sizeEl = document.createElement("span");
+  sizeEl.textContent = formatSize(file.size);
+  meta.appendChild(sizeEl);
+  row.appendChild(meta);
+
+  // Reveal-in-file-manager button (Shift+Enter affordance)
+  const revealBtn = document.createElement("button");
+  revealBtn.type = "button";
+  revealBtn.className = "ls-reveal-btn";
+  revealBtn.title = "Reveal in file manager (Shift+Enter)";
+  revealBtn.setAttribute("aria-label", `Reveal ${file.name} in file manager`);
+  // Folder / reveal icon
+  revealBtn.innerHTML =
+    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"' +
+    ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>' +
+    "</svg>";
+  revealBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    void doReveal(index);
+  });
+  row.appendChild(revealBtn);
+
+  // Mouse: hover selects, click opens
+  row.addEventListener("mouseenter", () => {
+    activeIndex = index;
+    updateActiveRow();
+  });
+  row.addEventListener("click", () => void doOpen(index));
+
+  return row;
+}
+
+function updateActiveRow(): void {
+  if (!lsList) return;
+  lsList.querySelectorAll<HTMLElement>(".ls-result-row").forEach((row, i) => {
+    const active = i === activeIndex;
+    row.classList.toggle("active", active);
+    row.setAttribute("aria-selected", String(active));
+  });
+}
+
+function scrollActiveRowIntoView(): void {
+  if (!lsList || activeIndex < 0) return;
+  const rows = lsList.querySelectorAll<HTMLElement>(".ls-result-row");
+  rows[activeIndex]?.scrollIntoView({ block: "nearest" });
+}
+
+// ── File actions ──────────────────────────────────────────────────────────────
+
+async function doOpen(index: number): Promise<void> {
+  const file = currentResults[index];
+  if (!file) return;
+  const prefs = await getLocalSearchPrefs();
+  if (!prefs.port || !prefs.token) { showDisconnected(); return; }
+  try {
+    await companionOpenFile(prefs.port, prefs.token, file.path);
+    await recordRecentlyOpened(file.id);
+  } catch (err) {
+    await handleFileActionError(err);
+  }
+}
+
+async function doReveal(index: number): Promise<void> {
+  const file = currentResults[index];
+  if (!file) return;
+  const prefs = await getLocalSearchPrefs();
+  if (!prefs.port || !prefs.token) { showDisconnected(); return; }
+  try {
+    await companionOpenFile(prefs.port, prefs.token, file.path, true);
+    await recordRecentlyOpened(file.id);
+  } catch (err) {
+    await handleFileActionError(err);
+  }
+}
+
+async function handleFileActionError(err: unknown): Promise<void> {
+  if (err instanceof CompanionError && err.code === "unauthorized") {
+    await setLocalSearchPrefs({ token: undefined });
+    showUnauthorized();
+  } else {
+    showSnackbar({
+      message: `Could not open file: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+}
+
+/** Prepend `id` to recentlyOpened, dedupe, and cap at 30. */
+async function recordRecentlyOpened(id: string): Promise<void> {
+  const prefs = await getLocalSearchPrefs();
+  const existing = prefs.recentlyOpened ?? [];
+  const next = [id, ...existing.filter((x) => x !== id)].slice(0, 30);
+  await setLocalSearchPrefs({ recentlyOpened: next });
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+
+function formatSize(bytes: number): string {
+  if (bytes < 1_024) return `${bytes} B`;
+  if (bytes < 1_048_576) return `${(bytes / 1_024).toFixed(1)} KB`;
+  if (bytes < 1_073_741_824) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+  return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+}
+
+/**
+ * Format a Unix-epoch-seconds timestamp as a human-readable relative time.
+ * Falls back to locale date string for dates older than a week.
+ */
+function formatDate(ts: number): string {
+  const date = new Date(ts * 1_000); // companion sends seconds
+  const diffMin = Math.floor((Date.now() - date.getTime()) / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}

--- a/extension/src/newtab/local-search-results.ts
+++ b/extension/src/newtab/local-search-results.ts
@@ -167,7 +167,7 @@ function ensureContainer(): void {
   // ── Status area: loading / empty / error / disconnected ─────────────────
   lsStatus = document.createElement("div");
   lsStatus.id = "ls-status";
-  lsStatus.className = "hidden";
+  lsStatus.className = "ls-status hidden";
   lsStatus.setAttribute("role", "status");
   lsStatus.setAttribute("aria-live", "polite");
   lsContainer.appendChild(lsStatus);
@@ -182,7 +182,7 @@ function ensureContainer(): void {
   // ── Footer: total + indexer + degraded note ──────────────────────────────
   lsFooter = document.createElement("div");
   lsFooter.id = "ls-footer";
-  lsFooter.className = "hidden";
+  lsFooter.className = "ls-footer hidden";
   lsContainer.appendChild(lsFooter);
 
   app.appendChild(lsContainer);
@@ -328,17 +328,17 @@ async function runSearch(query: string): Promise<void> {
 
 function clearStatusAndList(): void {
   if (lsStatus) {
-    lsStatus.className = "hidden";
+    lsStatus.className = "ls-status hidden";
     lsStatus.replaceChildren();
   }
   lsList?.replaceChildren();
-  if (lsFooter) lsFooter.className = "hidden";
+  if (lsFooter) lsFooter.className = "ls-footer hidden";
 }
 
 function showLoading(): void {
   if (!lsStatus || !lsList || !lsFooter) return;
   lsList.replaceChildren();
-  lsFooter.className = "hidden";
+  lsFooter.className = "ls-footer hidden";
   lsStatus.className = "ls-status ls-status-loading";
   lsStatus.replaceChildren();
   const spinner = document.createElement("div");
@@ -353,7 +353,7 @@ function showLoading(): void {
 function showEmptyQueryState(): void {
   if (!lsStatus || !lsList || !lsFooter) return;
   lsList.replaceChildren();
-  lsFooter.className = "hidden";
+  lsFooter.className = "ls-footer hidden";
   lsStatus.className = "ls-status ls-status-empty";
   lsStatus.textContent = "Type a query to search your local files.";
 }
@@ -361,7 +361,7 @@ function showEmptyQueryState(): void {
 function showDisconnected(): void {
   if (!lsStatus || !lsList || !lsFooter) return;
   lsList.replaceChildren();
-  lsFooter.className = "hidden";
+  lsFooter.className = "ls-footer hidden";
   lsStatus.className = "ls-status ls-status-disconnected";
   lsStatus.replaceChildren();
   const msg = document.createElement("p");
@@ -373,7 +373,7 @@ function showDisconnected(): void {
 function showUnauthorized(): void {
   if (!lsStatus || !lsList || !lsFooter) return;
   lsList.replaceChildren();
-  lsFooter.className = "hidden";
+  lsFooter.className = "ls-footer hidden";
   lsStatus.className = "ls-status ls-status-disconnected";
   lsStatus.replaceChildren();
   const msg = document.createElement("p");
@@ -385,7 +385,7 @@ function showUnauthorized(): void {
 function showError(message: string, query: string): void {
   if (!lsStatus || !lsList || !lsFooter) return;
   lsList.replaceChildren();
-  lsFooter.className = "hidden";
+  lsFooter.className = "ls-footer hidden";
   lsStatus.className = "ls-status ls-status-error";
   lsStatus.replaceChildren();
   const msg = document.createElement("p");
@@ -431,11 +431,11 @@ function renderResults(
       ? `No files match “${query}”.`
       : "No files found.";
     lsList.replaceChildren();
-    lsFooter.className = "hidden";
+    lsFooter.className = "ls-footer hidden";
     return;
   }
 
-  lsStatus.className = "hidden";
+  lsStatus.className = "ls-status hidden";
   lsStatus.replaceChildren();
 
   lsList.replaceChildren();
@@ -603,11 +603,13 @@ function formatSize(bytes: number): string {
 }
 
 /**
- * Format a Unix-epoch-seconds timestamp as a human-readable relative time.
+ * Format an epoch-milliseconds timestamp as a human-readable relative time.
  * Falls back to locale date string for dates older than a week.
+ * Returns "—" when ts is 0 (unknown timestamp per protocol spec).
  */
-function formatDate(ts: number): string {
-  const date = new Date(ts * 1_000); // companion sends seconds
+export function formatDate(ts: number): string {
+  if (ts === 0) return "—";
+  const date = new Date(ts);
   const diffMin = Math.floor((Date.now() - date.getTime()) / 60_000);
   if (diffMin < 1) return "just now";
   if (diffMin < 60) return `${diffMin}m ago`;

--- a/extension/src/newtab/local-search-results.ts
+++ b/extension/src/newtab/local-search-results.ts
@@ -18,7 +18,7 @@ import {
   openFile as companionOpenFile,
   CompanionError,
 } from "../core/companion-client.js";
-import { renderFavicon } from "../ui/favicon.js";
+import { renderFileTypeIcon } from "./file-type-icon.js";
 import { showSnackbar } from "../ui/snackbar.js";
 import { mountToolbar } from "./local-search-toolbar.js";
 import type { ToolbarControls } from "./local-search-toolbar.js";
@@ -50,19 +50,21 @@ export function shouldInterceptLocalSearch(
 
 /**
  * Build a SearchRequest from current prefs + query + recently-opened ids.
- * page is always 0; pageSize is always 50.
+ * pageSize is always 50. page defaults to 0 (fresh search); pass a higher
+ * value when fetching additional pages for "Load more".
  */
 export function buildSearchRequest(
   prefs: LocalSearchPrefs,
   query: string,
   recentlyOpened: string[] = [],
+  page: number = 0,
 ): SearchRequest {
   return {
     query,
     queryMode: prefs.queryMode,
     sort: prefs.sort,
     filters: prefs.filters as Filters,
-    page: 0,
+    page,
     pageSize: 50,
     ...(recentlyOpened.length > 0 ? { history: recentlyOpened } : {}),
   };
@@ -86,6 +88,38 @@ export function navUp(index: number, total: number): number {
   return Math.max(index - 1, -1);
 }
 
+/**
+ * Returns true when there are more results to load (loaded < total).
+ * Used by the "Load more" button visibility logic and by unit tests.
+ */
+export function hasMore(loaded: number, total: number): boolean {
+  return loaded < total;
+}
+
+/**
+ * Return the next page number to fetch (current + 1).
+ * Page numbering is 0-based; page 0 is always fetched by the initial search.
+ */
+export function nextPage(current: number): number {
+  return current + 1;
+}
+
+/**
+ * Pure append reducer: concatenate two result arrays.
+ * Returns a new array without mutating either input.
+ */
+export function appendResults(prev: FileResult[], next: FileResult[]): FileResult[] {
+  return [...prev, ...next];
+}
+
+/**
+ * Pure reset reducer: returns an empty result array.
+ * Semantically clears the accumulated result state for a new search.
+ */
+export function resetResults(): FileResult[] {
+  return [];
+}
+
 // ── DOM state (module-level; reset on closeLocalSearch) ───────────────────────
 
 let isOpen = false;
@@ -102,11 +136,24 @@ let currentPing: PingResponse | null = null;
 /** Toolbar controls handle, set in ensureContainer (lazy, once). */
 let toolbarControls: ToolbarControls | null = null;
 
+// ── Pagination state ──────────────────────────────────────────────────────────
+/** Total result count from the last search response (may exceed loadedCount). */
+let currentTotal = 0;
+/** 0-based page index of the last fetched page. */
+let currentPage = 0;
+/** Query string used for the current search (needed by load-more). */
+let currentQuery = "";
+/** Indexer name from the last response, for the footer. */
+let currentIndexer = "";
+/** Degraded flag from the last response, for the footer. */
+let currentDegraded = false;
+
 // DOM refs — null until ensureContainer() runs
 let lsContainer: HTMLElement | null = null;
 let lsInput: HTMLInputElement | null = null;
 let lsStatus: HTMLElement | null = null;
 let lsList: HTMLElement | null = null;
+let lsLoadMore: HTMLElement | null = null;
 let lsFooter: HTMLElement | null = null;
 
 /** IDs of the normal newtab hero elements to hide while the results view is open. */
@@ -171,13 +218,15 @@ function ensureContainer(): void {
 
   lsContainer.appendChild(header);
 
-  // ── Toolbar: Drive-style query-mode, sort, and filter controls ──────────
+  // ── Toolbar: Drive-style query-mode, sort, filter controls + view toggle ─
   const toolbar = document.createElement("div");
   toolbar.id = "ls-toolbar";
   lsContainer.appendChild(toolbar);
-  toolbarControls = mountToolbar(toolbar, () => {
-    if (lsInput) void runSearch(lsInput.value);
-  });
+  toolbarControls = mountToolbar(
+    toolbar,
+    () => { if (lsInput) void runSearch(lsInput.value); },
+    rerenderCurrentResults,
+  );
 
   // ── Status area: loading / empty / error / disconnected ─────────────────
   lsStatus = document.createElement("div");
@@ -192,7 +241,20 @@ function ensureContainer(): void {
   lsList.id = "ls-list";
   lsList.setAttribute("role", "listbox");
   lsList.setAttribute("aria-label", "File search results");
+  lsList.dataset.view = "list"; // updated to "grid" on view-toggle
   lsContainer.appendChild(lsList);
+
+  // ── Load more affordance ─────────────────────────────────────────────────
+  lsLoadMore = document.createElement("div");
+  lsLoadMore.id = "ls-load-more";
+  lsLoadMore.className = "ls-load-more hidden";
+  const loadMoreBtn = document.createElement("button");
+  loadMoreBtn.type = "button";
+  loadMoreBtn.className = "ls-load-more-btn";
+  loadMoreBtn.textContent = "Load more";
+  loadMoreBtn.addEventListener("click", () => void loadMoreResults());
+  lsLoadMore.appendChild(loadMoreBtn);
+  lsContainer.appendChild(lsLoadMore);
 
   // ── Footer: total + indexer + degraded note ──────────────────────────────
   lsFooter = document.createElement("div");
@@ -273,6 +335,8 @@ export async function openLocalSearch(query: string): Promise<void> {
   // currentPing may be null on first open — toolbar shows safe defaults.
   const prefs = await getLocalSearchPrefs();
   if (!isOpen) return;
+  // Apply persisted view layout immediately so the first render uses the right layout.
+  if (lsList) lsList.dataset.view = prefs.view;
   toolbarControls?.sync(prefs, currentPing);
 
   // Fire discover in the background; update capability gating when it resolves.
@@ -311,6 +375,11 @@ export function closeLocalSearch(): void {
 
   currentResults = [];
   activeIndex = -1;
+  currentTotal = 0;
+  currentPage = 0;
+  currentQuery = "";
+  currentIndexer = "";
+  currentDegraded = false;
 
   // Restore normal newtab elements
   for (const id of HERO_IDS) {
@@ -325,6 +394,9 @@ export function closeLocalSearch(): void {
 
 async function runSearch(query: string): Promise<void> {
   const gen = ++searchGeneration;
+  // Reset pagination state for a fresh search
+  currentPage = 0;
+  currentQuery = query;
   showLoading();
 
   const prefs = await getLocalSearchPrefs();
@@ -340,7 +412,7 @@ async function runSearch(query: string): Promise<void> {
   try {
     const resp = await companionSearch(prefs.port, prefs.token, req);
     if (gen !== searchGeneration || !isOpen) return;
-    renderResults(resp.results, resp.total, resp.indexer, resp.degraded ?? false, query);
+    renderResults(resp.results, resp.total, resp.indexer, resp.degraded ?? false, query, false);
   } catch (err) {
     if (gen !== searchGeneration || !isOpen) return;
     if (err instanceof CompanionError && err.code === "unauthorized") {
@@ -363,12 +435,14 @@ function clearStatusAndList(): void {
     lsStatus.replaceChildren();
   }
   lsList?.replaceChildren();
+  if (lsLoadMore) lsLoadMore.className = "ls-load-more hidden";
   if (lsFooter) lsFooter.className = "ls-footer hidden";
 }
 
 function showLoading(): void {
   if (!lsStatus || !lsList || !lsFooter) return;
   lsList.replaceChildren();
+  if (lsLoadMore) lsLoadMore.className = "ls-load-more hidden";
   lsFooter.className = "ls-footer hidden";
   lsStatus.className = "ls-status ls-status-loading";
   lsStatus.replaceChildren();
@@ -444,37 +518,86 @@ function makeSettingsLink(text: string): HTMLParagraphElement {
 
 // ── Results rendering ─────────────────────────────────────────────────────────
 
+/**
+ * Render (or append) search results into the list.
+ *
+ * When `append` is false (fresh search): clears the list, resets
+ * currentResults, and rebuilds all rows from scratch.
+ *
+ * When `append` is true (load-more): concatenates onto currentResults and
+ * appends only the new rows to the existing DOM — keeps keyboard nav index
+ * across appended items because updateActiveRow() queries the full DOM.
+ */
 function renderResults(
   results: FileResult[],
   total: number,
   indexer: string,
   degraded: boolean,
   query: string,
+  append: boolean,
 ): void {
   if (!lsStatus || !lsList || !lsFooter) return;
 
-  currentResults = results;
-  activeIndex = -1;
+  if (!append) {
+    // Fresh search: reset accumulated state
+    currentResults = results;
+    activeIndex = -1;
+    currentTotal = total;
+    currentIndexer = indexer;
+    currentDegraded = degraded;
 
-  if (results.length === 0) {
-    lsStatus.className = "ls-status ls-status-empty";
-    lsStatus.textContent = query
-      ? `No files match “${query}”.`
-      : "No files found.";
+    if (results.length === 0) {
+      lsStatus.className = "ls-status ls-status-empty";
+      lsStatus.textContent = query
+        ? `No files match "${query}".`
+        : "No files found.";
+      lsList.replaceChildren();
+      if (lsLoadMore) lsLoadMore.className = "ls-load-more hidden";
+      lsFooter.className = "ls-footer hidden";
+      return;
+    }
+
+    lsStatus.className = "ls-status hidden";
+    lsStatus.replaceChildren();
+
     lsList.replaceChildren();
-    lsFooter.className = "ls-footer hidden";
-    return;
+    results.forEach((file, i) => {
+      lsList!.appendChild(buildResultRow(file, i));
+    });
+  } else {
+    // Load-more: append to existing state
+    const startIndex = currentResults.length;
+    currentResults = appendResults(currentResults, results);
+    currentTotal = total;
+    currentIndexer = indexer;
+    currentDegraded = degraded;
+
+    results.forEach((file, i) => {
+      lsList!.appendChild(buildResultRow(file, startIndex + i));
+    });
+
+    // Restore active highlight if it was set before load-more
+    updateActiveRow();
   }
 
-  lsStatus.className = "ls-status hidden";
-  lsStatus.replaceChildren();
-
-  lsList.replaceChildren();
-  results.forEach((file, i) => {
-    lsList!.appendChild(buildResultRow(file, i));
-  });
+  // Show/hide load-more button
+  if (lsLoadMore) {
+    lsLoadMore.className = hasMore(currentResults.length, currentTotal)
+      ? "ls-load-more"
+      : "ls-load-more hidden";
+    const btn = lsLoadMore.querySelector<HTMLButtonElement>(".ls-load-more-btn");
+    if (btn) {
+      btn.textContent = "Load more";
+      btn.disabled = false;
+    }
+  }
 
   // Footer: total count + indexer name + optional degraded badge
+  updateFooter(currentTotal, currentIndexer, currentDegraded);
+}
+
+function updateFooter(total: number, indexer: string, degraded: boolean): void {
+  if (!lsFooter) return;
   lsFooter.className = "ls-footer";
   lsFooter.replaceChildren();
   const countEl = document.createElement("span");
@@ -490,6 +613,90 @@ function renderResults(
   }
 }
 
+/**
+ * Re-render the currently loaded results in the current view layout,
+ * WITHOUT issuing a new network request.
+ *
+ * Called by the view toggle so switching list ⇄ grid is instant.
+ * Reads prefs.view from storage to pick up the just-written value.
+ */
+function rerenderCurrentResults(): void {
+  if (!lsList || currentResults.length === 0) return;
+
+  void getLocalSearchPrefs().then((prefs) => {
+    if (!lsList || !isOpen) return;
+    lsList.dataset.view = prefs.view;
+    lsList.replaceChildren();
+    currentResults.forEach((file, i) => {
+      lsList!.appendChild(buildResultRow(file, i));
+    });
+    // Restore active highlight
+    updateActiveRow();
+    // Keep load-more state consistent
+    if (lsLoadMore) {
+      lsLoadMore.className = hasMore(currentResults.length, currentTotal)
+        ? "ls-load-more"
+        : "ls-load-more hidden";
+    }
+  });
+}
+
+/**
+ * Fetch the next page of results (same query/prefs, incremented page number)
+ * and APPEND them to the current list.  Reuses the current searchGeneration so
+ * a concurrent new search will silently discard this response.
+ */
+async function loadMoreResults(): Promise<void> {
+  const gen = searchGeneration; // snapshot — don't increment
+  const page = nextPage(currentPage);
+
+  // Show loading state on the button
+  if (lsLoadMore) {
+    const btn = lsLoadMore.querySelector<HTMLButtonElement>(".ls-load-more-btn");
+    if (btn) {
+      btn.textContent = "Loading…";
+      btn.disabled = true;
+    }
+  }
+
+  const prefs = await getLocalSearchPrefs();
+  if (gen !== searchGeneration || !isOpen) return;
+
+  if (!prefs.port || !prefs.token) {
+    showDisconnected();
+    return;
+  }
+
+  const req = buildSearchRequest(prefs, currentQuery, prefs.recentlyOpened ?? [], page);
+
+  try {
+    const resp = await companionSearch(prefs.port, prefs.token, req);
+    if (gen !== searchGeneration || !isOpen) return;
+    currentPage = page;
+    renderResults(resp.results, resp.total, resp.indexer, resp.degraded ?? false, currentQuery, true);
+  } catch (err) {
+    if (gen !== searchGeneration || !isOpen) return;
+    // Reset button so the user can retry
+    if (lsLoadMore) {
+      const btn = lsLoadMore.querySelector<HTMLButtonElement>(".ls-load-more-btn");
+      if (btn) {
+        btn.textContent = "Load more";
+        btn.disabled = false;
+      }
+    }
+    if (err instanceof CompanionError && err.code === "unauthorized") {
+      await setLocalSearchPrefs({ token: undefined });
+      showUnauthorized();
+    } else if (err instanceof CompanionError && err.code === "network") {
+      showDisconnected();
+    } else {
+      showSnackbar({
+        message: `Load more failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+}
+
 function buildResultRow(file: FileResult, index: number): HTMLElement {
   const row = document.createElement("div");
   row.className = "ls-result-row";
@@ -497,14 +704,12 @@ function buildResultRow(file: FileResult, index: number): HTMLElement {
   row.setAttribute("aria-selected", "false");
   row.dataset.index = String(index);
 
-  // File-type icon — monogram keyed on ext/type for now; rich per-type icons come in 3b
+  // Per-type icon: tinted SVG, used in both list and grid views.
+  // Size is controlled by CSS (.ls-result-icon width/height) — the SVG
+  // inside scales to 60% of the container via .ls-type-icon-svg.
   const iconEl = document.createElement("div");
   iconEl.className = "ls-result-icon";
-  renderFavicon(iconEl, {
-    // Use the extension (e.g. ".pdf") or first letter of type as the monogram seed
-    trigger: file.ext ? `.${file.ext}` : file.type.charAt(0),
-    size: 20,
-  });
+  renderFileTypeIcon(iconEl, file.type, file.ext);
   row.appendChild(iconEl);
 
   // Primary name + secondary path

--- a/extension/src/newtab/local-search-results.ts
+++ b/extension/src/newtab/local-search-results.ts
@@ -8,13 +8,20 @@
  */
 
 import type { FastTravelConfig } from "../core/types.js";
-import type { SearchRequest, Filters, FileResult } from "../core/companion-types.js";
+import type { SearchRequest, Filters, FileResult, PingResponse } from "../core/companion-types.js";
 import type { LocalSearchPrefs } from "../core/local-search-store.js";
 import { getLocalSearchPrefs, setLocalSearchPrefs } from "../core/local-search-store.js";
 import { buildTriggerMap } from "../core/parser.js";
-import { search as companionSearch, openFile as companionOpenFile, CompanionError } from "../core/companion-client.js";
+import {
+  discover,
+  search as companionSearch,
+  openFile as companionOpenFile,
+  CompanionError,
+} from "../core/companion-client.js";
 import { renderFavicon } from "../ui/favicon.js";
 import { showSnackbar } from "../ui/snackbar.js";
+import { mountToolbar } from "./local-search-toolbar.js";
+import type { ToolbarControls } from "./local-search-toolbar.js";
 
 // ── Pure functions (exported + unit-tested) ───────────────────────────────────
 
@@ -89,6 +96,12 @@ let currentResults: FileResult[] = [];
 let searchGeneration = 0;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+/** Last-known ping response; null until discover() resolves on open. */
+let currentPing: PingResponse | null = null;
+
+/** Toolbar controls handle, set in ensureContainer (lazy, once). */
+let toolbarControls: ToolbarControls | null = null;
+
 // DOM refs — null until ensureContainer() runs
 let lsContainer: HTMLElement | null = null;
 let lsInput: HTMLInputElement | null = null;
@@ -158,11 +171,13 @@ function ensureContainer(): void {
 
   lsContainer.appendChild(header);
 
-  // ── Toolbar placeholder — 3b drops the Drive-style toolbar here ─────────
+  // ── Toolbar: Drive-style query-mode, sort, and filter controls ──────────
   const toolbar = document.createElement("div");
   toolbar.id = "ls-toolbar";
-  toolbar.setAttribute("aria-hidden", "true");
   lsContainer.appendChild(toolbar);
+  toolbarControls = mountToolbar(toolbar, () => {
+    if (lsInput) void runSearch(lsInput.value);
+  });
 
   // ── Status area: loading / empty / error / disconnected ─────────────────
   lsStatus = document.createElement("div");
@@ -254,6 +269,21 @@ export async function openLocalSearch(query: string): Promise<void> {
   lsInput.focus();
   lsInput.select();
 
+  // Sync toolbar to current prefs (reflects persisted selections on open).
+  // currentPing may be null on first open — toolbar shows safe defaults.
+  const prefs = await getLocalSearchPrefs();
+  if (!isOpen) return;
+  toolbarControls?.sync(prefs, currentPing);
+
+  // Fire discover in the background; update capability gating when it resolves.
+  void discover().then((result) => {
+    if (!isOpen) return;
+    currentPing = result?.ping ?? null;
+    void getLocalSearchPrefs().then((p) => {
+      if (isOpen) toolbarControls?.sync(p, currentPing);
+    });
+  });
+
   if (query) {
     await runSearch(query);
   } else {
@@ -268,6 +298,7 @@ export async function openLocalSearch(query: string): Promise<void> {
 export function closeLocalSearch(): void {
   if (!isOpen) return;
   isOpen = false;
+  currentPing = null;
   searchGeneration++;
 
   if (debounceTimer !== null) {

--- a/extension/src/newtab/local-search-results.ts
+++ b/extension/src/newtab/local-search-results.ts
@@ -67,6 +67,8 @@ export function buildSearchRequest(
     page,
     pageSize: 50,
     ...(recentlyOpened.length > 0 ? { history: recentlyOpened } : {}),
+    caseSensitive: prefs.caseSensitive,
+    exactPhrase: prefs.exactPhrase,
   };
 }
 
@@ -493,9 +495,15 @@ function showError(message: string, query: string): void {
   lsFooter.className = "ls-footer hidden";
   lsStatus.className = "ls-status ls-status-error";
   lsStatus.replaceChildren();
-  const msg = document.createElement("p");
-  msg.textContent = `Search error: ${message}`;
-  lsStatus.appendChild(msg);
+  // Bug A: show a friendly heading plus the companion's exact error message
+  const heading = document.createElement("p");
+  heading.className = "ls-status-heading";
+  heading.textContent = "Couldn't run that search";
+  lsStatus.appendChild(heading);
+  const detail = document.createElement("p");
+  detail.className = "ls-status-detail";
+  detail.textContent = message;
+  lsStatus.appendChild(detail);
   const retryBtn = document.createElement("button");
   retryBtn.type = "button";
   retryBtn.className = "ls-retry-btn";
@@ -602,15 +610,14 @@ function updateFooter(total: number, indexer: string, degraded: boolean): void {
   lsFooter.replaceChildren();
   const countEl = document.createElement("span");
   countEl.className = "ls-footer-count";
-  countEl.textContent = `${total.toLocaleString()} result${total !== 1 ? "s" : ""} · ${indexer}`;
-  lsFooter.appendChild(countEl);
   if (degraded) {
-    const badge = document.createElement("span");
-    badge.className = "ls-degraded-badge";
-    badge.title = "Index may be incomplete — results are best-effort";
-    badge.textContent = "best-effort";
-    lsFooter.appendChild(badge);
+    // Bug C: show lower-bound count when results are capped
+    countEl.textContent = `${total.toLocaleString()}+ results · ${indexer} · best-effort`;
+    countEl.title = "Index may be incomplete — count is a lower bound";
+  } else {
+    countEl.textContent = `${total.toLocaleString()} result${total !== 1 ? "s" : ""} · ${indexer}`;
   }
+  lsFooter.appendChild(countEl);
 }
 
 /**

--- a/extension/src/newtab/local-search-toolbar.ts
+++ b/extension/src/newtab/local-search-toolbar.ts
@@ -90,6 +90,27 @@ export interface ToolbarControls {
   sync(prefs: LocalSearchPrefs, ping: PingResponse | null): void;
 }
 
+// View toggle icon markup
+const ICON_LIST =
+  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"' +
+  ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<line x1="8" y1="6" x2="21" y2="6"/>' +
+  '<line x1="8" y1="12" x2="21" y2="12"/>' +
+  '<line x1="8" y1="18" x2="21" y2="18"/>' +
+  '<line x1="3" y1="6" x2="3.01" y2="6"/>' +
+  '<line x1="3" y1="12" x2="3.01" y2="12"/>' +
+  '<line x1="3" y1="18" x2="3.01" y2="18"/>' +
+  "</svg>";
+
+const ICON_GRID =
+  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"' +
+  ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<rect x="3" y="3" width="7" height="7"/>' +
+  '<rect x="14" y="3" width="7" height="7"/>' +
+  '<rect x="14" y="14" width="7" height="7"/>' +
+  '<rect x="3" y="14" width="7" height="7"/>' +
+  "</svg>";
+
 // ── DOM helper ───────────────────────────────────────────────────────────────
 
 function mkEl<K extends keyof HTMLElementTagNameMap>(
@@ -118,14 +139,18 @@ function mkEl<K extends keyof HTMLElementTagNameMap>(
  *
  * @param container  The #ls-toolbar HTMLElement to populate.
  * @param onReSearch Callback to re-trigger the current search after prefs change.
+ * @param onReRender Callback to re-render current results without a new search
+ *                   (used for view-toggle: same data, different layout).
  */
 export function mountToolbar(
   container: HTMLElement,
   onReSearch: () => void,
+  onReRender?: () => void,
 ): ToolbarControls {
   // ── Closure state (kept in sync by the returned sync function) ─────────
   let _types: string[] = [];
   let _sortDir: "asc" | "desc" = "desc";
+  let _view: "list" | "grid" = "list";
 
   // ── Row 1: query-mode segmented control + sort ──────────────────────────
 
@@ -214,6 +239,57 @@ export function mountToolbar(
   sortWrap.appendChild(sortDirBtn);
 
   mainRow.appendChild(sortWrap);
+
+  // -- View toggle (List / Grid) --
+
+  const viewSeg = mkEl("div", {
+    class: "ls-view-seg",
+    role: "group",
+    "aria-label": "View layout",
+  });
+
+  const listBtn = mkEl("button", {
+    type: "button",
+    class: "ls-view-btn active",
+    "data-view": "list",
+    title: "List view",
+    "aria-label": "List view",
+  });
+  listBtn.innerHTML = ICON_LIST;
+
+  const gridBtn = mkEl("button", {
+    type: "button",
+    class: "ls-view-btn",
+    "data-view": "grid",
+    title: "Grid view",
+    "aria-label": "Grid view",
+  });
+  gridBtn.innerHTML = ICON_GRID;
+
+  listBtn.addEventListener("click", () => {
+    if (_view === "list") return;
+    _view = "list";
+    listBtn.classList.add("active");
+    gridBtn.classList.remove("active");
+    void setLocalSearchPrefs({ view: "list" }).then(() => {
+      (onReRender ?? onReSearch)();
+    });
+  });
+
+  gridBtn.addEventListener("click", () => {
+    if (_view === "grid") return;
+    _view = "grid";
+    gridBtn.classList.add("active");
+    listBtn.classList.remove("active");
+    void setLocalSearchPrefs({ view: "grid" }).then(() => {
+      (onReRender ?? onReSearch)();
+    });
+  });
+
+  viewSeg.appendChild(listBtn);
+  viewSeg.appendChild(gridBtn);
+  mainRow.appendChild(viewSeg);
+
   container.appendChild(mainRow);
 
   // ── Row 2: type chips, date preset, path input, toggles, clear ─────────
@@ -407,6 +483,11 @@ export function mountToolbar(
     const showContent = ping !== null && contentAvailable(ping);
     contentLabel.classList.toggle("hidden", !showContent);
     contentCheck.checked = prefs.filters.content === true;
+
+    // View toggle
+    _view = prefs.view;
+    listBtn.classList.toggle("active", _view === "list");
+    gridBtn.classList.toggle("active", _view === "grid");
   }
 
   return { sync };

--- a/extension/src/newtab/local-search-toolbar.ts
+++ b/extension/src/newtab/local-search-toolbar.ts
@@ -131,6 +131,22 @@ function mkEl<K extends keyof HTMLElementTagNameMap>(
   return e;
 }
 
+// ── Sort field definitions (exported for unit tests) ─────────────────────────
+
+/**
+ * Available sort fields in the toolbar dropdown.
+ * "created" is intentionally absent — it was non-functional and has been
+ * removed (Bug B). Any stored pref with field "created" is treated as
+ * "relevance" in sync().
+ */
+export const SORT_FIELDS: Array<{
+  value: "relevance" | "modified";
+  label: string;
+}> = [
+  { value: "relevance", label: "Relevance" },
+  { value: "modified", label: "Date modified" },
+];
+
 // ── Toolbar mount ─────────────────────────────────────────────────────────────
 
 /**
@@ -151,6 +167,20 @@ export function mountToolbar(
   let _types: string[] = [];
   let _sortDir: "asc" | "desc" = "desc";
   let _view: "list" | "grid" = "list";
+  let _queryMode: "simple" | "wildcard" | "regex" = "simple";
+
+  // Forward-declared toggle elements (assigned in filterRow build below)
+  let exactPhraseCheck: HTMLInputElement | null = null;
+  let exactPhraseLabel: HTMLElement | null = null;
+
+  /** Update the exact-phrase toggle's disabled state based on current _queryMode. */
+  function syncExactPhraseEnabled(): void {
+    if (!exactPhraseCheck || !exactPhraseLabel) return;
+    const dis = _queryMode === "regex";
+    exactPhraseCheck.disabled = dis;
+    exactPhraseLabel.title = dis ? "Regex ignores phrase matching" : "";
+    exactPhraseLabel.classList.toggle("ls-filter-toggle-disabled", dis);
+  }
 
   // ── Row 1: query-mode segmented control + sort ──────────────────────────
 
@@ -182,6 +212,8 @@ export function mountToolbar(
       btn.title = "Not supported by your indexer";
     }
     btn.addEventListener("click", () => {
+      _queryMode = value;
+      syncExactPhraseEnabled();
       void setLocalSearchPrefs({ queryMode: value }).then(onReSearch);
     });
     modeSeg.appendChild(btn);
@@ -198,20 +230,12 @@ export function mountToolbar(
     "aria-label": "Sort by",
   }) as HTMLSelectElement;
 
-  const SORT_FIELD_DEFS: Array<{
-    value: "relevance" | "created" | "modified";
-    label: string;
-  }> = [
-    { value: "relevance", label: "Relevance" },
-    { value: "created", label: "Date created" },
-    { value: "modified", label: "Date modified" },
-  ];
-  for (const { value, label } of SORT_FIELD_DEFS) {
+  for (const { value, label } of SORT_FIELDS) {
     sortFieldSel.appendChild(mkEl("option", { value }, label));
   }
   sortFieldSel.addEventListener("change", () => {
     void setLocalSearchPrefs({
-      sort: { field: sortFieldSel.value as "relevance" | "created" | "modified" },
+      sort: { field: sortFieldSel.value as "relevance" | "modified" },
     }).then(onReSearch);
   });
   sortWrap.appendChild(sortFieldSel);
@@ -370,6 +394,41 @@ export function mountToolbar(
   });
   filterRow.appendChild(pathInput);
 
+  // -- Exact phrase toggle (disabled in Regex mode) --
+
+  exactPhraseCheck = mkEl("input", {
+    type: "checkbox",
+    id: "ls-exact-phrase",
+  }) as HTMLInputElement;
+  exactPhraseCheck.addEventListener("change", () => {
+    void setLocalSearchPrefs({ exactPhrase: (exactPhraseCheck as HTMLInputElement).checked })
+      .then(onReSearch);
+  });
+  exactPhraseLabel = mkEl("label", {
+    class: "ls-filter-toggle",
+    for: "ls-exact-phrase",
+  });
+  exactPhraseLabel.appendChild(exactPhraseCheck);
+  exactPhraseLabel.appendChild(document.createTextNode(" Exact phrase"));
+  filterRow.appendChild(exactPhraseLabel);
+
+  // -- Match case toggle --
+
+  const matchCaseCheck = mkEl("input", {
+    type: "checkbox",
+    id: "ls-match-case",
+  }) as HTMLInputElement;
+  matchCaseCheck.addEventListener("change", () => {
+    void setLocalSearchPrefs({ caseSensitive: matchCaseCheck.checked }).then(onReSearch);
+  });
+  const matchCaseLabel = mkEl("label", {
+    class: "ls-filter-toggle",
+    for: "ls-match-case",
+  });
+  matchCaseLabel.appendChild(matchCaseCheck);
+  matchCaseLabel.appendChild(document.createTextNode(" Match case"));
+  filterRow.appendChild(matchCaseLabel);
+
   // -- Title-only checkbox --
 
   const titleCheck = mkEl("input", {
@@ -445,6 +504,7 @@ export function mountToolbar(
     const now = Date.now();
 
     // Query mode
+    _queryMode = prefs.queryMode;
     for (const { value } of MODE_DEFS) {
       const btn = modeBtns[value];
       if (!btn) continue;
@@ -456,8 +516,9 @@ export function mountToolbar(
       }
     }
 
-    // Sort field
-    sortFieldSel.value = prefs.sort.field;
+    // Sort field — treat legacy "created" value as "relevance" (Bug B fallback)
+    const sortField = prefs.sort.field === "created" ? "relevance" : prefs.sort.field;
+    sortFieldSel.value = sortField;
 
     // Sort direction
     _sortDir = prefs.sort.dir;
@@ -475,6 +536,11 @@ export function mountToolbar(
 
     // Path prefix
     pathInput.value = prefs.filters.pathPrefix ?? "";
+
+    // Exact phrase + match case toggles
+    if (exactPhraseCheck) exactPhraseCheck.checked = prefs.exactPhrase;
+    matchCaseCheck.checked = prefs.caseSensitive;
+    syncExactPhraseEnabled();
 
     // Title only
     titleCheck.checked = prefs.filters.titleOnly === true;

--- a/extension/src/newtab/local-search-toolbar.ts
+++ b/extension/src/newtab/local-search-toolbar.ts
@@ -363,9 +363,6 @@ export function mountToolbar(
 
   container.appendChild(filterRow);
 
-  // Toolbar is now populated — remove the placeholder aria-hidden.
-  container.removeAttribute("aria-hidden");
-
   // ── sync function ─────────────────────────────────────────────────────────
 
   function sync(prefs: LocalSearchPrefs, ping: PingResponse | null): void {

--- a/extension/src/newtab/local-search-toolbar.ts
+++ b/extension/src/newtab/local-search-toolbar.ts
@@ -1,0 +1,416 @@
+/**
+ * Drive-style results toolbar for the local-search view.
+ *
+ * Pure, unit-tested exports:
+ *   datePresetToRange — converts a named date preset to an epoch-ms range
+ *   toggleType        — adds or removes a FileType string in the active set
+ *
+ * DOM export:
+ *   mountToolbar — populates the #ls-toolbar element and returns a
+ *                  ToolbarControls handle so the parent can sync it on open.
+ */
+
+import type { PingResponse, FileType } from "../core/companion-types.js";
+import type { LocalSearchPrefs } from "../core/local-search-store.js";
+import { setLocalSearchPrefs } from "../core/local-search-store.js";
+import { regexAvailable, contentAvailable } from "../core/local-search-capabilities.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type DatePreset = "any" | "week" | "month" | "year";
+
+// ── Pure helpers (exported + unit-tested) ─────────────────────────────────────
+
+/**
+ * Convert a named date preset to an epoch-ms open-ended range, or undefined
+ * for "any" (no filter). `now` must be an epoch-millisecond timestamp
+ * (e.g. Date.now()).
+ */
+export function datePresetToRange(
+  preset: DatePreset,
+  now: number,
+): { from: number } | undefined {
+  if (preset === "any") return undefined;
+  const DAY_MS = 86_400_000;
+  if (preset === "week") return { from: now - 7 * DAY_MS };
+  if (preset === "month") return { from: now - 30 * DAY_MS };
+  return { from: now - 365 * DAY_MS }; // "year"
+}
+
+/**
+ * Toggle a file-type string in the active types array.
+ * If `type` is already present it is removed; otherwise it is appended.
+ * Returns a new array — does not mutate the input.
+ * An empty result means "all types" (no filter).
+ */
+export function toggleType(types: string[] | undefined, type: string): string[] {
+  const current = types ?? [];
+  if (current.includes(type)) {
+    return current.filter((t) => t !== type);
+  }
+  return [...current, type];
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Infer which date preset a stored modifiedRange corresponds to.
+ * Uses generous time windows (±1 week extra) to survive session gaps.
+ * Returns "any" when no range is set or the age falls outside all bands.
+ */
+function inferDatePreset(
+  modifiedRange: { from?: number; to?: number } | undefined,
+  now: number,
+): DatePreset {
+  if (!modifiedRange?.from) return "any";
+  const ageMs = now - modifiedRange.from;
+  const DAY = 86_400_000;
+  if (ageMs <= 8 * DAY) return "week";
+  if (ageMs <= 35 * DAY) return "month";
+  return "year";
+}
+
+// ── File-type chip definitions ───────────────────────────────────────────────
+
+const FILE_TYPES: Array<{ value: FileType; label: string }> = [
+  { value: "document", label: "Doc" },
+  { value: "image", label: "Image" },
+  { value: "video", label: "Video" },
+  { value: "audio", label: "Audio" },
+  { value: "archive", label: "Archive" },
+  { value: "code", label: "Code" },
+  { value: "folder", label: "Folder" },
+  { value: "other", label: "Other" },
+];
+
+// ── Toolbar controls interface ───────────────────────────────────────────────
+
+export interface ToolbarControls {
+  /** Sync all control states to the given prefs + capability ping. */
+  sync(prefs: LocalSearchPrefs, ping: PingResponse | null): void;
+}
+
+// ── DOM helper ───────────────────────────────────────────────────────────────
+
+function mkEl<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  attrs?: Record<string, string> | null,
+  ...children: (string | Node)[]
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag);
+  if (attrs) {
+    for (const [k, v] of Object.entries(attrs)) {
+      e.setAttribute(k, v);
+    }
+  }
+  for (const c of children) {
+    if (typeof c === "string") e.appendChild(document.createTextNode(c));
+    else e.appendChild(c);
+  }
+  return e;
+}
+
+// ── Toolbar mount ─────────────────────────────────────────────────────────────
+
+/**
+ * Populate `container` (the #ls-toolbar element) with the Drive-style toolbar
+ * controls. Returns a ToolbarControls handle to sync control state on open.
+ *
+ * @param container  The #ls-toolbar HTMLElement to populate.
+ * @param onReSearch Callback to re-trigger the current search after prefs change.
+ */
+export function mountToolbar(
+  container: HTMLElement,
+  onReSearch: () => void,
+): ToolbarControls {
+  // ── Closure state (kept in sync by the returned sync function) ─────────
+  let _types: string[] = [];
+  let _sortDir: "asc" | "desc" = "desc";
+
+  // ── Row 1: query-mode segmented control + sort ──────────────────────────
+
+  const mainRow = mkEl("div", { class: "ls-toolbar-row ls-toolbar-main" });
+
+  // -- Query-mode segmented control --
+
+  const modeSeg = mkEl("div", {
+    class: "ls-mode-seg",
+    role: "group",
+    "aria-label": "Query mode",
+  });
+
+  const MODE_DEFS: Array<{ value: "simple" | "wildcard" | "regex"; label: string }> = [
+    { value: "simple", label: "Simple" },
+    { value: "wildcard", label: "Wildcard" },
+    { value: "regex", label: "Regex" },
+  ];
+  const modeBtns: Partial<Record<string, HTMLButtonElement>> = {};
+
+  for (const { value, label } of MODE_DEFS) {
+    const btn = mkEl("button", {
+      type: "button",
+      class: "ls-mode-btn",
+      "data-mode": value,
+    }, label);
+    if (value === "regex") {
+      btn.disabled = true;
+      btn.title = "Not supported by your indexer";
+    }
+    btn.addEventListener("click", () => {
+      void setLocalSearchPrefs({ queryMode: value }).then(onReSearch);
+    });
+    modeSeg.appendChild(btn);
+    modeBtns[value] = btn;
+  }
+  mainRow.appendChild(modeSeg);
+
+  // -- Sort: field dropdown + direction toggle --
+
+  const sortWrap = mkEl("div", { class: "ls-sort" });
+
+  const sortFieldSel = mkEl("select", {
+    class: "ls-sort-field",
+    "aria-label": "Sort by",
+  }) as HTMLSelectElement;
+
+  const SORT_FIELD_DEFS: Array<{
+    value: "relevance" | "created" | "modified";
+    label: string;
+  }> = [
+    { value: "relevance", label: "Relevance" },
+    { value: "created", label: "Date created" },
+    { value: "modified", label: "Date modified" },
+  ];
+  for (const { value, label } of SORT_FIELD_DEFS) {
+    sortFieldSel.appendChild(mkEl("option", { value }, label));
+  }
+  sortFieldSel.addEventListener("change", () => {
+    void setLocalSearchPrefs({
+      sort: { field: sortFieldSel.value as "relevance" | "created" | "modified" },
+    }).then(onReSearch);
+  });
+  sortWrap.appendChild(sortFieldSel);
+
+  // Direction toggle button (↓ desc / ↑ asc)
+  const sortDirBtn = mkEl("button", {
+    type: "button",
+    class: "ls-sort-dir",
+    "aria-label": "Toggle sort direction",
+    title: "Sort descending",
+  });
+  // Down-arrow SVG
+  sortDirBtn.innerHTML =
+    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"' +
+    ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M12 5v14"/><path d="m19 12-7 7-7-7"/>' +
+    "</svg>";
+  sortDirBtn.addEventListener("click", () => {
+    const next: "asc" | "desc" = _sortDir === "desc" ? "asc" : "desc";
+    _sortDir = next;
+    sortDirBtn.title = next === "asc" ? "Sort ascending" : "Sort descending";
+    sortDirBtn.classList.toggle("asc", next === "asc");
+    void setLocalSearchPrefs({ sort: { dir: next } }).then(onReSearch);
+  });
+  sortWrap.appendChild(sortDirBtn);
+
+  mainRow.appendChild(sortWrap);
+  container.appendChild(mainRow);
+
+  // ── Row 2: type chips, date preset, path input, toggles, clear ─────────
+
+  const filterRow = mkEl("div", { class: "ls-toolbar-row ls-filter-row" });
+
+  // -- Type chips --
+
+  const chipsWrap = mkEl("div", { class: "ls-type-chips" });
+  const chipBtns: Partial<Record<FileType, HTMLButtonElement>> = {};
+
+  for (const { value, label } of FILE_TYPES) {
+    const chip = mkEl("button", {
+      type: "button",
+      class: "ls-type-chip",
+      "data-type": value,
+      title: value.charAt(0).toUpperCase() + value.slice(1),
+    }, label);
+    chip.addEventListener("click", () => {
+      const newTypes = toggleType(_types, value);
+      _types = newTypes;
+      // Optimistic UI update
+      for (const { value: v } of FILE_TYPES) {
+        chipBtns[v]?.classList.toggle("active", newTypes.includes(v));
+      }
+      void setLocalSearchPrefs({
+        filters: { types: newTypes.length > 0 ? newTypes : undefined },
+      }).then(onReSearch);
+    });
+    chipsWrap.appendChild(chip);
+    chipBtns[value] = chip;
+  }
+  filterRow.appendChild(chipsWrap);
+
+  // -- Date preset select --
+
+  const dateSel = mkEl("select", {
+    class: "ls-date-sel",
+    "aria-label": "Date modified filter",
+  }) as HTMLSelectElement;
+
+  const DATE_OPTS: Array<{ value: DatePreset; label: string }> = [
+    { value: "any", label: "Any time" },
+    { value: "week", label: "Past week" },
+    { value: "month", label: "Past month" },
+    { value: "year", label: "Past year" },
+  ];
+  for (const { value, label } of DATE_OPTS) {
+    dateSel.appendChild(mkEl("option", { value }, label));
+  }
+  dateSel.addEventListener("change", () => {
+    const preset = dateSel.value as DatePreset;
+    const range = datePresetToRange(preset, Date.now());
+    void setLocalSearchPrefs({ filters: { modifiedRange: range } }).then(onReSearch);
+  });
+  filterRow.appendChild(dateSel);
+
+  // -- Path prefix input (debounced 400 ms) --
+
+  const pathInput = mkEl("input", {
+    type: "text",
+    class: "ls-path-input",
+    placeholder: "Path…",
+    "aria-label": "Filter by path prefix",
+  }) as HTMLInputElement;
+
+  let pathTimer: ReturnType<typeof setTimeout> | null = null;
+  pathInput.addEventListener("input", () => {
+    if (pathTimer !== null) {
+      clearTimeout(pathTimer);
+      pathTimer = null;
+    }
+    pathTimer = setTimeout(() => {
+      pathTimer = null;
+      const v = pathInput.value.trim();
+      void setLocalSearchPrefs({ filters: { pathPrefix: v || undefined } }).then(onReSearch);
+    }, 400);
+  });
+  filterRow.appendChild(pathInput);
+
+  // -- Title-only checkbox --
+
+  const titleCheck = mkEl("input", {
+    type: "checkbox",
+    id: "ls-title-only",
+  }) as HTMLInputElement;
+  titleCheck.addEventListener("change", () => {
+    void setLocalSearchPrefs({
+      filters: { titleOnly: titleCheck.checked || undefined },
+    }).then(onReSearch);
+  });
+  const titleLabel = mkEl("label", {
+    class: "ls-filter-toggle",
+    for: "ls-title-only",
+  });
+  titleLabel.appendChild(titleCheck);
+  titleLabel.appendChild(document.createTextNode(" Title only"));
+  filterRow.appendChild(titleLabel);
+
+  // -- Content search checkbox (capability-gated; hidden until ping confirms) --
+
+  const contentCheck = mkEl("input", {
+    type: "checkbox",
+    id: "ls-content-search",
+  }) as HTMLInputElement;
+  contentCheck.addEventListener("change", () => {
+    void setLocalSearchPrefs({
+      filters: { content: contentCheck.checked || undefined },
+    }).then(onReSearch);
+  });
+  const contentLabel = mkEl("label", {
+    class: "ls-filter-toggle ls-content-toggle hidden",
+    for: "ls-content-search",
+  });
+  contentLabel.appendChild(contentCheck);
+  contentLabel.appendChild(document.createTextNode(" Contents"));
+  filterRow.appendChild(contentLabel);
+
+  // -- Clear filters button --
+
+  const clearBtn = mkEl("button", { type: "button", class: "ls-clear-btn" }, "Clear");
+  clearBtn.addEventListener("click", () => {
+    void setLocalSearchPrefs({
+      filters: {
+        types: undefined,
+        titleOnly: undefined,
+        content: undefined,
+        pathPrefix: undefined,
+        modifiedRange: undefined,
+        createdRange: undefined,
+      },
+    }).then(() => {
+      // Reset UI immediately alongside prefs flush
+      _types = [];
+      _sortDir = _sortDir; // unchanged by clear
+      for (const { value } of FILE_TYPES) {
+        chipBtns[value]?.classList.remove("active");
+      }
+      dateSel.value = "any";
+      pathInput.value = "";
+      titleCheck.checked = false;
+      contentCheck.checked = false;
+      onReSearch();
+    });
+  });
+  filterRow.appendChild(clearBtn);
+
+  container.appendChild(filterRow);
+
+  // Toolbar is now populated — remove the placeholder aria-hidden.
+  container.removeAttribute("aria-hidden");
+
+  // ── sync function ─────────────────────────────────────────────────────────
+
+  function sync(prefs: LocalSearchPrefs, ping: PingResponse | null): void {
+    const now = Date.now();
+
+    // Query mode
+    for (const { value } of MODE_DEFS) {
+      const btn = modeBtns[value];
+      if (!btn) continue;
+      btn.classList.toggle("active", prefs.queryMode === value);
+      if (value === "regex") {
+        const ok = ping !== null && regexAvailable(ping);
+        btn.disabled = !ok;
+        btn.title = ok ? "" : "Not supported by your indexer";
+      }
+    }
+
+    // Sort field
+    sortFieldSel.value = prefs.sort.field;
+
+    // Sort direction
+    _sortDir = prefs.sort.dir;
+    sortDirBtn.title = _sortDir === "asc" ? "Sort ascending" : "Sort descending";
+    sortDirBtn.classList.toggle("asc", _sortDir === "asc");
+
+    // Type chips
+    _types = prefs.filters.types ?? [];
+    for (const { value } of FILE_TYPES) {
+      chipBtns[value]?.classList.toggle("active", _types.includes(value));
+    }
+
+    // Date preset
+    dateSel.value = inferDatePreset(prefs.filters.modifiedRange, now);
+
+    // Path prefix
+    pathInput.value = prefs.filters.pathPrefix ?? "";
+
+    // Title only
+    titleCheck.checked = prefs.filters.titleOnly === true;
+
+    // Content toggle: visibility gated by capability, state from prefs
+    const showContent = ping !== null && contentAvailable(ping);
+    contentLabel.classList.toggle("hidden", !showContent);
+    contentCheck.checked = prefs.filters.content === true;
+  }
+
+  return { sync };
+}

--- a/extension/src/newtab/newtab.css
+++ b/extension/src/newtab/newtab.css
@@ -975,6 +975,46 @@ body:hover #settings-link {
   background: var(--surface-hover);
 }
 
+/* View toggle (List / Grid) */
+.ls-view-seg {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.ls-view-btn {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--duration-short) var(--ease),
+              color var(--duration-short) var(--ease);
+  flex-shrink: 0;
+}
+
+.ls-view-btn:last-child {
+  border-right: none;
+}
+
+.ls-view-btn.active {
+  background: var(--primary);
+  color: var(--primary-contrast);
+}
+
+.ls-view-btn:hover:not(.active) {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
 @media (max-width: 560px) {
   .ls-toolbar-main {
     flex-wrap: wrap;
@@ -1100,10 +1140,11 @@ body:hover #settings-link {
 }
 
 .ls-result-icon {
-  width: 20px;
-  height: 20px;
+  /* Increased from 20px to give per-type SVG icons enough breathing room. */
+  width: 32px;
+  height: 32px;
   flex-shrink: 0;
-  border-radius: var(--radius-xs);
+  border-radius: var(--radius-sm);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -1116,10 +1157,17 @@ body:hover #settings-link {
   object-fit: contain;
 }
 
+/* Legacy monogram fallback (kept for any non-local-search usage). */
 .ls-result-icon.monogram {
   font-family: var(--mono);
   font-size: 9px;
   font-weight: 700;
+}
+
+/* SVG inside the per-type icon fills ~60% of its tinted container. */
+.ls-type-icon-svg {
+  width: 60%;
+  height: 60%;
 }
 
 .ls-result-text {
@@ -1221,9 +1269,131 @@ body:hover #settings-link {
   font-weight: 600;
 }
 
+/* ── Grid view ─────────────────────────────────────────────────────────────── */
+
+/* Switch #ls-list from a flex column to a responsive grid. */
+#ls-list[data-view="grid"] {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 10px;
+  padding: 4px 0 8px;
+}
+
+/* Each grid card: vertical flex, centred, with a card surface + border. */
+#ls-list[data-view="grid"] .ls-result-row {
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 16px 10px 12px;
+  gap: 8px;
+  min-height: unset;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  position: relative; /* anchor for absolute-positioned reveal btn */
+  overflow: hidden;
+}
+
+/* Larger icon in grid cards. The SVG inside scales via .ls-type-icon-svg (60%). */
+#ls-list[data-view="grid"] .ls-result-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+/* Text block: full width, centred. */
+#ls-list[data-view="grid"] .ls-result-text {
+  align-items: center;
+  width: 100%;
+}
+
+/* Filename clamps to 2 lines in grid cards. */
+#ls-list[data-view="grid"] .ls-result-primary {
+  white-space: normal;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  text-overflow: unset;
+  font-size: 12px;
+  word-break: break-word;
+  line-height: 1.4;
+}
+
+/* Hide directory path in grid — not enough space. */
+#ls-list[data-view="grid"] .ls-result-secondary {
+  display: none;
+}
+
+/* Meta row: show date centred; hide file size (too compact). */
+#ls-list[data-view="grid"] .ls-result-meta {
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  font-size: 10px;
+}
+
+#ls-list[data-view="grid"] .ls-result-meta span:not(:first-child) {
+  display: none;
+}
+
+/* Reveal button: absolute top-right corner of the card. */
+#ls-list[data-view="grid"] .ls-reveal-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 24px;
+  height: 24px;
+}
+
+/* ── Load more ─────────────────────────────────────────────────────────────── */
+
+.ls-load-more {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0 4px;
+}
+
+.ls-load-more.hidden {
+  display: none;
+}
+
+.ls-load-more-btn {
+  padding: 8px 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color var(--duration-short) var(--ease),
+              background var(--duration-short) var(--ease),
+              color var(--duration-short) var(--ease);
+}
+
+.ls-load-more-btn:hover:not(:disabled) {
+  border-color: var(--primary);
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.ls-load-more-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 @media (max-width: 560px) {
   .ls-result-meta {
     display: none;
+  }
+
+  /* Tighter grid on small screens */
+  #ls-list[data-view="grid"] {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 8px;
   }
 }
 

--- a/extension/src/newtab/newtab.css
+++ b/extension/src/newtab/newtab.css
@@ -941,6 +941,13 @@ body:hover #settings-link {
   user-select: none;
 }
 
+/* Greyed-out state, e.g. "Exact phrase" while query mode is Regex. */
+.ls-filter-toggle.ls-filter-toggle-disabled {
+  opacity: 0.45;
+  cursor: default;
+  pointer-events: none;
+}
+
 .ls-filter-toggle input[type="checkbox"] {
   accent-color: var(--primary);
   cursor: pointer;
@@ -1051,6 +1058,15 @@ body:hover #settings-link {
 .ls-status p {
   margin: 0;
   line-height: 1.5;
+}
+
+.ls-status-heading {
+  font-weight: 600;
+}
+
+.ls-status-detail {
+  color: var(--text-secondary);
+  font-size: 13px;
 }
 
 .ls-status-hint a {
@@ -1258,15 +1274,6 @@ body:hover #settings-link {
 
 .ls-footer-count {
   flex: 1;
-}
-
-.ls-degraded-badge {
-  padding: 2px 8px;
-  border-radius: var(--radius-pill);
-  background: var(--tint-amber-fill);
-  color: var(--tint-amber-fg);
-  font-size: 10px;
-  font-weight: 600;
 }
 
 /* ── Grid view ─────────────────────────────────────────────────────────────── */

--- a/extension/src/newtab/newtab.css
+++ b/extension/src/newtab/newtab.css
@@ -652,3 +652,331 @@ body:hover #settings-link {
     padding: 10px 16px;
   }
 }
+
+/* ── Local-search results view ─────────────────────────────────────────────── */
+
+/* Hide hero elements while local search is active.
+ * Uses a class (not display:none on the elements themselves) so transitions
+ * don't flash. */
+.ls-hidden {
+  display: none !important;
+}
+
+#ls-container {
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 60vh;
+  animation: dropdown-in var(--duration-short) var(--ease);
+}
+
+#ls-container.hidden {
+  display: none;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────────── */
+
+#ls-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+#ls-back {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--duration-short) var(--ease), color var(--duration-short) var(--ease);
+}
+
+#ls-back:hover,
+#ls-back:focus-visible {
+  background: var(--surface-2);
+  color: var(--text);
+  outline: none;
+}
+
+#ls-input-wrapper {
+  flex: 1;
+  position: relative;
+}
+
+#ls-input {
+  width: 100%;
+  height: 44px;
+  padding: 0 16px;
+  font-size: 15px;
+  font-family: var(--font);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  outline: none;
+  transition: border-color var(--duration-short) var(--ease), box-shadow var(--duration-short) var(--ease);
+}
+
+#ls-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent);
+}
+
+#ls-input::placeholder {
+  color: var(--text-placeholder);
+}
+
+/* ── Toolbar placeholder ─────────────────────────────────────────────────────── */
+/* 3b drops the Drive-style toolbar (query-mode control, sort, filter chips,
+ * list/grid toggle) here. Empty in 3a — no height so it doesn't shift layout. */
+
+#ls-toolbar {
+  /* intentionally empty */
+}
+
+/* ── Status area (loading / empty / error / disconnected) ─────────────────── */
+
+.ls-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-secondary);
+  animation: dropdown-in var(--duration-short) var(--ease);
+}
+
+.ls-status.hidden {
+  display: none;
+}
+
+.ls-status p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.ls-status-hint a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.ls-status-hint a:hover {
+  text-decoration: underline;
+}
+
+.ls-status-error {
+  color: var(--danger);
+}
+
+.ls-status-disconnected {
+  color: var(--text-secondary);
+}
+
+/* Spinner */
+.ls-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2.5px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: ls-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes ls-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Retry button */
+.ls-retry-btn {
+  padding: 8px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color var(--duration-short) var(--ease),
+              background var(--duration-short) var(--ease);
+}
+
+.ls-retry-btn:hover {
+  border-color: var(--primary);
+  background: var(--surface-hover);
+}
+
+/* ── Results list ─────────────────────────────────────────────────────────── */
+
+#ls-list {
+  display: flex;
+  flex-direction: column;
+  /* No extra padding — rows carry their own vertical padding */
+}
+
+/* Each result row is a horizontal flex container:
+ *   [icon] [text-block (name + path)] [meta (date + size)] [reveal-btn]
+ * 3b extends this layout by swapping to a grid when view=grid.
+ * The toolbar above the list + the row structure here are the two extension
+ * points for 3b to hook into. */
+.ls-result-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 4px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  min-height: 52px;
+  transition: background var(--duration-short) var(--ease);
+}
+
+.ls-result-row:hover,
+.ls-result-row.active {
+  background: var(--surface-hover);
+}
+
+.ls-result-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  border-radius: var(--radius-xs);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ls-result-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.ls-result-icon.monogram {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.ls-result-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ls-result-primary {
+  font-size: 14px;
+  color: var(--text);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ls-result-secondary {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Ellipsis on the left (tail-visible) so the filename is always readable */
+  direction: rtl;
+  text-align: left;
+}
+
+.ls-result-meta {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--text-placeholder);
+  white-space: nowrap;
+}
+
+/* Reveal-in-file-manager affordance. Hidden until row hover/active,
+ * so it doesn't crowd the meta column. */
+.ls-reveal-btn {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-placeholder);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--duration-short) var(--ease),
+              background var(--duration-short) var(--ease),
+              color var(--duration-short) var(--ease);
+}
+
+.ls-result-row:hover .ls-reveal-btn,
+.ls-result-row.active .ls-reveal-btn {
+  opacity: 1;
+}
+
+.ls-reveal-btn:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────────────── */
+
+.ls-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 4px 4px;
+  font-size: 11px;
+  color: var(--text-placeholder);
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+}
+
+.ls-footer.hidden {
+  display: none;
+}
+
+.ls-footer-count {
+  flex: 1;
+}
+
+.ls-degraded-badge {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--tint-amber-fill);
+  color: var(--tint-amber-fg);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+@media (max-width: 560px) {
+  .ls-result-meta {
+    display: none;
+  }
+}
+

--- a/extension/src/newtab/newtab.css
+++ b/extension/src/newtab/newtab.css
@@ -734,12 +734,259 @@ body:hover #settings-link {
   color: var(--text-placeholder);
 }
 
-/* ── Toolbar placeholder ─────────────────────────────────────────────────────── */
-/* 3b drops the Drive-style toolbar (query-mode control, sort, filter chips,
- * list/grid toggle) here. Empty in 3a — no height so it doesn't shift layout. */
+/* ── Toolbar (Drive-style query-mode, sort, filters) ─────────────────────────── */
 
 #ls-toolbar {
-  /* intentionally empty */
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.ls-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Query-mode segmented control */
+.ls-mode-seg {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.ls-mode-btn {
+  padding: 5px 11px;
+  font: inherit;
+  font-size: 12px;
+  border: none;
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  line-height: 1.4;
+  transition: background var(--duration-short) var(--ease),
+              color var(--duration-short) var(--ease);
+}
+
+.ls-mode-btn:last-child {
+  border-right: none;
+}
+
+.ls-mode-btn.active {
+  background: var(--primary);
+  color: var(--primary-contrast);
+}
+
+.ls-mode-btn:hover:not(.active):not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.ls-mode-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Sort controls */
+.ls-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.ls-sort-field {
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  outline: none;
+  transition: border-color var(--duration-short) var(--ease);
+}
+
+.ls-sort-field:focus-visible {
+  border-color: var(--primary);
+}
+
+.ls-sort-dir {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--duration-short) var(--ease),
+              color var(--duration-short) var(--ease);
+  flex-shrink: 0;
+}
+
+.ls-sort-dir:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.ls-sort-dir svg {
+  transition: transform var(--duration-short) var(--ease);
+}
+
+.ls-sort-dir.asc svg {
+  transform: rotate(180deg);
+}
+
+/* Filter row */
+.ls-filter-row {
+  gap: 6px;
+}
+
+/* Type chips */
+.ls-type-chips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.ls-type-chip {
+  padding: 3px 10px;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1.5;
+  transition: background var(--duration-short) var(--ease),
+              color var(--duration-short) var(--ease),
+              border-color var(--duration-short) var(--ease);
+}
+
+.ls-type-chip.active {
+  background: var(--tint-blue-fill);
+  color: var(--tint-blue-fg);
+  border-color: var(--tint-blue-fg);
+}
+
+.ls-type-chip:hover:not(.active) {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+/* Date modified preset select */
+.ls-date-sel {
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  outline: none;
+  flex-shrink: 0;
+  transition: border-color var(--duration-short) var(--ease);
+}
+
+.ls-date-sel:focus-visible {
+  border-color: var(--primary);
+}
+
+/* Path prefix input */
+.ls-path-input {
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  width: 110px;
+  outline: none;
+  transition: border-color var(--duration-short) var(--ease),
+              box-shadow var(--duration-short) var(--ease);
+}
+
+.ls-path-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent);
+}
+
+.ls-path-input::placeholder {
+  color: var(--text-placeholder);
+}
+
+/* Inline filter toggles (Title only / Contents) */
+.ls-filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.ls-filter-toggle input[type="checkbox"] {
+  accent-color: var(--primary);
+  cursor: pointer;
+  width: 13px;
+  height: 13px;
+}
+
+.ls-filter-toggle.hidden {
+  display: none;
+}
+
+/* Clear filters button */
+.ls-clear-btn {
+  margin-left: auto;
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--duration-short) var(--ease),
+              color var(--duration-short) var(--ease),
+              border-color var(--duration-short) var(--ease);
+}
+
+.ls-clear-btn:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+  background: var(--surface-hover);
+}
+
+@media (max-width: 560px) {
+  .ls-toolbar-main {
+    flex-wrap: wrap;
+  }
+
+  .ls-sort {
+    margin-left: 0;
+  }
+
+  .ls-path-input {
+    width: 80px;
+  }
 }
 
 /* ── Status area (loading / empty / error / disconnected) ─────────────────── */

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -8,6 +8,13 @@ import type {
   Command,
   Group,
 } from "../core/types.js";
+import { getLocalSearchPrefs } from "../core/local-search-store.js";
+import type { LocalSearchPrefs } from "../core/local-search-store.js";
+import {
+  shouldInterceptLocalSearch,
+  openLocalSearch,
+  initLocalSearch,
+} from "./local-search-results.js";
 import type { Suggestion } from "../core/suggestions.js";
 import { resolveGroupTint } from "../ui/group-colors.js";
 import { renderFavicon } from "../ui/favicon.js";
@@ -85,6 +92,7 @@ function findResolvedByTrigger(cfg: FastTravelConfig, trigger: string): Resolved
 
 // State
 let config: FastTravelConfig | null = null;
+let localSearchPrefs: LocalSearchPrefs | null = null;
 // Recent usage history, fetched once at load and used to frecency-rank the
 // empty-input quick chips.
 let topChipHistory: HistoryEntry[] = [];
@@ -167,6 +175,8 @@ async function init(): Promise<void> {
     config = await chrome.runtime.sendMessage({ type: "getConfig" });
     await refreshIgnoreState();
     topChipHistory = (await chrome.runtime.sendMessage({ type: "getHistory" })) ?? [];
+    localSearchPrefs = await getLocalSearchPrefs();
+    initLocalSearch();
 
     // Omnibox search-provider path: ?q=<query> → resolve + navigate immediately.
     // The presence of ?q= proves Fast Travel is the active default search engine.
@@ -324,6 +334,17 @@ function handleSearch(): void {
   if (!config) return;
   const query = searchInput.value.trim();
   if (!query) return;
+
+  // Local-search intercept: `s <query>` when enabled + paired + config has no `s` trigger.
+  // Returns { intercept: false } for all other input — strict no-op guard.
+  if (localSearchPrefs) {
+    const intercept = shouldInterceptLocalSearch(query, localSearchPrefs, config);
+    if (intercept.intercept) {
+      hideSuggestions();
+      void openLocalSearch(intercept.query);
+      return;
+    }
+  }
 
   const result = parseCommand({
     rawQuery: query,

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -262,7 +262,13 @@ function focusSearchInput(): void {
     // and clearing currentTypo before the typo handler ever sees the key, which
     // is why the typo shortcuts appeared dead.
     if (currentTypo) return;
-    if (e.target === searchInput) return;
+    // Don't hijack keystrokes when ANY text field is focused — including the
+    // local-search results input (#ls-input). Previously this only exempted the
+    // main search box, so typing in the results input was stolen back to here.
+    {
+      const tgt = e.target as HTMLElement | null;
+      if (tgt && (tgt.tagName === "INPUT" || tgt.tagName === "TEXTAREA" || tgt.isContentEditable)) return;
+    }
     if (e.ctrlKey || e.metaKey || e.altKey) return;
     if (e.key.length !== 1) return;
     e.preventDefault();
@@ -504,6 +510,15 @@ async function showHistory(): Promise<void> {
   renderSuggestions(items, true);
 }
 
+// Synthetic command used to surface the local-search `s` entry in the
+// suggestions dropdown (`s` is a submit-intercept, not a real config command).
+const LOCAL_SEARCH_SUGGESTION_CMD = {
+  id: "__local-search__",
+  name: "Local search",
+  triggers: ["s"],
+  type: "standard",
+} as unknown as Command;
+
 function showSuggestions(query: string): void {
   updateLeadingIcon(query);
   if (suggestionTimer) {
@@ -525,6 +540,23 @@ function showSuggestions(query: string): void {
   const commandItems: SuggestionItem[] = [];
 
   if (parts.length === 1) {
+    // Surface the local-search `s` command (a submit-intercept, not a config
+    // command) so typing `s` shows it in the dropdown like any other command.
+    if (
+      localSearchPrefs?.enabled &&
+      localSearchPrefs.token &&
+      !triggerMap.has("s") &&
+      "s".startsWith(partial)
+    ) {
+      commandItems.push({
+        text: "s ",
+        display: "s — Local search",
+        kind: "command",
+        command: LOCAL_SEARCH_SUGGESTION_CMD,
+        matchedTrigger: "s",
+        groupColor: "#34a853",
+      });
+    }
     for (const [trigger, cmd] of triggerMap) {
       if (cmd.type === "prefix") continue;
       if (trigger.startsWith(partial) && trigger !== partial) {

--- a/extension/src/options/options.css
+++ b/extension/src/options/options.css
@@ -1355,6 +1355,87 @@ button:disabled {
   color: var(--text-secondary);
 }
 
+/* ---- Toggle switch ---- */
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.toggle-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--border);
+  cursor: pointer;
+  transition: background var(--duration-short) var(--ease);
+}
+
+.toggle-switch input:checked + .toggle-track {
+  background: var(--primary);
+}
+
+.toggle-switch input:disabled + .toggle-track {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.toggle-track::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform var(--duration-short) var(--ease);
+}
+
+.toggle-switch input:checked + .toggle-track::after {
+  transform: translateX(18px);
+}
+
+/* ---- Local Search screen ---- */
+
+.ls-banner {
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  margin-bottom: 16px;
+  font-size: 13px;
+  line-height: 1.5;
+  border: 1px solid;
+}
+
+.ls-banner-error {
+  background: color-mix(in oklab, var(--danger) 10%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 30%, transparent);
+  color: var(--danger);
+}
+
+.ls-install-guide {
+  margin-top: 14px;
+}
+
+.ls-install-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
 /* ---- Per-device icon overrides ---- */
 
 .icon-override-row {

--- a/extension/src/options/options.html
+++ b/extension/src/options/options.html
@@ -38,6 +38,10 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
           Set as default
         </a>
+        <a class="sidebar-link" data-route="#/local-search" href="#/local-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="22" y1="12" x2="2" y2="12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" y1="16" x2="6.01" y2="16"/><line x1="10" y1="16" x2="10.01" y2="16"/></svg>
+          Local Search
+        </a>
         <a class="sidebar-link" data-route="#/about" href="#/about">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
           About

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -9,6 +9,7 @@ import { renderImportExport } from "./screens/import-export.js";
 import { renderHistory } from "./screens/history.js";
 import { renderAbout } from "./screens/about.js";
 import { renderSearchEngine } from "./screens/search-engine.js";
+import { renderLocalSearch } from "./screens/local-search.js";
 
 defineRoutes([
   { pattern: /^#\/appearance$/, render: (main) => renderAppearance(main) },
@@ -29,6 +30,7 @@ defineRoutes([
   { pattern: /^#\/import-export$/, render: (main) => renderImportExport(main) },
   { pattern: /^#\/history$/, render: (main) => renderHistory(main) },
   { pattern: /^#\/search-engine$/, render: (main) => renderSearchEngine(main) },
+  { pattern: /^#\/local-search$/, render: (main) => renderLocalSearch(main) },
   { pattern: /^#\/about$/, render: (main) => renderAbout(main) },
 ]);
 

--- a/extension/src/options/screens/local-search.ts
+++ b/extension/src/options/screens/local-search.ts
@@ -1,0 +1,517 @@
+/**
+ * "Local Search" settings screen — companion status + pairing flow,
+ * enable toggle, `s`-keyword collision guard, and capability-gated defaults.
+ *
+ * Phase 2b: options screen only.  The results UI and `s` command intercept
+ * are Phase 3.
+ *
+ * Security note: the companion's /v1/pairing/open endpoint is same-origin-
+ * guarded and cannot be called from the extension.  Pairing is opened either
+ * automatically on the companion's first run, or by the user clicking "Open
+ * Pairing" on the companion's own /setup page.  This screen only calls
+ * companionClient.pair() — it never calls companionClient.openPairingWindow().
+ */
+
+import { el, card, screenHeader } from "../dom.js";
+import { getConfig } from "../data.js";
+import { showSnackbar } from "../../ui/snackbar.js";
+import * as companionClient from "../../core/companion-client.js";
+import { getLocalSearchPrefs, setLocalSearchPrefs } from "../../core/local-search-store.js";
+import { buildTriggerMap } from "../../core/parser.js";
+import type { FastTravelConfig } from "../../core/types.js";
+import type { PingResponse } from "../../core/companion-types.js";
+
+// ── Status type ────────────────────────────────────────────────────────────────
+
+export type CompanionStatus = "notFound" | "unpaired" | "connected" | "disconnected";
+
+// ── Pure helpers (exported for unit tests) ────────────────────────────────────
+
+/**
+ * Detect the host OS from a User-Agent string.
+ * Returns "windows", "macos", or "linux" (default).
+ */
+export function detectOS(ua: string): "windows" | "macos" | "linux" {
+  const lower = ua.toLowerCase();
+  if (lower.includes("win")) return "windows";
+  if (lower.includes("mac")) return "macos";
+  return "linux";
+}
+
+/**
+ * Returns true if the config already maps the trigger "s" to a command.
+ * The check is case-insensitive because buildTriggerMap lower-cases all
+ * triggers before inserting them.
+ */
+export function configHasSTrigger(config: FastTravelConfig): boolean {
+  return buildTriggerMap(config).has("s");
+}
+
+/**
+ * Returns true if at least one *available* indexer in the ping response
+ * advertises `capabilities.regex === true`.
+ */
+export function regexAvailable(ping: PingResponse): boolean {
+  return ping.indexers.some((idx) => idx.available && idx.capabilities.regex);
+}
+
+/**
+ * Returns true if the *default* indexer is available and supports content
+ * search.
+ */
+export function contentAvailable(ping: PingResponse): boolean {
+  const def = ping.indexers.find((idx) => idx.id === ping.defaultIndexer);
+  return def !== undefined && def.available && def.capabilities.content;
+}
+
+/**
+ * Derive the companion connection status from a discover() result and stored
+ * prefs.
+ *
+ * - null + no previous port  → "notFound"      (never seen a companion)
+ * - null + had previous port → "disconnected"  (companion went away)
+ * - result + ping.paired + has token → "connected"
+ * - result + otherwise       → "unpaired"
+ */
+export function deriveStatus(
+  result: { port: number; ping: PingResponse } | null,
+  prefs: { port?: number; token?: string },
+): CompanionStatus {
+  if (result === null) {
+    return prefs.port !== undefined ? "disconnected" : "notFound";
+  }
+  if (result.ping.paired && prefs.token) return "connected";
+  return "unpaired";
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const RELEASES_URL = "https://github.com/DoubleGremlin181/fast-travel-app/releases";
+
+// ── Screen entry point ───────────────────────────────────────────────────────
+
+export async function renderLocalSearch(main: HTMLElement): Promise<void> {
+  main.appendChild(
+    screenHeader(
+      "Local Search",
+      "Search files on this device using the ‘s’ command. Requires the Fast Travel Companion daemon.",
+    ),
+  );
+
+  const contentArea = el("div", null);
+  main.appendChild(contentArea);
+
+  await loadAndRender();
+
+  async function loadAndRender(): Promise<void> {
+    contentArea.replaceChildren();
+    contentArea.appendChild(buildLoadingCard());
+
+    const [discoverResult, prefs, config] = await Promise.all([
+      companionClient.discover(),
+      getLocalSearchPrefs(),
+      getConfig(),
+    ]);
+
+    const status = deriveStatus(discoverResult, prefs);
+    const collision = config !== null ? configHasSTrigger(config) : false;
+    const os = detectOS(navigator.userAgent);
+
+    contentArea.replaceChildren();
+
+    // 1. Companion status card (always shown)
+    contentArea.appendChild(
+      buildStatusCard(status, discoverResult, prefs, os, loadAndRender),
+    );
+
+    // 2. Collision error banner (shown when 's' is already a command trigger)
+    if (collision) {
+      contentArea.appendChild(buildCollisionBanner());
+    }
+
+    // 3. Enable toggle card
+    contentArea.appendChild(
+      buildEnableCard(status, collision, prefs, async (enabled) => {
+        await setLocalSearchPrefs({ enabled });
+      }),
+    );
+
+    // 4. Capability-gated defaults (only when connected)
+    if (status === "connected" && discoverResult !== null) {
+      contentArea.appendChild(buildDefaultsCard(discoverResult.ping, prefs));
+    }
+  }
+}
+
+// ── Card builders ────────────────────────────────────────────────────────────
+
+function buildLoadingCard(): HTMLElement {
+  const body = el(
+    "div",
+    { class: "card-body", style: "display:flex;align-items:center;gap:10px;" },
+    el("span", { class: "spinner" }),
+    "Discovering companion…",
+  );
+  const section = el("section", { class: "card" });
+  section.appendChild(el("div", { class: "card-header" }, "Companion status"));
+  section.appendChild(body);
+  return section;
+}
+
+function buildStatusCard(
+  status: CompanionStatus,
+  result: { port: number; ping: PingResponse } | null,
+  prefs: { token?: string; port?: number },
+  os: "windows" | "macos" | "linux",
+  onRetry: () => void,
+): HTMLElement {
+  const section = el("section", { class: "card" });
+  section.appendChild(el("div", { class: "card-header" }, "Companion status"));
+
+  const body = el("div", { class: "card-body" });
+
+  const STATUS_TEXT: Record<CompanionStatus, string> = {
+    notFound: "Companion not installed or not running.",
+    unpaired: "Companion detected — pair to connect.",
+    connected: "Connected ✓",
+    disconnected: "Companion disconnected.",
+  };
+  const STATUS_CLASS: Record<CompanionStatus, string> = {
+    notFound: "status",
+    unpaired: "status",
+    connected: "status success",
+    disconnected: "status error",
+  };
+
+  body.appendChild(el("div", { class: STATUS_CLASS[status] }, STATUS_TEXT[status]));
+
+  if (status === "notFound") {
+    body.appendChild(buildInstallGuide(os));
+    body.appendChild(
+      el("div", { class: "btn-row" }, mkBtn("Refresh", undefined, onRetry)),
+    );
+  } else if (status === "disconnected") {
+    body.appendChild(
+      el("div", { class: "btn-row" }, mkBtn("Retry", "primary", onRetry)),
+    );
+  } else if (status === "unpaired" && result !== null) {
+    body.appendChild(buildPairingActions(result.port, result.ping, onRetry));
+  } else if (status === "connected") {
+    body.appendChild(
+      el("div", { class: "btn-row" }, mkBtn("Refresh", undefined, onRetry)),
+    );
+  }
+
+  section.appendChild(body);
+  return section;
+}
+
+function buildPairingActions(
+  port: number,
+  ping: PingResponse,
+  onDone: () => void,
+): HTMLElement {
+  const wrap = el("div", null);
+
+  if (!ping.pairingOpen) {
+    wrap.appendChild(
+      el(
+        "div",
+        { class: "form-hint", style: "margin-top:10px;" },
+        "Pairing is not yet open on the companion. Open the companion setup page and " +
+          "click “Open Pairing” there, then click Pair now.",
+      ),
+    );
+  }
+
+  const btnRow = el("div", { class: "btn-row" });
+
+  if (!ping.pairingOpen) {
+    const openBtn = mkBtn("Open companion setup", undefined, () => {
+      window.open(`http://127.0.0.1:${port}/setup`, "_blank");
+    });
+    btnRow.appendChild(openBtn);
+  }
+
+  const pairBtn = el("button", { class: "primary", type: "button" }, "Pair now");
+  pairBtn.addEventListener("click", () => {
+    pairBtn.disabled = true;
+    pairBtn.textContent = "Pairing…";
+    companionClient
+      .pair(port, "Fast Travel Extension")
+      .then(async (token) => {
+        await setLocalSearchPrefs({ token });
+        onDone();
+      })
+      .catch((err: unknown) => {
+        const code =
+          err instanceof companionClient.CompanionError ? err.code : "network";
+        if (code === "pairing_closed") {
+          showSnackbar({
+            message:
+              "Pairing is not open. Click “Open companion setup” first, then open pairing from there.",
+          });
+        } else {
+          showSnackbar({
+            message: `Pairing failed: ${(err as Error).message}`,
+          });
+        }
+        pairBtn.disabled = false;
+        pairBtn.textContent = "Pair now";
+      });
+  });
+  btnRow.appendChild(pairBtn);
+  wrap.appendChild(btnRow);
+  return wrap;
+}
+
+function buildInstallGuide(os: "windows" | "macos" | "linux"): HTMLElement {
+  const wrap = el("div", { class: "ls-install-guide" });
+  wrap.appendChild(
+    el(
+      "div",
+      { class: "ls-install-title" },
+      "Install the Fast Travel Companion",
+    ),
+  );
+
+  if (os === "macos") {
+    wrap.appendChild(
+      el(
+        "p",
+        { class: "form-hint", style: "margin-top:8px;" },
+        "macOS support is coming soon. Check the Releases page for updates.",
+      ),
+    );
+    wrap.appendChild(
+      el(
+        "div",
+        { class: "btn-row", style: "margin-top:10px;" },
+        el(
+          "a",
+          {
+            href: RELEASES_URL,
+            target: "_blank",
+            rel: "noopener noreferrer",
+            class: "btn",
+          },
+          "View Releases",
+        ),
+      ),
+    );
+    return wrap;
+  }
+
+  const assetName =
+    os === "windows"
+      ? "fast-travel-companion-windows-amd64.exe"
+      : "fast-travel-companion-linux-amd64";
+
+  const steps = el("ol", { class: "setup-steps" });
+
+  const li1 = el("li", null);
+  li1.appendChild(document.createTextNode("Download "));
+  li1.appendChild(el("code", null, assetName));
+  if (os === "linux") {
+    li1.appendChild(document.createTextNode(" (or "));
+    li1.appendChild(el("code", null, "fast-travel-companion-linux-arm64"));
+    li1.appendChild(document.createTextNode(" for ARM64) "));
+  }
+  li1.appendChild(document.createTextNode(" from the "));
+  li1.appendChild(
+    el(
+      "a",
+      {
+        href: RELEASES_URL,
+        target: "_blank",
+        rel: "noopener noreferrer",
+      },
+      "Releases page",
+    ),
+  );
+  li1.appendChild(document.createTextNode("."));
+  steps.appendChild(li1);
+
+  steps.appendChild(
+    el(
+      "li",
+      null,
+      os === "windows"
+        ? "Run the .exe — it opens a setup page in your browser and starts listening on 127.0.0.1."
+        : "Make it executable (chmod +x) and run it — it opens a setup page and starts listening on 127.0.0.1.",
+    ),
+  );
+
+  steps.appendChild(
+    el(
+      "li",
+      null,
+      "Once the companion is running, click Refresh above.",
+    ),
+  );
+
+  wrap.appendChild(steps);
+  return wrap;
+}
+
+function buildCollisionBanner(): HTMLElement {
+  const banner = el("div", { class: "ls-banner ls-banner-error" });
+  banner.appendChild(el("strong", null, "Keyword conflict:"));
+  banner.appendChild(
+    document.createTextNode(
+      " The ‘s’ keyword is already used by a command in your config. " +
+        "Rename or remove that command to use Local Search.",
+    ),
+  );
+  return banner;
+}
+
+function buildEnableCard(
+  status: CompanionStatus,
+  collision: boolean,
+  prefs: { enabled: boolean },
+  onToggle: (enabled: boolean) => Promise<void>,
+): HTMLElement {
+  const canEnable = status === "connected" && !collision;
+
+  const subtitle =
+    status !== "connected"
+      ? "Connect the companion daemon to enable."
+      : collision
+        ? "Resolve the keyword conflict above to enable."
+        : "Type ‘s <query>’ in the new tab page to search files.";
+
+  const checkbox = el("input", { type: "checkbox", id: "ls-enable" });
+  checkbox.checked = prefs.enabled && canEnable;
+  checkbox.disabled = !canEnable;
+
+  checkbox.addEventListener("change", () => {
+    const next = checkbox.checked;
+    onToggle(next).catch((err: unknown) => {
+      checkbox.checked = !next; // revert on failure
+      showSnackbar({ message: `Failed to save: ${(err as Error).message}` });
+    });
+  });
+
+  const toggleLabel = el(
+    "label",
+    { class: "toggle-switch" },
+    checkbox,
+    el("span", { class: "toggle-track" }),
+  );
+
+  const section = el("section", { class: "card" });
+  section.appendChild(el("div", { class: "card-header" }, "Local Search"));
+
+  const row = el("div", { class: "card-row" });
+  const rowMain = el("div", { class: "card-row-main" });
+  rowMain.appendChild(el("div", { class: "card-row-title" }, "Enable Local Search"));
+  rowMain.appendChild(el("div", { class: "card-row-subtitle" }, subtitle));
+  row.appendChild(rowMain);
+  row.appendChild(toggleLabel);
+  section.appendChild(row);
+
+  return section;
+}
+
+function buildDefaultsCard(
+  ping: PingResponse,
+  prefs: { queryMode: "simple" | "wildcard" | "regex"; filters: { content?: boolean } },
+): HTMLElement {
+  const body = el("div", { class: "card-body" });
+
+  // ── Query mode selector ────────────────────────────────────────────────────
+  const modeRow = el("div", { class: "form-row" });
+  const modeLabel = el(
+    "label",
+    { class: "form-label", for: "ls-query-mode" },
+    "Default query mode",
+  );
+  modeRow.appendChild(modeLabel);
+
+  const modeSelect = el("select", { id: "ls-query-mode" });
+  const hasRegex = regexAvailable(ping);
+
+  const MODES: { value: "simple" | "wildcard" | "regex"; label: string }[] = [
+    { value: "simple", label: "Simple" },
+    { value: "wildcard", label: "Wildcard" },
+    { value: "regex", label: "Regex" },
+  ];
+
+  for (const { value, label } of MODES) {
+    const isRegexOpt = value === "regex";
+    const opt = el("option", { value }, label);
+    if (isRegexOpt && !hasRegex) {
+      opt.disabled = true;
+      opt.title = "Not supported by your indexer.";
+    }
+    if (value === prefs.queryMode) opt.selected = true;
+    modeSelect.appendChild(opt);
+  }
+
+  modeSelect.addEventListener("change", () => {
+    void setLocalSearchPrefs({
+      queryMode: modeSelect.value as "simple" | "wildcard" | "regex",
+    });
+  });
+  modeRow.appendChild(modeSelect);
+
+  if (!hasRegex) {
+    modeRow.appendChild(
+      el(
+        "div",
+        { class: "form-hint" },
+        "Regex mode is not supported by your current indexer.",
+      ),
+    );
+  }
+  body.appendChild(modeRow);
+
+  // ── Content search toggle (only when the default indexer supports it) ──────
+  if (contentAvailable(ping)) {
+    const contentRow = el("div", { class: "card-row", style: "border-top:1px solid var(--border);margin-top:12px;" });
+
+    const rowMain = el("div", { class: "card-row-main" });
+    rowMain.appendChild(
+      el("div", { class: "card-row-title" }, "Search file contents"),
+    );
+    rowMain.appendChild(
+      el(
+        "div",
+        { class: "card-row-subtitle" },
+        "Include file contents in search results (slower).",
+      ),
+    );
+
+    const contentCheck = el("input", { type: "checkbox", id: "ls-content" });
+    contentCheck.checked = prefs.filters.content === true;
+    contentCheck.addEventListener("change", () => {
+      void setLocalSearchPrefs({ filters: { content: contentCheck.checked } });
+    });
+
+    const contentLabel = el(
+      "label",
+      { class: "toggle-switch" },
+      contentCheck,
+      el("span", { class: "toggle-track" }),
+    );
+
+    contentRow.appendChild(rowMain);
+    contentRow.appendChild(contentLabel);
+    body.appendChild(contentRow);
+  }
+
+  return card("Defaults", body);
+}
+
+// ── DOM utilities ────────────────────────────────────────────────────────────
+
+function mkBtn(
+  text: string,
+  variant: "primary" | "ghost" | undefined,
+  onClick: () => void,
+): HTMLButtonElement {
+  const btn = el("button", { type: "button", class: variant }, text);
+  btn.addEventListener("click", onClick);
+  return btn;
+}

--- a/extension/src/options/screens/local-search.ts
+++ b/extension/src/options/screens/local-search.ts
@@ -152,7 +152,7 @@ function buildLoadingCard(): HTMLElement {
 function buildStatusCard(
   status: CompanionStatus,
   result: { port: number; ping: PingResponse } | null,
-  prefs: { token?: string; port?: number },
+  _prefs: { token?: string; port?: number },
   os: "windows" | "macos" | "linux",
   onRetry: () => void,
 ): HTMLElement {

--- a/extension/src/options/screens/local-search.ts
+++ b/extension/src/options/screens/local-search.ts
@@ -20,6 +20,14 @@ import { getLocalSearchPrefs, setLocalSearchPrefs } from "../../core/local-searc
 import { buildTriggerMap } from "../../core/parser.js";
 import type { FastTravelConfig } from "../../core/types.js";
 import type { PingResponse } from "../../core/companion-types.js";
+import {
+  regexAvailable,
+  contentAvailable,
+} from "../../core/local-search-capabilities.js";
+
+// Re-export so the existing test surface (tests/unit/local-search-screen.test.ts)
+// continues to import from this module without changes.
+export { regexAvailable, contentAvailable };
 
 // ── Status type ────────────────────────────────────────────────────────────────
 
@@ -45,23 +53,6 @@ export function detectOS(ua: string): "windows" | "macos" | "linux" {
  */
 export function configHasSTrigger(config: FastTravelConfig): boolean {
   return buildTriggerMap(config).has("s");
-}
-
-/**
- * Returns true if at least one *available* indexer in the ping response
- * advertises `capabilities.regex === true`.
- */
-export function regexAvailable(ping: PingResponse): boolean {
-  return ping.indexers.some((idx) => idx.available && idx.capabilities.regex);
-}
-
-/**
- * Returns true if the *default* indexer is available and supports content
- * search.
- */
-export function contentAvailable(ping: PingResponse): boolean {
-  const def = ping.indexers.find((idx) => idx.id === ping.defaultIndexer);
-  return def !== undefined && def.available && def.capabilities.content;
 }
 
 /**

--- a/extension/tests/e2e/local-search-stub.ts
+++ b/extension/tests/e2e/local-search-stub.ts
@@ -1,0 +1,270 @@
+/**
+ * Stub companion HTTP server for local-search e2e tests.
+ *
+ * Implements the minimal Fast Travel companion protocol subset needed for
+ * end-to-end testing:
+ *   GET  /v1/ping   — discovery probe (no auth)
+ *   POST /v1/pair   — pairing (returns a fixed Bearer token)
+ *   POST /v1/search — authenticated file search (returns 3 canned results)
+ *   POST /v1/open   — authenticated file open (records the path)
+ *
+ * CORS headers are permissive (* origin) so the extension-origin fetch works
+ * regardless of the loaded-extension origin Chromium assigns.
+ */
+
+import * as http from "node:http";
+
+// ── Internal state ────────────────────────────────────────────────────────────
+
+let paired = false;
+let lastSearchBody: unknown = null;
+let lastOpenPath: string | null = null;
+let openCallCount = 0;
+let searchCallCount = 0;
+
+// ── Canned ping response ──────────────────────────────────────────────────────
+
+function buildPingResponse() {
+  return {
+    name: "fast-travel-companion",
+    version: "test",
+    protocolVersion: 1,
+    os: "linux",
+    paired,
+    pairingOpen: true,
+    defaultIndexer: "baloo",
+    indexers: [
+      {
+        id: "baloo",
+        name: "KDE Baloo",
+        available: true,
+        capabilities: {
+          booleanOps: true,
+          prefixWildcard: true,
+          infixWildcard: true,
+          regex: false,
+          pathScope: true,
+          content: true,
+        },
+      },
+      {
+        id: "plocate",
+        name: "plocate",
+        available: true,
+        capabilities: {
+          booleanOps: false,
+          prefixWildcard: true,
+          infixWildcard: true,
+          regex: true,
+          pathScope: true,
+          content: false,
+        },
+      },
+    ],
+  };
+}
+
+// ── Canned search response ────────────────────────────────────────────────────
+
+function buildSearchResponse(query: string) {
+  const now = Date.now();
+  const results = [
+    {
+      id: "/home/user/docs/report-2024.pdf",
+      name: "report-2024.pdf",
+      path: "/home/user/docs/report-2024.pdf",
+      dir: "/home/user/docs",
+      ext: "pdf",
+      mime: "application/pdf",
+      type: "document",
+      size: 1_048_576,
+      createdAt: now - 86_400_000 * 30,
+      modifiedAt: now - 3_600_000,
+      score: 0.95,
+    },
+    {
+      id: "/home/user/docs/report-draft.docx",
+      name: "report-draft.docx",
+      path: "/home/user/docs/report-draft.docx",
+      dir: "/home/user/docs",
+      ext: "docx",
+      mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      type: "document",
+      size: 524_288,
+      createdAt: now - 86_400_000 * 7,
+      modifiedAt: now - 86_400_000,
+      score: 0.88,
+    },
+    {
+      id: "/home/user/docs/quarterly-report.xlsx",
+      name: "quarterly-report.xlsx",
+      path: "/home/user/docs/quarterly-report.xlsx",
+      dir: "/home/user/docs",
+      ext: "xlsx",
+      mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      type: "document",
+      size: 262_144,
+      createdAt: now - 86_400_000 * 14,
+      modifiedAt: now - 86_400_000 * 2,
+      score: 0.76,
+    },
+  ];
+
+  return {
+    results,
+    total: 3,
+    page: 0,
+    tookMs: 1,
+    indexer: "baloo",
+    degraded: false,
+  };
+}
+
+// ── CORS headers ──────────────────────────────────────────────────────────────
+
+const CORS_HEADERS: http.OutgoingHttpHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+};
+
+// ── Request routing ───────────────────────────────────────────────────────────
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    req.on("error", reject);
+  });
+}
+
+function sendJson(
+  res: http.ServerResponse,
+  status: number,
+  body: unknown,
+): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    ...CORS_HEADERS,
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+async function handleRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<void> {
+  const { method, url } = req;
+
+  // ── CORS preflight ──────────────────────────────────────────────────────────
+  if (method === "OPTIONS") {
+    res.writeHead(204, CORS_HEADERS);
+    res.end();
+    return;
+  }
+
+  // ── Routes ──────────────────────────────────────────────────────────────────
+
+  if (method === "GET" && url === "/v1/ping") {
+    sendJson(res, 200, buildPingResponse());
+    return;
+  }
+
+  if (method === "POST" && url === "/v1/pair") {
+    paired = true;
+    sendJson(res, 200, { token: "e2e-test-token" });
+    return;
+  }
+
+  if (method === "POST" && url === "/v1/search") {
+    const raw = await readBody(req);
+    let body: unknown;
+    try { body = JSON.parse(raw); } catch { body = raw; }
+    lastSearchBody = body;
+    searchCallCount++;
+    const query = typeof body === "object" && body !== null && "query" in body
+      ? String((body as Record<string, unknown>).query)
+      : "";
+    sendJson(res, 200, buildSearchResponse(query));
+    return;
+  }
+
+  if (method === "POST" && url === "/v1/open") {
+    const raw = await readBody(req);
+    let body: unknown;
+    try { body = JSON.parse(raw); } catch { body = raw; }
+    const path = typeof body === "object" && body !== null && "path" in body
+      ? String((body as Record<string, unknown>).path)
+      : null;
+    lastOpenPath = path;
+    openCallCount++;
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  // Unknown route
+  sendJson(res, 404, { error: "not_found", message: `No route for ${method} ${url}` });
+}
+
+// ── Server lifecycle ──────────────────────────────────────────────────────────
+
+let server: http.Server | null = null;
+
+export function start(): Promise<void> {
+  // Reset all state on (re)start
+  paired = false;
+  lastSearchBody = null;
+  lastOpenPath = null;
+  openCallCount = 0;
+  searchCallCount = 0;
+
+  return new Promise((resolve, reject) => {
+    server = http.createServer((req, res) => {
+      handleRequest(req, res).catch((err: unknown) => {
+        console.error("[stub] unhandled error:", err);
+        if (!res.headersSent) {
+          sendJson(res, 500, { error: "internal", message: String(err) });
+        }
+      });
+    });
+    server.listen(7333, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+}
+
+export function stop(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!server) return resolve();
+    server.close((err) => {
+      server = null;
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+// ── Accessors for test assertions ─────────────────────────────────────────────
+
+export function getLastSearchBody(): unknown {
+  return lastSearchBody;
+}
+
+export function getLastOpenPath(): string | null {
+  return lastOpenPath;
+}
+
+export function getOpenCallCount(): number {
+  return openCallCount;
+}
+
+export function getSearchCallCount(): number {
+  return searchCallCount;
+}
+
+export function isPaired(): boolean {
+  return paired;
+}

--- a/extension/tests/e2e/local-search.spec.ts
+++ b/extension/tests/e2e/local-search.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * E2E test: Local Search feature (stub companion on 127.0.0.1:7333).
+ *
+ * Step A — Pairing + enable: opens the Local Search settings screen, waits
+ *   for the companion to be detected, pairs, then enables the toggle.
+ * Step B — Search: opens newtab, types "s report", presses Enter, verifies
+ *   the three canned result files render.
+ * Step C — Interactions: toggles grid view, changes sort (fires a new search),
+ *   clicks a result to open a file.
+ *
+ * Steps B and C inject prefs directly via chrome.storage.local to avoid
+ * repeating the full pairing UI flow (Step A covers that thoroughly).
+ */
+
+import path from "node:path";
+import { test, expect } from "./fixtures";
+import {
+  start,
+  stop,
+  getLastSearchBody,
+  getLastOpenPath,
+  getOpenCallCount,
+  getSearchCallCount,
+} from "./local-search-stub";
+
+const SCREENSHOTS = path.resolve(__dirname, "screenshots");
+// ── Pre-paired prefs injected into chrome.storage to skip UI pairing in B/C ──
+
+const PAIRED_PREFS = {
+  "fast-travel-local-search-prefs": {
+    enabled: true,
+    token: "e2e-test-token",
+    port: 7333,
+    queryMode: "simple",
+    sort: { field: "relevance", dir: "desc" },
+    filters: {},
+    view: "list",
+  },
+};
+
+// ── Shared helper: inject prefs into a loaded extension page ─────────────────
+
+async function injectPrefs(
+  page: import("@playwright/test").Page,
+  prefs: Record<string, unknown>,
+): Promise<void> {
+  await page.evaluate(async (p) => {
+    await chrome.storage.local.set(p);
+  }, prefs);
+}
+
+// ── Stub lifecycle ────────────────────────────────────────────────────────────
+
+test.beforeAll(async () => {
+  await start();
+});
+
+test.afterAll(async () => {
+  await stop();
+});
+
+// ── Step A: Pairing + enable ──────────────────────────────────────────────────
+
+test("Step A: pair companion and enable local search", async ({ context, extensionId }) => {
+  const page = await context.newPage();
+
+  await page.goto(`chrome-extension://${extensionId}/options/options.html#/local-search`);
+
+  // Wait for the screen to finish loading (spinner → status card).
+  // discover() will hit 127.0.0.1:7333 — our stub. Paired=false on first call.
+  await expect(
+    page.locator(".status", { hasText: "Companion detected" }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await page.screenshot({ path: `${SCREENSHOTS}/local-search-a1-detected.png` });
+
+  // Click "Pair now".
+  const pairBtn = page.getByRole("button", { name: "Pair now" });
+  await expect(pairBtn).toBeVisible({ timeout: 5_000 });
+  await pairBtn.click();
+
+  // After pairing, loadAndRender() re-runs discover(). The stub now returns
+  // paired:true and the token is in prefs → status "Connected ✓".
+  await expect(
+    page.locator(".status.success", { hasText: "Connected" }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await page.screenshot({ path: `${SCREENSHOTS}/local-search-a2-connected.png` });
+
+  // Enable local search via the toggle switch label (the <input> checkbox is
+  // hidden with CSS; click the wrapping <label class="toggle-switch"> instead).
+  const toggleLabel = page.locator("label.toggle-switch:has(#ls-enable)");
+  await expect(toggleLabel).toBeVisible({ timeout: 5_000 });
+
+  // Verify the underlying checkbox is enabled but not yet checked.
+  const enableChk = page.locator("#ls-enable");
+  await expect(enableChk).toBeEnabled({ timeout: 5_000 });
+  await expect(enableChk).not.toBeChecked();
+
+  await toggleLabel.click();
+  await expect(enableChk).toBeChecked({ timeout: 3_000 });
+
+  await page.screenshot({ path: `${SCREENSHOTS}/local-search-a3-enabled.png` });
+
+  await page.close();
+});
+
+// ── Step B: Search ────────────────────────────────────────────────────────────
+
+test("Step B: type 's report' in newtab and verify results render", async ({ context, extensionId }) => {
+  // Inject paired prefs via an extension page before opening newtab.
+  const prePage = await context.newPage();
+  await prePage.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await injectPrefs(prePage, PAIRED_PREFS);
+  await prePage.close();
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
+
+  // Wait for the newtab to finish init() — essential before pressing Enter
+  // (handleSearch no-ops while config is null or localSearchPrefs is null).
+  await page.locator("html[data-ft-ready]").waitFor({ timeout: 10_000 });
+
+  const searchInput = page.locator("#search-input");
+  await searchInput.fill("s report");
+  await page.keyboard.press("Enter");
+
+  // The local-search container is lazily created + made visible on openLocalSearch().
+  // Wait for it to appear in the DOM and not have the "hidden" class.
+  await page.waitForSelector("#ls-container:not(.hidden)", { timeout: 15_000 });
+
+  // The results list should contain the three canned file names.
+  const list = page.locator("#ls-list");
+  await expect(list).toBeVisible({ timeout: 10_000 });
+
+  const primaryItems = list.locator(".ls-result-primary");
+  await expect(primaryItems).toHaveCount(3, { timeout: 10_000 });
+
+  const names = await primaryItems.allTextContents();
+  expect(names).toContain("report-2024.pdf");
+  expect(names).toContain("report-draft.docx");
+  expect(names).toContain("quarterly-report.xlsx");
+
+  // Toolbar must be present.
+  const toolbar = page.locator("#ls-toolbar");
+  await expect(toolbar).toBeVisible();
+
+  // Footer shows result count.
+  const footer = page.locator("#ls-footer");
+  await expect(footer).toBeVisible();
+  await expect(footer).toContainText("3 results");
+
+  await page.screenshot({ path: `${SCREENSHOTS}/local-search-b1-results.png` });
+  await page.close();
+});
+
+// ── Step C: Interactions ──────────────────────────────────────────────────────
+
+test("Step C: view toggle, sort change, and file open", async ({ context, extensionId }) => {
+  // Inject paired prefs.
+  const prePage = await context.newPage();
+  await prePage.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await injectPrefs(prePage, PAIRED_PREFS);
+  await prePage.close();
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
+  await page.locator("html[data-ft-ready]").waitFor({ timeout: 10_000 });
+
+  // Trigger local search.
+  await page.locator("#search-input").fill("s report");
+  await page.keyboard.press("Enter");
+
+  await page.waitForSelector("#ls-container:not(.hidden)", { timeout: 15_000 });
+
+  // Wait for results.
+  const list = page.locator("#ls-list");
+  await expect(list.locator(".ls-result-primary")).toHaveCount(3, { timeout: 10_000 });
+
+  const searchCountBefore = getSearchCallCount();
+
+  // ── View toggle: list → grid ─────────────────────────────────────────────
+
+  const gridBtn = page.locator('[data-view="grid"]');
+  await expect(gridBtn).toBeVisible();
+  await gridBtn.click();
+
+  // The list's data-view attribute should update to "grid".
+  await expect(list).toHaveAttribute("data-view", "grid", { timeout: 5_000 });
+
+  // Results should still be present (re-render without a new search request).
+  await expect(list.locator(".ls-result-primary")).toHaveCount(3);
+
+  await page.screenshot({ path: `${SCREENSHOTS}/local-search-c1-grid.png` });
+
+  // ── Sort change: triggers a new search ───────────────────────────────────
+
+  const sortField = page.locator(".ls-sort-field");
+  await expect(sortField).toBeVisible();
+  await sortField.selectOption("modified");
+
+  // Wait for a new search request to fire.
+  await expect
+    .poll(() => getSearchCallCount(), { timeout: 8_000, intervals: [200] })
+    .toBeGreaterThan(searchCountBefore);
+
+  // Results repopulate.
+  await expect(list.locator(".ls-result-primary")).toHaveCount(3, { timeout: 8_000 });
+
+  const lastSearch = getLastSearchBody() as Record<string, unknown>;
+  expect(lastSearch?.sort).toMatchObject({ field: "modified" });
+
+  await page.screenshot({ path: `${SCREENSHOTS}/local-search-c2-sort.png` });
+
+  // ── File open: clicking a row calls /v1/open ──────────────────────────────
+
+  const openCountBefore = getOpenCallCount();
+
+  const firstRow = list.locator(".ls-result-row").first();
+  await expect(firstRow).toBeVisible();
+  await firstRow.click();
+
+  // Wait for the open RPC to fire.
+  await expect
+    .poll(() => getOpenCallCount(), { timeout: 8_000, intervals: [200] })
+    .toBeGreaterThan(openCountBefore);
+
+  expect(getLastOpenPath()).toBe("/home/user/docs/report-2024.pdf");
+
+  await page.screenshot({ path: `${SCREENSHOTS}/local-search-c3-open.png` });
+
+  await page.close();
+});

--- a/extension/tests/setup.ts
+++ b/extension/tests/setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Global test environment setup — runs before any test file's imports are
+ * resolved. Provides a minimal chrome stub so modules that access
+ * chrome.storage / chrome.storage.onChanged at module load time (e.g.
+ * ui/favicon.ts) don't throw in the Node/Vitest environment.
+ *
+ * Individual tests override chrome.storage.local via installMockStorage() in
+ * their beforeEach hooks to get per-test isolation and the _backing inspector.
+ */
+(globalThis as unknown as Record<string, unknown>).chrome = {
+  storage: {
+    local: {
+      get: async () => ({}),
+      set: async () => {},
+      remove: async () => {},
+    },
+    onChanged: {
+      addListener: () => {},
+      removeListener: () => {},
+    },
+  },
+  runtime: {
+    sendMessage: async () => undefined,
+  },
+};

--- a/extension/tests/unit/companion-client.test.ts
+++ b/extension/tests/unit/companion-client.test.ts
@@ -10,7 +10,7 @@
  * that discover()'s prefs read/write does not require a real extension context.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   discover,
   pair,
@@ -21,33 +21,10 @@ import {
   DISCOVERY_PORTS,
 } from "../../src/core/companion-client.js";
 import type { PingResponse, SearchRequest } from "../../src/core/companion-types.js";
-
-// ── Storage mock ─────────────────────────────────────────────────────────────
-
-function mockStorage(initial: Record<string, unknown> = {}) {
-  const backing: Record<string, unknown> = { ...initial };
-  return {
-    get: async (keys: string | string[]) => {
-      const want = Array.isArray(keys) ? keys : [keys];
-      const out: Record<string, unknown> = {};
-      for (const k of want) if (k in backing) out[k] = backing[k];
-      return out;
-    },
-    set: async (obj: Record<string, unknown>) => {
-      Object.assign(backing, obj);
-    },
-    remove: async (k: string | string[]) => {
-      for (const key of Array.isArray(k) ? k : [k]) delete backing[key];
-    },
-    _backing: backing,
-  };
-}
-
-function installStorage(initial: Record<string, unknown> = {}) {
-  const storage = mockStorage(initial);
-  (globalThis as unknown as { chrome: unknown }).chrome = { storage: { local: storage } };
-  return storage;
-}
+import {
+  installMockStorage as installStorage,
+  type MockStorage,
+} from "./helpers/mock-storage.js";
 
 // ── Fetch stub helpers ───────────────────────────────────────────────────────
 
@@ -383,12 +360,38 @@ describe("search", () => {
     expect(capturedBody).toEqual(SEARCH_REQ);
   });
 
-  it("token is sent only in Authorization header, not logged or thrown", async () => {
-    // Structural: verify token does not appear in any thrown error message
-    // on an ordinary 200 response. The body test above confirms the header path.
-    stubFetch(async () => new Response(JSON.stringify(SEARCH_RESP), { status: 200 }));
-    // No assertions needed — test passes if no error is thrown with token in it.
-    await search(7333, "secret-token", SEARCH_REQ);
+  it("token is never logged or leaked into error messages", async () => {
+    const SECRET = "super-secret-bearer-token";
+
+    // Spy on every console method to capture any logged output.
+    const consoleMethods = ["log", "error", "warn", "info", "debug"] as const;
+    const spies = consoleMethods.map((m) => vi.spyOn(console, m).mockImplementation(() => {}));
+
+    try {
+      // Happy path: 200 — token must not appear in any console output.
+      stubFetch(async () => new Response(JSON.stringify(SEARCH_RESP), { status: 200 }));
+      await search(7333, SECRET, SEARCH_REQ);
+
+      // Error path: 401 — token must not appear in the thrown error message.
+      stubFetch(async () => new Response(null, { status: 401 }));
+      let thrownMessage = "";
+      try {
+        await search(7333, SECRET, SEARCH_REQ);
+      } catch (e) {
+        thrownMessage = (e as Error).message;
+      }
+      expect(thrownMessage).not.toContain(SECRET);
+
+      // Verify no console call contained the token.
+      const allCalls = spies.flatMap((spy) =>
+        (spy.mock.calls as unknown[][]).map((args) => args.join(" ")),
+      );
+      for (const call of allCalls) {
+        expect(call).not.toContain(SECRET);
+      }
+    } finally {
+      spies.forEach((spy) => spy.mockRestore());
+    }
   });
 
   it("401 → CompanionError with code unauthorized", async () => {
@@ -528,6 +531,19 @@ describe("openFile", () => {
     } catch (e) {
       expect(e).toBeInstanceOf(CompanionError);
       expect((e as CompanionError).code).toBe("unauthorized");
+    }
+  });
+
+  it("401 without body → CompanionError with code unauthorized (fallback)", async () => {
+    stubFetch(async () => new Response(null, { status: 401 }));
+
+    try {
+      await openFile(7333, "bad", "/path");
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("unauthorized");
+      expect((e as CompanionError).message).toBe("Unauthorized");
     }
   });
 });

--- a/extension/tests/unit/companion-client.test.ts
+++ b/extension/tests/unit/companion-client.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Unit tests for companion-client.ts.
+ *
+ * All network I/O is intercepted by replacing globalThis.fetch with a stub.
+ * AbortController is the real browser global (Node 18+ supplies it); we do not
+ * need to mock it — mocked fetch throws / resolves before the abort timer fires,
+ * and clearTimeout() cancels the timer in the finally block.
+ *
+ * chrome.storage.local is mocked (same helper as auto-ignore-store.test.ts) so
+ * that discover()'s prefs read/write does not require a real extension context.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  discover,
+  pair,
+  openPairingWindow,
+  search,
+  openFile,
+  CompanionError,
+  DISCOVERY_PORTS,
+} from "../../src/core/companion-client.js";
+import type { PingResponse, SearchRequest } from "../../src/core/companion-types.js";
+
+// ── Storage mock ─────────────────────────────────────────────────────────────
+
+function mockStorage(initial: Record<string, unknown> = {}) {
+  const backing: Record<string, unknown> = { ...initial };
+  return {
+    get: async (keys: string | string[]) => {
+      const want = Array.isArray(keys) ? keys : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of want) if (k in backing) out[k] = backing[k];
+      return out;
+    },
+    set: async (obj: Record<string, unknown>) => {
+      Object.assign(backing, obj);
+    },
+    remove: async (k: string | string[]) => {
+      for (const key of Array.isArray(k) ? k : [k]) delete backing[key];
+    },
+    _backing: backing,
+  };
+}
+
+function installStorage(initial: Record<string, unknown> = {}) {
+  const storage = mockStorage(initial);
+  (globalThis as unknown as { chrome: unknown }).chrome = { storage: { local: storage } };
+  return storage;
+}
+
+// ── Fetch stub helpers ───────────────────────────────────────────────────────
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+function stubFetch(fn: FetchFn) {
+  (globalThis as unknown as { fetch: FetchFn }).fetch = fn;
+}
+
+function restoreFetch() {
+  delete (globalThis as unknown as Record<string, unknown>).fetch;
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PING: PingResponse = {
+  name: "fast-travel-companion",
+  version: "1.0.0",
+  protocolVersion: 1,
+  os: "linux",
+  paired: false,
+  pairingOpen: false,
+  defaultIndexer: "baloo",
+  indexers: [],
+};
+
+const SEARCH_REQ: SearchRequest = {
+  query: "report",
+  queryMode: "simple",
+  sort: { field: "relevance", dir: "desc" },
+  filters: {},
+  page: 0,
+  pageSize: 20,
+};
+
+const SEARCH_RESP = {
+  results: [],
+  total: 0,
+  page: 0,
+  tookMs: 3,
+  indexer: "baloo",
+};
+
+// ── discover() ───────────────────────────────────────────────────────────────
+
+describe("discover", () => {
+  beforeEach(() => {
+    installStorage(); // empty → no cached port → full scan
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("returns first responding port (7333)", async () => {
+    let callCount = 0;
+    stubFetch(async (url) => {
+      callCount++;
+      if (url.includes(":7333/")) {
+        return new Response(JSON.stringify(PING), { status: 200 });
+      }
+      // Should not reach here for the first-port-succeeds case
+      throw new Error(`Unexpected probe of ${url}`);
+    });
+
+    const result = await discover();
+
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(7333);
+    expect(result!.ping).toEqual(PING);
+    expect(callCount).toBe(1);
+  });
+
+  it("skips the first port and returns the second when 7333 fails", async () => {
+    stubFetch(async (url) => {
+      if (url.includes(":7334/")) {
+        return new Response(JSON.stringify(PING), { status: 200 });
+      }
+      throw new Error("port unreachable");
+    });
+
+    const result = await discover();
+
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(7334);
+  });
+
+  it("returns null when all ports fail", async () => {
+    stubFetch(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    const result = await discover();
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when all ports return non-ok HTTP status", async () => {
+    stubFetch(async () => new Response(null, { status: 503 }));
+
+    const result = await discover();
+
+    expect(result).toBeNull();
+  });
+
+  it("scans all DISCOVERY_PORTS (11 ports, 7333–7343) before giving up", async () => {
+    const probed: number[] = [];
+    stubFetch(async (url) => {
+      const match = url.match(/:(\d+)\//);
+      if (match) probed.push(parseInt(match[1], 10));
+      throw new Error("unreachable");
+    });
+
+    await discover();
+
+    expect(probed).toEqual([...DISCOVERY_PORTS]);
+  });
+
+  it("uses cached port first, skipping full scan", async () => {
+    // Pre-populate storage with a cached port
+    const cachedPort = 7337;
+    installStorage({
+      "fast-travel-local-search-prefs": {
+        enabled: false,
+        queryMode: "simple",
+        sort: { field: "relevance", dir: "desc" },
+        filters: {},
+        view: "list",
+        port: cachedPort,
+      },
+    });
+
+    let callCount = 0;
+    stubFetch(async (url) => {
+      callCount++;
+      if (url.includes(`:${cachedPort}/`)) {
+        return new Response(JSON.stringify(PING), { status: 200 });
+      }
+      throw new Error("should not probe other ports");
+    });
+
+    const result = await discover();
+
+    expect(result!.port).toBe(cachedPort);
+    expect(callCount).toBe(1); // only the cached port was tried
+  });
+
+  it("falls back to full scan when cached port fails", async () => {
+    installStorage({
+      "fast-travel-local-search-prefs": {
+        enabled: false,
+        queryMode: "simple",
+        sort: { field: "relevance", dir: "desc" },
+        filters: {},
+        view: "list",
+        port: 7337, // cached but dead
+      },
+    });
+
+    stubFetch(async (url) => {
+      if (url.includes(":7333/")) {
+        return new Response(JSON.stringify(PING), { status: 200 });
+      }
+      throw new Error("unreachable");
+    });
+
+    const result = await discover();
+
+    expect(result!.port).toBe(7333);
+  });
+});
+
+// ── pair() ───────────────────────────────────────────────────────────────────
+
+describe("pair", () => {
+  beforeEach(() => {
+    installStorage();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("POSTs {clientName} to /v1/pair and returns the token", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit = {};
+
+    stubFetch(async (url, init = {}) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return new Response(JSON.stringify({ token: "tok-abc123" }), { status: 200 });
+    });
+
+    const token = await pair(7333, "Fast Travel (Chrome)");
+
+    expect(token).toBe("tok-abc123");
+    expect(capturedUrl).toBe("http://127.0.0.1:7333/v1/pair");
+    expect(capturedInit.method).toBe("POST");
+    expect(JSON.parse(capturedInit.body as string)).toEqual({
+      clientName: "Fast Travel (Chrome)",
+    });
+  });
+
+  it("403 response → CompanionError with code pairing_closed", async () => {
+    stubFetch(async () =>
+      new Response(
+        JSON.stringify({ error: "pairing_closed", message: "Pairing window is closed" }),
+        { status: 403 },
+      ),
+    );
+
+    try {
+      await pair(7333, "X");
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("pairing_closed");
+      expect((e as CompanionError).errorResponse?.error).toBe("pairing_closed");
+    }
+  });
+
+  it("403 without body → CompanionError with code pairing_closed (fallback)", async () => {
+    stubFetch(async () => new Response(null, { status: 403 }));
+
+    try {
+      await pair(7333, "X");
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("pairing_closed");
+    }
+  });
+
+  it("network failure → CompanionError with code network", async () => {
+    stubFetch(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    try {
+      await pair(7333, "X");
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("network");
+    }
+  });
+
+  it("other non-ok status → CompanionError with server error code", async () => {
+    stubFetch(async () =>
+      new Response(
+        JSON.stringify({ error: "internal", message: "Unexpected error" }),
+        { status: 500 },
+      ),
+    );
+
+    try {
+      await pair(7333, "X");
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("internal");
+    }
+  });
+});
+
+// ── openPairingWindow() ──────────────────────────────────────────────────────
+
+describe("openPairingWindow", () => {
+  beforeEach(() => {
+    installStorage();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("POSTs to /v1/pairing/open and resolves on 200", async () => {
+    let capturedUrl = "";
+    stubFetch(async (url) => {
+      capturedUrl = url;
+      return new Response(null, { status: 200 });
+    });
+
+    await expect(openPairingWindow(7333)).resolves.toBeUndefined();
+    expect(capturedUrl).toBe("http://127.0.0.1:7333/v1/pairing/open");
+  });
+
+  it("network failure → CompanionError with code network", async () => {
+    stubFetch(async () => {
+      throw new Error("network");
+    });
+
+    try {
+      await openPairingWindow(7333);
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("network");
+    }
+  });
+});
+
+// ── search() ─────────────────────────────────────────────────────────────────
+
+describe("search", () => {
+  beforeEach(() => {
+    installStorage();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("sends Authorization: Bearer header and POST body, returns SearchResponse", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Record<string, string> = {};
+    let capturedBody: unknown;
+
+    stubFetch(async (url, init = {}) => {
+      capturedUrl = url;
+      capturedHeaders = Object.fromEntries(
+        new Headers(init.headers as HeadersInit).entries(),
+      );
+      capturedBody = JSON.parse(init.body as string);
+      return new Response(JSON.stringify(SEARCH_RESP), { status: 200 });
+    });
+
+    const result = await search(7333, "tok-xyz", SEARCH_REQ);
+
+    expect(result).toEqual(SEARCH_RESP);
+    expect(capturedUrl).toBe("http://127.0.0.1:7333/v1/search");
+    expect(capturedHeaders["authorization"]).toBe("Bearer tok-xyz");
+    expect(capturedBody).toEqual(SEARCH_REQ);
+  });
+
+  it("token is sent only in Authorization header, not logged or thrown", async () => {
+    // Structural: verify token does not appear in any thrown error message
+    // on an ordinary 200 response. The body test above confirms the header path.
+    stubFetch(async () => new Response(JSON.stringify(SEARCH_RESP), { status: 200 }));
+    // No assertions needed — test passes if no error is thrown with token in it.
+    await search(7333, "secret-token", SEARCH_REQ);
+  });
+
+  it("401 → CompanionError with code unauthorized", async () => {
+    stubFetch(async () =>
+      new Response(
+        JSON.stringify({ error: "unauthorized", message: "Invalid token" }),
+        { status: 401 },
+      ),
+    );
+
+    try {
+      await search(7333, "bad-token", SEARCH_REQ);
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("unauthorized");
+    }
+  });
+
+  it("401 without body → CompanionError with code unauthorized (fallback)", async () => {
+    stubFetch(async () => new Response(null, { status: 401 }));
+
+    try {
+      await search(7333, "bad-token", SEARCH_REQ);
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("unauthorized");
+      expect((e as CompanionError).message).toBe("Unauthorized");
+    }
+  });
+
+  it("503 → CompanionError with code indexer_unavailable", async () => {
+    stubFetch(async () =>
+      new Response(
+        JSON.stringify({ error: "indexer_unavailable", message: "Baloo not running" }),
+        { status: 503 },
+      ),
+    );
+
+    try {
+      await search(7333, "tok", SEARCH_REQ);
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("indexer_unavailable");
+    }
+  });
+
+  it("network failure → CompanionError with code network", async () => {
+    stubFetch(async () => {
+      throw new Error("fetch failed");
+    });
+
+    try {
+      await search(7333, "tok", SEARCH_REQ);
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("network");
+    }
+  });
+});
+
+// ── openFile() ───────────────────────────────────────────────────────────────
+
+describe("openFile", () => {
+  beforeEach(() => {
+    installStorage();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("POSTs {path} to /v1/open without reveal when reveal=false (default)", async () => {
+    let capturedBody: unknown;
+    stubFetch(async (_url, init = {}) => {
+      capturedBody = JSON.parse(init.body as string);
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    await openFile(7333, "tok", "/home/alice/doc.pdf");
+
+    expect(capturedBody).toEqual({ path: "/home/alice/doc.pdf" });
+  });
+
+  it("POSTs {path, reveal:true} when reveal=true", async () => {
+    let capturedBody: unknown;
+    stubFetch(async (_url, init = {}) => {
+      capturedBody = JSON.parse(init.body as string);
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    await openFile(7333, "tok", "/home/alice/doc.pdf", true);
+
+    expect(capturedBody).toEqual({ path: "/home/alice/doc.pdf", reveal: true });
+  });
+
+  it("sends Authorization: Bearer header", async () => {
+    let authHeader = "";
+    stubFetch(async (_url, init = {}) => {
+      authHeader = new Headers(init.headers as HeadersInit).get("authorization") ?? "";
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    await openFile(7333, "tok-open", "/some/path");
+
+    expect(authHeader).toBe("Bearer tok-open");
+  });
+
+  it("network failure → CompanionError with code network", async () => {
+    stubFetch(async () => {
+      throw new Error("ECONNRESET");
+    });
+
+    try {
+      await openFile(7333, "tok", "/path");
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("network");
+    }
+  });
+
+  it("401 → CompanionError with code unauthorized", async () => {
+    stubFetch(async () =>
+      new Response(
+        JSON.stringify({ error: "unauthorized", message: "Bad token" }),
+        { status: 401 },
+      ),
+    );
+
+    try {
+      await openFile(7333, "bad", "/path");
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CompanionError);
+      expect((e as CompanionError).code).toBe("unauthorized");
+    }
+  });
+});

--- a/extension/tests/unit/companion-client.test.ts
+++ b/extension/tests/unit/companion-client.test.ts
@@ -19,6 +19,7 @@ import {
   openFile,
   CompanionError,
   DISCOVERY_PORTS,
+  MIN_PROTOCOL_VERSION,
 } from "../../src/core/companion-client.js";
 import type { PingResponse, SearchRequest } from "../../src/core/companion-types.js";
 import {
@@ -193,6 +194,38 @@ describe("discover", () => {
 
     const result = await discover();
 
+    expect(result!.port).toBe(7333);
+  });
+
+  it("returns null when companion protocolVersion is below MIN_PROTOCOL_VERSION", async () => {
+    // Companion responds with a protocolVersion below the minimum — even though
+    // the HTTP call succeeded, discover() must treat it as not usable (returns null).
+    const oldPing: PingResponse = { ...PING, protocolVersion: MIN_PROTOCOL_VERSION - 1 };
+    stubFetch(async (url) => {
+      if (url.includes(":7333/")) {
+        return new Response(JSON.stringify(oldPing), { status: 200 });
+      }
+      throw new Error("port unreachable");
+    });
+
+    const result = await discover();
+
+    expect(result).toBeNull();
+  });
+
+  it("accepts companion with exactly MIN_PROTOCOL_VERSION", async () => {
+    // Companion at exactly the minimum version must be accepted.
+    const minPing: PingResponse = { ...PING, protocolVersion: MIN_PROTOCOL_VERSION };
+    stubFetch(async (url) => {
+      if (url.includes(":7333/")) {
+        return new Response(JSON.stringify(minPing), { status: 200 });
+      }
+      throw new Error("port unreachable");
+    });
+
+    const result = await discover();
+
+    expect(result).not.toBeNull();
     expect(result!.port).toBe(7333);
   });
 });

--- a/extension/tests/unit/file-type-icon.test.ts
+++ b/extension/tests/unit/file-type-icon.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for extension/src/newtab/file-type-icon.ts
+ *
+ * Covers the pure fileTypeIconDescriptor function:
+ *   - each of the 8 FileType categories maps to a distinct iconId
+ *   - each category yields a distinct fillVar (no two categories share the same background tint)
+ *   - unknown type → "other" (unknown-type fallback)
+ *   - ext argument is accepted (future extensibility) without breaking results
+ *
+ * No DOM or chrome.storage interaction — all helpers under test are pure.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  fileTypeIconDescriptor,
+  type FileTypeIconDescriptor,
+} from "../../src/newtab/file-type-icon.js";
+import type { FileType } from "../../src/core/companion-types.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ALL_TYPES: FileType[] = [
+  "document",
+  "image",
+  "video",
+  "audio",
+  "archive",
+  "code",
+  "folder",
+  "other",
+];
+
+// ── fileTypeIconDescriptor — per-category mapping ─────────────────────────────
+
+describe("fileTypeIconDescriptor", () => {
+  // --- each known type resolves to the correct iconId ------------------------
+
+  it.each(ALL_TYPES)("type '%s' → iconId matches", (type) => {
+    const result = fileTypeIconDescriptor(type);
+    expect(result.iconId).toBe(type);
+  });
+
+  // --- all 8 iconIds are distinct -------------------------------------------
+
+  it("all 8 categories yield distinct iconIds", () => {
+    const ids = ALL_TYPES.map((t) => fileTypeIconDescriptor(t).iconId);
+    expect(new Set(ids).size).toBe(ALL_TYPES.length);
+  });
+
+  // --- all 8 fillVars are distinct (no two categories share a background) ---
+
+  it("all 8 categories yield distinct fillVar tints", () => {
+    const fills = ALL_TYPES.map((t) => fileTypeIconDescriptor(t).fillVar);
+    expect(new Set(fills).size).toBe(ALL_TYPES.length);
+  });
+
+  // --- all 8 fgVars are distinct -------------------------------------------
+
+  it("all 8 categories yield distinct fgVar tints", () => {
+    const fgs = ALL_TYPES.map((t) => fileTypeIconDescriptor(t).fgVar);
+    expect(new Set(fgs).size).toBe(ALL_TYPES.length);
+  });
+
+  // --- fillVar and fgVar reference CSS custom properties -------------------
+
+  it.each(ALL_TYPES)("type '%s' fillVar is a CSS custom property", (type) => {
+    const { fillVar } = fileTypeIconDescriptor(type);
+    expect(fillVar).toMatch(/^var\(--tint-/);
+  });
+
+  it.each(ALL_TYPES)("type '%s' fgVar is a CSS custom property", (type) => {
+    const { fgVar } = fileTypeIconDescriptor(type);
+    expect(fgVar).toMatch(/^var\(--tint-/);
+  });
+
+  // --- unknown type → "other" fallback ------------------------------------
+
+  it("completely unknown type string → iconId 'other'", () => {
+    const result = fileTypeIconDescriptor("spreadsheet");
+    expect(result.iconId).toBe("other");
+  });
+
+  it("empty string type → iconId 'other'", () => {
+    const result = fileTypeIconDescriptor("");
+    expect(result.iconId).toBe("other");
+  });
+
+  it("unknown type → fillVar matches 'other' tint", () => {
+    const unknown = fileTypeIconDescriptor("binary");
+    const other = fileTypeIconDescriptor("other");
+    expect(unknown.fillVar).toBe(other.fillVar);
+    expect(unknown.fgVar).toBe(other.fgVar);
+  });
+
+  // --- ext argument is accepted without altering type-level result ---------
+
+  it("passing an ext does not change the type-level result for known types", () => {
+    const withExt = fileTypeIconDescriptor("document", "pdf");
+    const withoutExt = fileTypeIconDescriptor("document");
+    const result: FileTypeIconDescriptor = withExt;
+    expect(result.iconId).toBe(withoutExt.iconId);
+    expect(result.fillVar).toBe(withoutExt.fillVar);
+    expect(result.fgVar).toBe(withoutExt.fgVar);
+  });
+
+  it("passing an ext to unknown type still falls back to 'other'", () => {
+    const result = fileTypeIconDescriptor("binary", "exe");
+    expect(result.iconId).toBe("other");
+  });
+
+  // --- spot checks for individual type tints (human-readable assertions) ---
+
+  it("folder uses amber tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("folder");
+    expect(fillVar).toContain("amber");
+    expect(fgVar).toContain("amber");
+  });
+
+  it("image uses green tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("image");
+    expect(fillVar).toContain("green");
+    expect(fgVar).toContain("green");
+  });
+
+  it("video uses purple tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("video");
+    expect(fillVar).toContain("purple");
+    expect(fgVar).toContain("purple");
+  });
+
+  it("audio uses cyan tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("audio");
+    expect(fillVar).toContain("cyan");
+    expect(fgVar).toContain("cyan");
+  });
+
+  it("archive uses orange tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("archive");
+    expect(fillVar).toContain("orange");
+    expect(fgVar).toContain("orange");
+  });
+
+  it("code uses blue tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("code");
+    expect(fillVar).toContain("blue");
+    expect(fgVar).toContain("blue");
+  });
+
+  it("document uses red tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("document");
+    expect(fillVar).toContain("red");
+    expect(fgVar).toContain("red");
+  });
+
+  it("other uses neutral tint", () => {
+    const { fillVar, fgVar } = fileTypeIconDescriptor("other");
+    expect(fillVar).toContain("neutral");
+    expect(fgVar).toContain("neutral");
+  });
+
+  // --- return type is stable -----------------------------------------------
+
+  it("same inputs always yield the same descriptor (referentially stable values)", () => {
+    const a = fileTypeIconDescriptor("code", "ts");
+    const b = fileTypeIconDescriptor("code", "ts");
+    expect(a.iconId).toBe(b.iconId);
+    expect(a.fillVar).toBe(b.fillVar);
+    expect(a.fgVar).toBe(b.fgVar);
+  });
+});

--- a/extension/tests/unit/helpers/mock-storage.ts
+++ b/extension/tests/unit/helpers/mock-storage.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared chrome.storage.local mock for unit tests.
+ *
+ * Usage:
+ *   import { installMockStorage, type MockStorage } from "./helpers/mock-storage.js";
+ *
+ *   let storage: MockStorage;
+ *   beforeEach(() => { storage = installMockStorage(); });
+ */
+
+export function mockStorage(initial: Record<string, unknown> = {}) {
+  const backing: Record<string, unknown> = { ...initial };
+  return {
+    get: async (keys: string | string[]) => {
+      const want = Array.isArray(keys) ? keys : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of want) if (k in backing) out[k] = backing[k];
+      return out;
+    },
+    set: async (obj: Record<string, unknown>) => {
+      Object.assign(backing, obj);
+    },
+    remove: async (k: string | string[]) => {
+      for (const key of Array.isArray(k) ? k : [k]) delete backing[key];
+    },
+    _backing: backing,
+  };
+}
+
+export type MockStorage = ReturnType<typeof mockStorage>;
+
+/**
+ * Create a fresh storage mock and wire it into globalThis.chrome.storage.local.
+ * Call this in beforeEach to get a clean slate for each test.
+ */
+export function installMockStorage(initial: Record<string, unknown> = {}): MockStorage {
+  const storage = mockStorage(initial);
+  (globalThis as unknown as { chrome: unknown }).chrome = { storage: { local: storage } };
+  return storage;
+}

--- a/extension/tests/unit/local-search-results.test.ts
+++ b/extension/tests/unit/local-search-results.test.ts
@@ -16,6 +16,7 @@ import {
   buildSearchRequest,
   navDown,
   navUp,
+  formatDate,
 } from "../../src/newtab/local-search-results.js";
 import type { LocalSearchPrefs } from "../../src/core/local-search-store.js";
 import type { FastTravelConfig } from "../../src/core/types.js";
@@ -305,5 +306,36 @@ describe("navUp", () => {
   it("works correctly with total=1", () => {
     expect(navUp(0, 1)).toBe(-1);
     expect(navUp(-1, 1)).toBe(-1);
+  });
+});
+
+// ── formatDate ────────────────────────────────────────────────────────────────
+
+describe("formatDate", () => {
+  it("returns '—' for ts=0 (unknown timestamp)", () => {
+    expect(formatDate(0)).toBe("—");
+  });
+
+  it("returns 'just now' for a timestamp 30 seconds ago (ms)", () => {
+    const ts = Date.now() - 30_000;
+    expect(formatDate(ts)).toBe("just now");
+  });
+
+  it("returns 'Xd ago' for a timestamp a few days ago (ms) — not a 1970 date", () => {
+    const threeDaysAgoMs = Date.now() - 3 * 24 * 60 * 60 * 1_000;
+    const result = formatDate(threeDaysAgoMs);
+    expect(result).toBe("3d ago");
+  });
+
+  it("returns a locale date string (not 1/1/1970) for a timestamp older than 7 days (ms)", () => {
+    const tenDaysAgoMs = Date.now() - 10 * 24 * 60 * 60 * 1_000;
+    const result = formatDate(tenDaysAgoMs);
+    expect(result).not.toBe("1/1/1970");
+    // Must contain the current year (or last year near year boundaries)
+    const currentYear = new Date().getFullYear();
+    const containsYear =
+      result.includes(String(currentYear)) ||
+      result.includes(String(currentYear - 1));
+    expect(containsYear).toBe(true);
   });
 });

--- a/extension/tests/unit/local-search-results.test.ts
+++ b/extension/tests/unit/local-search-results.test.ts
@@ -238,6 +238,68 @@ describe("buildSearchRequest", () => {
     const req = buildSearchRequest(PREFS_ENABLED, "q");
     expect(req.history).toBeUndefined();
   });
+
+  // Extended filter fields (Phase 3b)
+
+  it("carries pathPrefix from prefs.filters when set", () => {
+    const prefs: LocalSearchPrefs = {
+      ...PREFS_ENABLED,
+      filters: { pathPrefix: "/home/user/Documents" },
+    };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.filters.pathPrefix).toBe("/home/user/Documents");
+  });
+
+  it("carries modifiedRange from prefs.filters when set (epoch ms)", () => {
+    const range = { from: 1_700_000_000_000 };
+    const prefs: LocalSearchPrefs = {
+      ...PREFS_ENABLED,
+      filters: { modifiedRange: range },
+    };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.filters.modifiedRange).toEqual(range);
+  });
+
+  it("carries createdRange from prefs.filters when set (epoch ms)", () => {
+    const range = { from: 1_680_000_000_000, to: 1_700_000_000_000 };
+    const prefs: LocalSearchPrefs = {
+      ...PREFS_ENABLED,
+      filters: { createdRange: range },
+    };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.filters.createdRange).toEqual(range);
+  });
+
+  it("omits pathPrefix from filters when not set in prefs", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", []);
+    expect(req.filters.pathPrefix).toBeUndefined();
+  });
+
+  it("omits modifiedRange from filters when not set in prefs", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", []);
+    expect(req.filters.modifiedRange).toBeUndefined();
+  });
+
+  it("carries all extended filter fields simultaneously", () => {
+    const modRange = { from: 1_690_000_000_000 };
+    const crRange = { from: 1_680_000_000_000 };
+    const prefs: LocalSearchPrefs = {
+      ...PREFS_ENABLED,
+      filters: {
+        types: ["document"],
+        pathPrefix: "/home/user",
+        modifiedRange: modRange,
+        createdRange: crRange,
+        titleOnly: true,
+      },
+    };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.filters.types).toEqual(["document"]);
+    expect(req.filters.pathPrefix).toBe("/home/user");
+    expect(req.filters.modifiedRange).toEqual(modRange);
+    expect(req.filters.createdRange).toEqual(crRange);
+    expect(req.filters.titleOnly).toBe(true);
+  });
 });
 
 // ── navDown ───────────────────────────────────────────────────────────────────

--- a/extension/tests/unit/local-search-results.test.ts
+++ b/extension/tests/unit/local-search-results.test.ts
@@ -305,6 +305,39 @@ describe("buildSearchRequest", () => {
     expect(req.filters.createdRange).toEqual(crRange);
     expect(req.filters.titleOnly).toBe(true);
   });
+
+  // caseSensitive + exactPhrase (Phase 6b)
+
+  it("includes caseSensitive: false when prefs use the default", () => {
+    const prefs: LocalSearchPrefs = { ...PREFS_ENABLED, caseSensitive: false, exactPhrase: false };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.caseSensitive).toBe(false);
+  });
+
+  it("includes exactPhrase: false when prefs use the default", () => {
+    const prefs: LocalSearchPrefs = { ...PREFS_ENABLED, caseSensitive: false, exactPhrase: false };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.exactPhrase).toBe(false);
+  });
+
+  it("passes caseSensitive: true from prefs", () => {
+    const prefs: LocalSearchPrefs = { ...PREFS_ENABLED, caseSensitive: true, exactPhrase: false };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.caseSensitive).toBe(true);
+  });
+
+  it("passes exactPhrase: true from prefs", () => {
+    const prefs: LocalSearchPrefs = { ...PREFS_ENABLED, caseSensitive: false, exactPhrase: true };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.exactPhrase).toBe(true);
+  });
+
+  it("passes both caseSensitive and exactPhrase simultaneously", () => {
+    const prefs: LocalSearchPrefs = { ...PREFS_ENABLED, caseSensitive: true, exactPhrase: true };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.caseSensitive).toBe(true);
+    expect(req.exactPhrase).toBe(true);
+  });
 });
 
 // ── navDown ───────────────────────────────────────────────────────────────────

--- a/extension/tests/unit/local-search-results.test.ts
+++ b/extension/tests/unit/local-search-results.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Unit tests for the pure helpers in newtab/local-search-results.ts.
+ *
+ * Covers:
+ *   - shouldInterceptLocalSearch: all guard conditions
+ *   - buildSearchRequest: correct field mapping from prefs + query
+ *   - navDown / navUp: index arithmetic at all boundary conditions
+ *
+ * No DOM or chrome.storage interaction — all helpers under test are pure
+ * functions that take data and return a value.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  shouldInterceptLocalSearch,
+  buildSearchRequest,
+  navDown,
+  navUp,
+} from "../../src/newtab/local-search-results.js";
+import type { LocalSearchPrefs } from "../../src/core/local-search-store.js";
+import type { FastTravelConfig } from "../../src/core/types.js";
+import { installMockStorage } from "./helpers/mock-storage.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PREFS_ENABLED: LocalSearchPrefs = {
+  enabled: true,
+  token: "tok-abc",
+  port: 7333,
+  queryMode: "simple",
+  sort: { field: "relevance", dir: "desc" },
+  filters: {},
+  view: "list",
+};
+
+const PREFS_DISABLED: LocalSearchPrefs = {
+  ...PREFS_ENABLED,
+  enabled: false,
+};
+
+const PREFS_UNPAIRED: LocalSearchPrefs = {
+  ...PREFS_ENABLED,
+  token: undefined,
+};
+
+/** Config with no commands (no "s" trigger). */
+function makeConfig(triggers: string[] = []): FastTravelConfig {
+  return {
+    version: 2,
+    defaultCommand: "g",
+    groups: [
+      {
+        id: "g1",
+        name: "General",
+        commands: triggers.map((t, i) => ({
+          id: `cmd-${i}`,
+          triggers: [t],
+          name: `Command ${t}`,
+          type: "standard" as const,
+          routes: [],
+        })),
+      },
+    ],
+    ignoreList: [],
+  };
+}
+
+const CONFIG_NO_S = makeConfig(["g", "yt", "gh"]);
+const CONFIG_WITH_S = makeConfig(["g", "s", "gh"]);
+
+// ── shouldInterceptLocalSearch ────────────────────────────────────────────────
+
+describe("shouldInterceptLocalSearch", () => {
+  beforeEach(() => {
+    installMockStorage();
+  });
+
+  // -- Positive cases --------------------------------------------------------
+
+  it("intercepts 's' with no query", () => {
+    const result = shouldInterceptLocalSearch("s", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(true);
+    if (result.intercept) expect(result.query).toBe("");
+  });
+
+  it("intercepts 's query' and extracts the trimmed query", () => {
+    const result = shouldInterceptLocalSearch("s hello world", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(true);
+    if (result.intercept) expect(result.query).toBe("hello world");
+  });
+
+  it("intercepts 's  leading-spaces-in-query' trimming the query", () => {
+    const result = shouldInterceptLocalSearch("s   my query  ", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(true);
+    // The raw match captures "my query  " from after "s   ", then we trim
+    if (result.intercept) expect(result.query).toBe("my query");
+  });
+
+  it("intercepts 'S query' (case-insensitive trigger matching)", () => {
+    const result = shouldInterceptLocalSearch("S report", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(true);
+    if (result.intercept) expect(result.query).toBe("report");
+  });
+
+  // -- Guard: disabled -------------------------------------------------------
+
+  it("does NOT intercept when prefs.enabled is false", () => {
+    const result = shouldInterceptLocalSearch("s query", PREFS_DISABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  // -- Guard: unpaired -------------------------------------------------------
+
+  it("does NOT intercept when prefs.token is absent (unpaired)", () => {
+    const result = shouldInterceptLocalSearch("s query", PREFS_UNPAIRED, CONFIG_NO_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  it("does NOT intercept when prefs.token is empty string (treated as absent via falsy check)", () => {
+    const prefs: LocalSearchPrefs = { ...PREFS_ENABLED, token: "" };
+    const result = shouldInterceptLocalSearch("s query", prefs, CONFIG_NO_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  // -- Guard: config has "s" -------------------------------------------------
+
+  it("does NOT intercept when config defines 's' trigger (config command wins)", () => {
+    const result = shouldInterceptLocalSearch("s query", PREFS_ENABLED, CONFIG_WITH_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  it("does NOT intercept when config defines 'S' (uppercase — buildTriggerMap lowercases)", () => {
+    const cfg = makeConfig(["g", "gh"]);
+    cfg.groups[0].commands!.push({
+      id: "cmd-s",
+      triggers: ["S"],
+      name: "Stack Overflow",
+      type: "standard",
+      routes: [],
+    });
+    const result = shouldInterceptLocalSearch("s query", PREFS_ENABLED, cfg);
+    expect(result.intercept).toBe(false);
+  });
+
+  // -- Guard: input doesn't match "s" command --------------------------------
+
+  it("does NOT intercept for a non-'s' trigger (e.g. 'g query')", () => {
+    const result = shouldInterceptLocalSearch("g query", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  it("does NOT intercept for 'search query' (starts with 's' but not the 's' command)", () => {
+    const result = shouldInterceptLocalSearch("search docs", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  it("does NOT intercept for empty input", () => {
+    const result = shouldInterceptLocalSearch("", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  it("does NOT intercept when all guards fail simultaneously (disabled + no token + config-s)", () => {
+    const result = shouldInterceptLocalSearch("s query", PREFS_DISABLED, CONFIG_WITH_S);
+    expect(result.intercept).toBe(false);
+  });
+
+  it("does NOT intercept for 'st query' (trigger is 'st', not 's')", () => {
+    const result = shouldInterceptLocalSearch("st query", PREFS_ENABLED, CONFIG_NO_S);
+    expect(result.intercept).toBe(false);
+  });
+});
+
+// ── buildSearchRequest ────────────────────────────────────────────────────────
+
+describe("buildSearchRequest", () => {
+  it("maps query correctly", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "my query", []);
+    expect(req.query).toBe("my query");
+  });
+
+  it("maps queryMode from prefs", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", []);
+    expect(req.queryMode).toBe("simple");
+  });
+
+  it("maps queryMode wildcard when prefs say wildcard", () => {
+    const prefs: LocalSearchPrefs = { ...PREFS_ENABLED, queryMode: "wildcard" };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.queryMode).toBe("wildcard");
+  });
+
+  it("maps sort field and dir from prefs", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", []);
+    expect(req.sort).toEqual({ field: "relevance", dir: "desc" });
+  });
+
+  it("maps non-default sort correctly", () => {
+    const prefs: LocalSearchPrefs = {
+      ...PREFS_ENABLED,
+      sort: { field: "modified", dir: "asc" },
+    };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.sort).toEqual({ field: "modified", dir: "asc" });
+  });
+
+  it("maps filters from prefs", () => {
+    const prefs: LocalSearchPrefs = {
+      ...PREFS_ENABLED,
+      filters: { types: ["document", "image"], titleOnly: true },
+    };
+    const req = buildSearchRequest(prefs, "q", []);
+    expect(req.filters).toEqual({ types: ["document", "image"], titleOnly: true });
+  });
+
+  it("always sets page=0", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", []);
+    expect(req.page).toBe(0);
+  });
+
+  it("always sets pageSize=50", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", []);
+    expect(req.pageSize).toBe(50);
+  });
+
+  it("omits history field when recentlyOpened is empty", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", []);
+    expect(req.history).toBeUndefined();
+  });
+
+  it("passes recentlyOpened as history when non-empty", () => {
+    const recent = ["id-1", "id-2", "id-3"];
+    const req = buildSearchRequest(PREFS_ENABLED, "q", recent);
+    expect(req.history).toEqual(recent);
+  });
+
+  it("uses empty recentlyOpened by default (no third arg)", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q");
+    expect(req.history).toBeUndefined();
+  });
+});
+
+// ── navDown ───────────────────────────────────────────────────────────────────
+
+describe("navDown", () => {
+  it("returns -1 when total is 0 (nothing to select)", () => {
+    expect(navDown(-1, 0)).toBe(-1);
+    expect(navDown(0, 0)).toBe(-1);
+  });
+
+  it("moves from -1 to 0 (first item) on first down", () => {
+    expect(navDown(-1, 5)).toBe(0);
+  });
+
+  it("moves from 0 to 1", () => {
+    expect(navDown(0, 5)).toBe(1);
+  });
+
+  it("moves from middle to next", () => {
+    expect(navDown(2, 5)).toBe(3);
+  });
+
+  it("clamps at last item (index total-1)", () => {
+    expect(navDown(4, 5)).toBe(4);
+  });
+
+  it("stays at last item if already there", () => {
+    expect(navDown(4, 5)).toBe(4);
+    expect(navDown(9, 10)).toBe(9);
+  });
+
+  it("works correctly with total=1", () => {
+    expect(navDown(-1, 1)).toBe(0);
+    expect(navDown(0, 1)).toBe(0); // clamp at 0
+  });
+});
+
+// ── navUp ─────────────────────────────────────────────────────────────────────
+
+describe("navUp", () => {
+  it("returns -1 when total is 0", () => {
+    expect(navUp(-1, 0)).toBe(-1);
+    expect(navUp(2, 0)).toBe(-1);
+  });
+
+  it("moves from 1 to 0", () => {
+    expect(navUp(1, 5)).toBe(0);
+  });
+
+  it("moves from middle to previous", () => {
+    expect(navUp(3, 5)).toBe(2);
+  });
+
+  it("moves from 0 to -1 (deselects — above the list)", () => {
+    expect(navUp(0, 5)).toBe(-1);
+  });
+
+  it("stays at -1 when already deselected", () => {
+    expect(navUp(-1, 5)).toBe(-1);
+  });
+
+  it("moves from last item upward", () => {
+    expect(navUp(4, 5)).toBe(3);
+  });
+
+  it("works correctly with total=1", () => {
+    expect(navUp(0, 1)).toBe(-1);
+    expect(navUp(-1, 1)).toBe(-1);
+  });
+});

--- a/extension/tests/unit/local-search-results.test.ts
+++ b/extension/tests/unit/local-search-results.test.ts
@@ -17,7 +17,12 @@ import {
   navDown,
   navUp,
   formatDate,
+  hasMore,
+  nextPage,
+  appendResults,
+  resetResults,
 } from "../../src/newtab/local-search-results.js";
+import type { FileResult } from "../../src/core/companion-types.js";
 import type { LocalSearchPrefs } from "../../src/core/local-search-store.js";
 import type { FastTravelConfig } from "../../src/core/types.js";
 import { installMockStorage } from "./helpers/mock-storage.js";
@@ -368,6 +373,164 @@ describe("navUp", () => {
   it("works correctly with total=1", () => {
     expect(navUp(0, 1)).toBe(-1);
     expect(navUp(-1, 1)).toBe(-1);
+  });
+});
+
+// ── buildSearchRequest — page parameter ───────────────────────────────────────
+
+describe("buildSearchRequest — page parameter", () => {
+  it("defaults to page=0 when page arg is omitted", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q");
+    expect(req.page).toBe(0);
+  });
+
+  it("passes explicit page=0", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", [], 0);
+    expect(req.page).toBe(0);
+  });
+
+  it("passes explicit page=1 for the second page", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", [], 1);
+    expect(req.page).toBe(1);
+  });
+
+  it("passes explicit page=5", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", [], 5);
+    expect(req.page).toBe(5);
+  });
+
+  it("pageSize is always 50 regardless of page", () => {
+    const req = buildSearchRequest(PREFS_ENABLED, "q", [], 3);
+    expect(req.pageSize).toBe(50);
+  });
+});
+
+// ── hasMore ───────────────────────────────────────────────────────────────────
+
+describe("hasMore", () => {
+  it("returns false when loaded === total (all loaded)", () => {
+    expect(hasMore(50, 50)).toBe(false);
+  });
+
+  it("returns false when loaded > total (shouldn't happen, but safe)", () => {
+    expect(hasMore(55, 50)).toBe(false);
+  });
+
+  it("returns true when loaded < total", () => {
+    expect(hasMore(50, 100)).toBe(true);
+  });
+
+  it("returns false when both are 0 (no results)", () => {
+    expect(hasMore(0, 0)).toBe(false);
+  });
+
+  it("returns true when loaded=0 and total>0 (nothing loaded yet)", () => {
+    expect(hasMore(0, 1)).toBe(true);
+  });
+
+  it("returns true for partial first page (50 of 200)", () => {
+    expect(hasMore(50, 200)).toBe(true);
+  });
+
+  it("returns false at exact boundary (loaded === total)", () => {
+    expect(hasMore(1, 1)).toBe(false);
+    expect(hasMore(200, 200)).toBe(false);
+  });
+});
+
+// ── nextPage ──────────────────────────────────────────────────────────────────
+
+describe("nextPage", () => {
+  it("returns 1 when current is 0 (first page → second page)", () => {
+    expect(nextPage(0)).toBe(1);
+  });
+
+  it("returns 2 when current is 1", () => {
+    expect(nextPage(1)).toBe(2);
+  });
+
+  it("returns current + 1 for arbitrary pages", () => {
+    expect(nextPage(5)).toBe(6);
+    expect(nextPage(99)).toBe(100);
+  });
+});
+
+// ── appendResults ─────────────────────────────────────────────────────────────
+
+function makeFile(id: string): FileResult {
+  return {
+    id,
+    name: `${id}.txt`,
+    path: `/files/${id}.txt`,
+    dir: "/files",
+    ext: "txt",
+    mime: "text/plain",
+    type: "document",
+    size: 1024,
+    createdAt: 1_700_000_000_000,
+    modifiedAt: 1_700_000_000_000,
+    score: 1,
+  };
+}
+
+describe("appendResults", () => {
+  it("appends next results to prev", () => {
+    const prev = [makeFile("a"), makeFile("b")];
+    const next = [makeFile("c"), makeFile("d")];
+    const result = appendResults(prev, next);
+    expect(result.map((f) => f.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("does not mutate the prev array", () => {
+    const prev = [makeFile("a")];
+    const next = [makeFile("b")];
+    appendResults(prev, next);
+    expect(prev).toHaveLength(1);
+  });
+
+  it("handles empty prev", () => {
+    const next = [makeFile("a")];
+    const result = appendResults([], next);
+    expect(result).toEqual(next);
+  });
+
+  it("handles empty next", () => {
+    const prev = [makeFile("a")];
+    const result = appendResults(prev, []);
+    expect(result).toEqual(prev);
+    // Returns a new array, not the original
+    expect(result).not.toBe(prev);
+  });
+
+  it("handles both empty", () => {
+    expect(appendResults([], [])).toEqual([]);
+  });
+
+  it("preserves order: prev items come before next items", () => {
+    const prev = [makeFile("x")];
+    const next = [makeFile("y"), makeFile("z")];
+    const result = appendResults(prev, next);
+    expect(result[0].id).toBe("x");
+    expect(result[1].id).toBe("y");
+    expect(result[2].id).toBe("z");
+  });
+});
+
+// ── resetResults ──────────────────────────────────────────────────────────────
+
+describe("resetResults", () => {
+  it("returns an empty array", () => {
+    expect(resetResults()).toEqual([]);
+  });
+
+  it("each call returns a new empty array (not the same reference)", () => {
+    const a = resetResults();
+    const b = resetResults();
+    expect(a).not.toBe(b);
+  });
+
+  it("return value has length 0", () => {
+    expect(resetResults()).toHaveLength(0);
   });
 });
 

--- a/extension/tests/unit/local-search-screen.test.ts
+++ b/extension/tests/unit/local-search-screen.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for the pure helpers in options/screens/local-search.ts.
+ *
+ * None of these tests touch the DOM or chrome.storage — all helpers are
+ * pure functions that take data and return a value.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectOS,
+  configHasSTrigger,
+  regexAvailable,
+  contentAvailable,
+  deriveStatus,
+} from "../../src/options/screens/local-search.js";
+import type { FastTravelConfig } from "../../src/core/types.js";
+import type { PingResponse, IndexerInfo, Capabilities } from "../../src/core/companion-types.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CAPS_NONE: Capabilities = {
+  booleanOps: false,
+  prefixWildcard: false,
+  infixWildcard: false,
+  regex: false,
+  pathScope: false,
+  content: false,
+};
+
+function makeIndexer(
+  id: string,
+  available: boolean,
+  caps: Partial<Capabilities> = {},
+): IndexerInfo {
+  return { id, name: id, available, capabilities: { ...CAPS_NONE, ...caps } };
+}
+
+const PING_BASE: PingResponse = {
+  name: "fast-travel-companion",
+  version: "1.0.0",
+  protocolVersion: 1,
+  os: "linux",
+  paired: false,
+  pairingOpen: false,
+  defaultIndexer: "baloo",
+  indexers: [],
+};
+
+function makeConfig(triggers: string[]): FastTravelConfig {
+  return {
+    version: 2,
+    defaultCommand: triggers[0] ?? "g",
+    groups: [
+      {
+        id: "g1",
+        name: "General",
+        commands: triggers.map((t, i) => ({
+          id: `cmd-${i}`,
+          triggers: [t],
+          name: `Command ${i}`,
+          type: "standard" as const,
+          routes: [],
+        })),
+      },
+    ],
+    ignoreList: [],
+  };
+}
+
+// ── detectOS ─────────────────────────────────────────────────────────────────
+
+describe("detectOS", () => {
+  it("detects Windows from a typical Chrome/Windows UA", () => {
+    const ua =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0";
+    expect(detectOS(ua)).toBe("windows");
+  });
+
+  it("detects Windows case-insensitively ('win' substring)", () => {
+    expect(detectOS("Mozilla/5.0 (Win32; x86) Gecko/20100101")).toBe("windows");
+  });
+
+  it("detects macOS from a typical Safari UA", () => {
+    const ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 Safari/605.1.15";
+    expect(detectOS(ua)).toBe("macos");
+  });
+
+  it("detects macOS from 'Mac' substring", () => {
+    expect(detectOS("Mozilla/5.0 (Mac OS X 10_15_7)")).toBe("macos");
+  });
+
+  it("defaults to linux for a Linux UA", () => {
+    const ua = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0.0.0";
+    expect(detectOS(ua)).toBe("linux");
+  });
+
+  it("defaults to linux for an empty string", () => {
+    expect(detectOS("")).toBe("linux");
+  });
+
+  it("defaults to linux for an unrecognised UA", () => {
+    expect(detectOS("SomeUnknownBrowser/1.0")).toBe("linux");
+  });
+});
+
+// ── configHasSTrigger ─────────────────────────────────────────────────────────
+
+describe("configHasSTrigger", () => {
+  it("returns false for an empty config", () => {
+    const cfg = makeConfig([]);
+    // makeConfig uses triggers[0] as defaultCommand; guard against empty
+    cfg.groups[0].commands = [];
+    cfg.defaultCommand = "g";
+    expect(configHasSTrigger(cfg)).toBe(false);
+  });
+
+  it("returns false when no command uses 's'", () => {
+    expect(configHasSTrigger(makeConfig(["g", "yt", "gh"]))).toBe(false);
+  });
+
+  it("returns true when a command has 's' as a trigger (lowercase)", () => {
+    expect(configHasSTrigger(makeConfig(["g", "s", "gh"]))).toBe(true);
+  });
+
+  it("returns true when a command has 'S' (uppercase — triggers are lower-cased by buildTriggerMap)", () => {
+    const cfg = makeConfig(["g", "gh"]);
+    cfg.groups[0].commands!.push({
+      id: "cmd-s",
+      triggers: ["S"],
+      name: "Stack Overflow",
+      type: "standard",
+      routes: [],
+    });
+    expect(configHasSTrigger(cfg)).toBe(true);
+  });
+
+  it("returns false when the only trigger is 'st' (not 's')", () => {
+    expect(configHasSTrigger(makeConfig(["g", "st"]))).toBe(false);
+  });
+});
+
+// ── regexAvailable ────────────────────────────────────────────────────────────
+
+describe("regexAvailable", () => {
+  it("returns false when indexers list is empty", () => {
+    expect(regexAvailable({ ...PING_BASE, indexers: [] })).toBe(false);
+  });
+
+  it("returns false when no available indexer supports regex", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      indexers: [makeIndexer("baloo", true, { regex: false })],
+    };
+    expect(regexAvailable(ping)).toBe(false);
+  });
+
+  it("returns false when the regex-capable indexer is not available", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      indexers: [makeIndexer("recoll", false, { regex: true })],
+    };
+    expect(regexAvailable(ping)).toBe(false);
+  });
+
+  it("returns true when at least one available indexer supports regex", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      indexers: [
+        makeIndexer("baloo", true, { regex: false }),
+        makeIndexer("recoll", true, { regex: true }),
+      ],
+    };
+    expect(regexAvailable(ping)).toBe(true);
+  });
+
+  it("returns true when the sole indexer is available and supports regex", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      indexers: [makeIndexer("recoll", true, { regex: true })],
+    };
+    expect(regexAvailable(ping)).toBe(true);
+  });
+});
+
+// ── contentAvailable ──────────────────────────────────────────────────────────
+
+describe("contentAvailable", () => {
+  it("returns false when there are no indexers", () => {
+    expect(contentAvailable({ ...PING_BASE, indexers: [] })).toBe(false);
+  });
+
+  it("returns false when the default indexer is not in the list", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      defaultIndexer: "missing",
+      indexers: [makeIndexer("baloo", true, { content: true })],
+    };
+    expect(contentAvailable(ping)).toBe(false);
+  });
+
+  it("returns false when the default indexer does not support content", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      defaultIndexer: "baloo",
+      indexers: [makeIndexer("baloo", true, { content: false })],
+    };
+    expect(contentAvailable(ping)).toBe(false);
+  });
+
+  it("returns false when the default indexer supports content but is not available", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      defaultIndexer: "recoll",
+      indexers: [makeIndexer("recoll", false, { content: true })],
+    };
+    expect(contentAvailable(ping)).toBe(false);
+  });
+
+  it("returns true when the default indexer is available and supports content", () => {
+    const ping: PingResponse = {
+      ...PING_BASE,
+      defaultIndexer: "recoll",
+      indexers: [
+        makeIndexer("baloo", true, { content: false }),
+        makeIndexer("recoll", true, { content: true }),
+      ],
+    };
+    expect(contentAvailable(ping)).toBe(true);
+  });
+});
+
+// ── deriveStatus ──────────────────────────────────────────────────────────────
+
+describe("deriveStatus", () => {
+  it("returns 'notFound' when discover result is null and no previous port", () => {
+    expect(deriveStatus(null, {})).toBe("notFound");
+  });
+
+  it("returns 'notFound' when discover result is null and port is undefined", () => {
+    expect(deriveStatus(null, { port: undefined })).toBe("notFound");
+  });
+
+  it("returns 'disconnected' when discover result is null but a previous port is stored", () => {
+    expect(deriveStatus(null, { port: 7333 })).toBe("disconnected");
+  });
+
+  it("returns 'unpaired' when companion is found but ping.paired is false", () => {
+    const result = { port: 7333, ping: { ...PING_BASE, paired: false } };
+    expect(deriveStatus(result, {})).toBe("unpaired");
+  });
+
+  it("returns 'unpaired' when companion is paired but we have no stored token", () => {
+    const result = { port: 7333, ping: { ...PING_BASE, paired: true } };
+    expect(deriveStatus(result, { port: 7333 })).toBe("unpaired");
+  });
+
+  it("returns 'connected' when companion is paired and we have a stored token", () => {
+    const result = { port: 7333, ping: { ...PING_BASE, paired: true } };
+    expect(deriveStatus(result, { port: 7333, token: "tok-abc" })).toBe("connected");
+  });
+
+  it("returns 'unpaired' when companion reports paired:false even if we have a stored token (re-pair needed)", () => {
+    // Companion was reset; our old token is now invalid.
+    const result = { port: 7333, ping: { ...PING_BASE, paired: false } };
+    expect(deriveStatus(result, { port: 7333, token: "tok-old" })).toBe("unpaired");
+  });
+});

--- a/extension/tests/unit/local-search-store.test.ts
+++ b/extension/tests/unit/local-search-store.test.ts
@@ -3,35 +3,10 @@ import {
   getLocalSearchPrefs,
   setLocalSearchPrefs,
 } from "../../src/core/local-search-store.js";
-
-// ── Storage mock (same pattern as auto-ignore-store.test.ts) ─────────────────
-
-function mockStorage(initial: Record<string, unknown> = {}) {
-  const backing: Record<string, unknown> = { ...initial };
-  return {
-    get: async (keys: string | string[]) => {
-      const want = Array.isArray(keys) ? keys : [keys];
-      const out: Record<string, unknown> = {};
-      for (const k of want) if (k in backing) out[k] = backing[k];
-      return out;
-    },
-    set: async (obj: Record<string, unknown>) => {
-      Object.assign(backing, obj);
-    },
-    remove: async (k: string | string[]) => {
-      for (const key of Array.isArray(k) ? k : [k]) delete backing[key];
-    },
-    _backing: backing,
-  };
-}
-
-type MockStorage = ReturnType<typeof mockStorage>;
-
-function install(initial: Record<string, unknown> = {}): MockStorage {
-  const storage = mockStorage(initial);
-  (globalThis as unknown as { chrome: unknown }).chrome = { storage: { local: storage } };
-  return storage;
-}
+import {
+  installMockStorage as install,
+  type MockStorage,
+} from "./helpers/mock-storage.js";
 
 const STORE_KEY = "fast-travel-local-search-prefs";
 

--- a/extension/tests/unit/local-search-store.test.ts
+++ b/extension/tests/unit/local-search-store.test.ts
@@ -30,6 +30,8 @@ describe("local-search-store", () => {
     expect(prefs.view).toBe("list");
     expect(prefs.token).toBeUndefined();
     expect(prefs.port).toBeUndefined();
+    expect(prefs.caseSensitive).toBe(false);
+    expect(prefs.exactPhrase).toBe(false);
   });
 
   it("enabled defaults to false (opt-in)", async () => {
@@ -119,6 +121,44 @@ describe("local-search-store", () => {
     expect(prefs.token).toBe("tok-xyz");
     expect(prefs.port).toBe(7333);
     expect(prefs.enabled).toBe(true);
+  });
+
+  // ── caseSensitive + exactPhrase (Phase 6b) ────────────────────────────────
+
+  it("caseSensitive defaults to false", async () => {
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.caseSensitive).toBe(false);
+  });
+
+  it("exactPhrase defaults to false", async () => {
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.exactPhrase).toBe(false);
+  });
+
+  it("caseSensitive round-trips through set/get", async () => {
+    await setLocalSearchPrefs({ caseSensitive: true });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.caseSensitive).toBe(true);
+  });
+
+  it("exactPhrase round-trips through set/get", async () => {
+    await setLocalSearchPrefs({ exactPhrase: true });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.exactPhrase).toBe(true);
+  });
+
+  it("caseSensitive survives a subsequent unrelated partial update", async () => {
+    await setLocalSearchPrefs({ caseSensitive: true });
+    await setLocalSearchPrefs({ view: "grid" });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.caseSensitive).toBe(true);
+  });
+
+  it("exactPhrase survives a subsequent unrelated partial update", async () => {
+    await setLocalSearchPrefs({ exactPhrase: true });
+    await setLocalSearchPrefs({ enabled: true });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.exactPhrase).toBe(true);
   });
 
   // ── Storage key ───────────────────────────────────────────────────────────

--- a/extension/tests/unit/local-search-store.test.ts
+++ b/extension/tests/unit/local-search-store.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getLocalSearchPrefs,
+  setLocalSearchPrefs,
+} from "../../src/core/local-search-store.js";
+
+// ── Storage mock (same pattern as auto-ignore-store.test.ts) ─────────────────
+
+function mockStorage(initial: Record<string, unknown> = {}) {
+  const backing: Record<string, unknown> = { ...initial };
+  return {
+    get: async (keys: string | string[]) => {
+      const want = Array.isArray(keys) ? keys : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of want) if (k in backing) out[k] = backing[k];
+      return out;
+    },
+    set: async (obj: Record<string, unknown>) => {
+      Object.assign(backing, obj);
+    },
+    remove: async (k: string | string[]) => {
+      for (const key of Array.isArray(k) ? k : [k]) delete backing[key];
+    },
+    _backing: backing,
+  };
+}
+
+type MockStorage = ReturnType<typeof mockStorage>;
+
+function install(initial: Record<string, unknown> = {}): MockStorage {
+  const storage = mockStorage(initial);
+  (globalThis as unknown as { chrome: unknown }).chrome = { storage: { local: storage } };
+  return storage;
+}
+
+const STORE_KEY = "fast-travel-local-search-prefs";
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("local-search-store", () => {
+  let storage: MockStorage;
+
+  beforeEach(() => {
+    storage = install();
+  });
+
+  // ── Defaults ──────────────────────────────────────────────────────────────
+
+  it("returns defaults when store is empty", async () => {
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.enabled).toBe(false);
+    expect(prefs.queryMode).toBe("simple");
+    expect(prefs.sort).toEqual({ field: "relevance", dir: "desc" });
+    expect(prefs.filters).toEqual({});
+    expect(prefs.view).toBe("list");
+    expect(prefs.token).toBeUndefined();
+    expect(prefs.port).toBeUndefined();
+  });
+
+  it("enabled defaults to false (opt-in)", async () => {
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.enabled).toBe(false);
+  });
+
+  it("queryMode default is simple", async () => {
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.queryMode).toBe("simple");
+  });
+
+  it("sort default is relevance/desc", async () => {
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.sort.field).toBe("relevance");
+    expect(prefs.sort.dir).toBe("desc");
+  });
+
+  it("view default is list", async () => {
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.view).toBe("list");
+  });
+
+  // ── Merging on write ──────────────────────────────────────────────────────
+
+  it("setLocalSearchPrefs merges: only changed fields update", async () => {
+    await setLocalSearchPrefs({ enabled: true, queryMode: "wildcard" });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.enabled).toBe(true);
+    expect(prefs.queryMode).toBe("wildcard");
+    // Untouched defaults must survive
+    expect(prefs.sort).toEqual({ field: "relevance", dir: "desc" });
+    expect(prefs.view).toBe("list");
+    expect(prefs.filters).toEqual({});
+  });
+
+  it("setLocalSearchPrefs returns the merged result", async () => {
+    const result = await setLocalSearchPrefs({ enabled: true });
+    expect(result.enabled).toBe(true);
+    expect(result.queryMode).toBe("simple");
+  });
+
+  it("sort is shallow-merged: updating dir preserves field", async () => {
+    await setLocalSearchPrefs({ sort: { field: "created", dir: "asc" } });
+    await setLocalSearchPrefs({ sort: { field: "created", dir: "desc" } });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.sort.field).toBe("created");
+    expect(prefs.sort.dir).toBe("desc");
+  });
+
+  it("filters is shallow-merged: adding titleOnly preserves types", async () => {
+    await setLocalSearchPrefs({ filters: { types: ["document"] } });
+    await setLocalSearchPrefs({ filters: { titleOnly: true } });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.filters.types).toEqual(["document"]);
+    expect(prefs.filters.titleOnly).toBe(true);
+  });
+
+  // ── Round-trip ────────────────────────────────────────────────────────────
+
+  it("round-trip: set and get preserve all fields", async () => {
+    const toSet = {
+      enabled: true,
+      token: "tok-abc",
+      port: 7334,
+      queryMode: "regex" as const,
+      sort: { field: "modified" as const, dir: "asc" as const },
+      filters: { titleOnly: true, types: ["image" as const] },
+      view: "grid" as const,
+    };
+    await setLocalSearchPrefs(toSet);
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.enabled).toBe(true);
+    expect(prefs.token).toBe("tok-abc");
+    expect(prefs.port).toBe(7334);
+    expect(prefs.queryMode).toBe("regex");
+    expect(prefs.sort).toEqual({ field: "modified", dir: "asc" });
+    expect(prefs.filters.titleOnly).toBe(true);
+    expect(prefs.filters.types).toEqual(["image"]);
+    expect(prefs.view).toBe("grid");
+  });
+
+  it("token and port survive a subsequent partial update", async () => {
+    await setLocalSearchPrefs({ token: "tok-xyz", port: 7333 });
+    await setLocalSearchPrefs({ enabled: true });
+    const prefs = await getLocalSearchPrefs();
+    expect(prefs.token).toBe("tok-xyz");
+    expect(prefs.port).toBe(7333);
+    expect(prefs.enabled).toBe(true);
+  });
+
+  // ── Storage key ───────────────────────────────────────────────────────────
+
+  it("persists under the correct storage key", async () => {
+    await setLocalSearchPrefs({ enabled: true });
+    expect(storage._backing[STORE_KEY]).toBeDefined();
+    expect((storage._backing[STORE_KEY] as { enabled: boolean }).enabled).toBe(true);
+  });
+
+  it("does not write to any other key", async () => {
+    await setLocalSearchPrefs({ enabled: true });
+    const keys = Object.keys(storage._backing);
+    expect(keys).toEqual([STORE_KEY]);
+  });
+});

--- a/extension/tests/unit/local-search-toolbar.test.ts
+++ b/extension/tests/unit/local-search-toolbar.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the pure helpers in newtab/local-search-toolbar.ts.
+ *
+ * Covers:
+ *   - datePresetToRange: epoch-ms range for each preset, including "any"
+ *   - toggleType: add/remove semantics, pure result, no mutation
+ *
+ * No DOM or chrome.storage interaction — all helpers under test are pure
+ * functions that take data and return a value.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  datePresetToRange,
+  toggleType,
+} from "../../src/newtab/local-search-toolbar.js";
+
+// ── datePresetToRange ─────────────────────────────────────────────────────────
+
+describe("datePresetToRange", () => {
+  const NOW = 1_700_000_000_000; // fixed epoch-ms anchor (≈ Nov 2023)
+  const DAY = 86_400_000;
+
+  it("returns undefined for 'any' (no filter)", () => {
+    expect(datePresetToRange("any", NOW)).toBeUndefined();
+  });
+
+  it("returns { from: now - 7 days } for 'week' (epoch ms)", () => {
+    const result = datePresetToRange("week", NOW);
+    expect(result).toEqual({ from: NOW - 7 * DAY });
+  });
+
+  it("returns { from: now - 30 days } for 'month' (epoch ms)", () => {
+    const result = datePresetToRange("month", NOW);
+    expect(result).toEqual({ from: NOW - 30 * DAY });
+  });
+
+  it("returns { from: now - 365 days } for 'year' (epoch ms)", () => {
+    const result = datePresetToRange("year", NOW);
+    expect(result).toEqual({ from: NOW - 365 * DAY });
+  });
+
+  it("'week' from is strictly less than 'month' from (week is more recent)", () => {
+    const week = datePresetToRange("week", NOW)!;
+    const month = datePresetToRange("month", NOW)!;
+    expect(week.from).toBeGreaterThan(month.from);
+  });
+
+  it("'month' from is strictly less than 'year' from (month is more recent)", () => {
+    const month = datePresetToRange("month", NOW)!;
+    const year = datePresetToRange("year", NOW)!;
+    expect(month.from).toBeGreaterThan(year.from);
+  });
+
+  it("does not include a 'to' field (open-ended upper bound)", () => {
+    const result = datePresetToRange("week", NOW);
+    expect(result).not.toHaveProperty("to");
+  });
+
+  it("uses the exact `now` value provided (not Date.now() internally)", () => {
+    const t1 = 1_000_000_000_000;
+    const t2 = 2_000_000_000_000;
+    const r1 = datePresetToRange("month", t1)!;
+    const r2 = datePresetToRange("month", t2)!;
+    expect(r1.from).toBe(t1 - 30 * DAY);
+    expect(r2.from).toBe(t2 - 30 * DAY);
+    expect(r1.from).not.toBe(r2.from);
+  });
+});
+
+// ── toggleType ────────────────────────────────────────────────────────────────
+
+describe("toggleType", () => {
+  it("adds a type to an empty array", () => {
+    expect(toggleType([], "document")).toEqual(["document"]);
+  });
+
+  it("adds a type when undefined is passed (treats as empty)", () => {
+    expect(toggleType(undefined, "image")).toEqual(["image"]);
+  });
+
+  it("adds a type that is not already present", () => {
+    expect(toggleType(["document"], "image")).toEqual(["document", "image"]);
+  });
+
+  it("removes a type that is already present", () => {
+    expect(toggleType(["document", "image"], "image")).toEqual(["document"]);
+  });
+
+  it("removes the sole type, resulting in an empty array", () => {
+    expect(toggleType(["document"], "document")).toEqual([]);
+  });
+
+  it("does not mutate the original array (pure)", () => {
+    const original = ["document", "image"];
+    const result = toggleType(original, "image");
+    expect(original).toEqual(["document", "image"]); // unchanged
+    expect(result).toEqual(["document"]);
+  });
+
+  it("preserves insertion order when adding", () => {
+    const result = toggleType(["code", "image"], "audio");
+    expect(result).toEqual(["code", "image", "audio"]);
+  });
+
+  it("preserves relative order of remaining items when removing from middle", () => {
+    const result = toggleType(["document", "image", "video"], "image");
+    expect(result).toEqual(["document", "video"]);
+  });
+
+  it("works with all FileType values", () => {
+    const types = ["document", "image", "video", "audio", "archive", "code", "folder", "other"];
+    let current: string[] = [];
+    // Add all
+    for (const t of types) {
+      current = toggleType(current, t);
+    }
+    expect(current).toEqual(types);
+    // Remove all
+    for (const t of types) {
+      current = toggleType(current, t);
+    }
+    expect(current).toEqual([]);
+  });
+});

--- a/extension/tests/unit/local-search-toolbar.test.ts
+++ b/extension/tests/unit/local-search-toolbar.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect } from "vitest";
 import {
   datePresetToRange,
   toggleType,
+  SORT_FIELDS,
 } from "../../src/newtab/local-search-toolbar.js";
 
 // ── datePresetToRange ─────────────────────────────────────────────────────────
@@ -65,6 +66,29 @@ describe("datePresetToRange", () => {
     expect(r1.from).toBe(t1 - 30 * DAY);
     expect(r2.from).toBe(t2 - 30 * DAY);
     expect(r1.from).not.toBe(r2.from);
+  });
+});
+
+// ── SORT_FIELDS (Bug B — no "created") ───────────────────────────────────────
+
+describe("SORT_FIELDS", () => {
+  it("does not include 'created' (Bug B: Date created removed)", () => {
+    const values = SORT_FIELDS.map((f) => f.value);
+    expect(values).not.toContain("created");
+  });
+
+  it("includes 'relevance'", () => {
+    const values = SORT_FIELDS.map((f) => f.value);
+    expect(values).toContain("relevance");
+  });
+
+  it("includes 'modified'", () => {
+    const values = SORT_FIELDS.map((f) => f.value);
+    expect(values).toContain("modified");
+  });
+
+  it("contains exactly two entries (relevance + modified)", () => {
+    expect(SORT_FIELDS).toHaveLength(2);
   });
 });
 

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["tests/**/*.test.ts"],
+    setupFiles: ["tests/setup.ts"],
   },
   resolve: {
     alias: {

--- a/shared/companion-protocol/README.md
+++ b/shared/companion-protocol/README.md
@@ -157,6 +157,24 @@ Ranking favors name matches over path-only matches.
 All implementations (the Go companion and the Android app) MUST follow these semantics so
 results are consistent across platforms.
 
+### `caseSensitive` (optional, default `false`)
+
+When `caseSensitive` is `false` (the default), term and phrase comparisons are
+**case-insensitive**: `"Report"` matches `"report.pdf"`.  When `true`, comparisons are
+**case-sensitive**: `"Report"` does NOT match `"report.pdf"`.
+
+`regex` nodes are **unaffected** by `caseSensitive` — the regular expression pattern's own
+inline flags (e.g. `(?i)`) control case for regex queries.
+
+### `exactPhrase` (optional, default `false`)
+
+When `exactPhrase` is `false` (the default), a multi-word query is **AND'd**: each word
+must appear somewhere in the file's name or path, in any order.  When `true`, the **whole
+query string** is treated as a single ordered phrase: the words must appear contiguous and
+in order (e.g. `"annual report"` matches `annual report.pdf` but NOT `annual_report.pdf`).
+
+`exactPhrase` is **ignored** in `regex` mode — the pattern is already the entire query.
+
 ---
 
 ## 4. Capabilities matrix

--- a/shared/companion-protocol/README.md
+++ b/shared/companion-protocol/README.md
@@ -14,12 +14,17 @@ node shared/companion-protocol/validate.mjs
 
 Exit 0 = all fixtures pass; exit 1 = errors.  Use as a CI gate or pre-commit hook.
 
+**Note:** The enum constants inside `validate.mjs` (e.g., `OS_VALUES`, `QUERY_MODES`) mirror those in `protocol.schema.json` and must be kept in sync when the schema's enums change.
+
 ---
 
 ## Endpoints
 
-All endpoints are HTTP/JSON on `127.0.0.1`. The companion listens on a fixed local port
-(not yet specified here; tracked in the companion implementation task).
+All endpoints are HTTP/JSON on `127.0.0.1`.
+
+### Companion port
+
+The daemon listens on `127.0.0.1` at default port **7333**.  If that port is busy, it scans upward through **7333–7343**.  Clients discover the active port and capabilities via `GET /v1/ping`.
 
 | Method / Path   | Auth         | Request body  | Response body                    |
 |-----------------|--------------|---------------|----------------------------------|
@@ -152,9 +157,6 @@ platform scenarios:
 | Linux KDE | `baloo` | plocate available for regex routing |
 | Linux (plocate only) | `plocate` | No content search |
 | Windows | `wsearch` | Everything available for regex/wildcard |
-| Android | `mediastore` | Reports `os: "linux"` (Android kernel); no regex, no content |
+| Android | `mediastore` | Reports `os: "android"`; no regex, no content |
 
-> **Android OS value:** The companion protocol's `os` field has three values —
-> `"linux"`, `"windows"`, `"macos"`. An Android device reports `"linux"` because Android
-> runs on the Linux kernel.  Client code that needs to distinguish Android from a desktop
-> Linux host should check whether `defaultIndexer` is `"mediastore"`.
+> **Android detection:** Android devices report `os: "android"` in the `PingResponse`. The `defaultIndexer` is `"mediastore"` as a secondary signal.

--- a/shared/companion-protocol/README.md
+++ b/shared/companion-protocol/README.md
@@ -147,7 +147,19 @@ See [`fixtures/query-parsing.json`](./fixtures/query-parsing.json) for the full 
 
 ---
 
-## 3. Capabilities matrix
+## 3. Matching semantics (normative)
+
+A query matches a file when the parsed AST matches the file's **name OR path** by default.
+The `titleOnly` filter restricts matching to the file **name** only (under `titleOnly`, all
+leaves — including `path:`-scoped ones — are evaluated against the name).
+A `path:`-scoped term matches the path.
+Ranking favors name matches over path-only matches.
+All implementations (the Go companion and the Android app) MUST follow these semantics so
+results are consistent across platforms.
+
+---
+
+## 4. Capabilities matrix
 
 See [`fixtures/capabilities.json`](./fixtures/capabilities.json) for the four documented
 platform scenarios:

--- a/shared/companion-protocol/README.md
+++ b/shared/companion-protocol/README.md
@@ -1,0 +1,160 @@
+# Fast Travel Companion Protocol
+
+Cross-platform JSON contract between the **fast-travel local-search companion daemon** (Go),
+the **browser extension** (TypeScript), and the **Android app** (Kotlin).
+
+All types are defined in [`protocol.schema.json`](./protocol.schema.json).  
+Fixtures are in [`fixtures/`](./fixtures/).
+
+## Running the validator
+
+```bash
+node shared/companion-protocol/validate.mjs
+```
+
+Exit 0 = all fixtures pass; exit 1 = errors.  Use as a CI gate or pre-commit hook.
+
+---
+
+## Endpoints
+
+All endpoints are HTTP/JSON on `127.0.0.1`. The companion listens on a fixed local port
+(not yet specified here; tracked in the companion implementation task).
+
+| Method / Path   | Auth         | Request body  | Response body                    |
+|-----------------|--------------|---------------|----------------------------------|
+| `GET /v1/ping`  | none         | —             | `PingResponse`                   |
+| `POST /v1/pair` | Origin-check | `PairRequest` | `PairResponse` or `ErrorResponse`|
+| `POST /v1/search`| Bearer token| `SearchRequest`| `SearchResponse` or `ErrorResponse`|
+| `POST /v1/open` | Bearer token | `OpenRequest` | `OpenResponse` or `ErrorResponse`|
+
+**Auth:** authenticated endpoints require `Authorization: Bearer <token>` where the token was
+obtained from `POST /v1/pair`.  The companion validates the Origin header on `/v1/pair` to
+prevent cross-site request forgery; it rejects origins that are not the extension's own
+`chrome-extension://` or `moz-extension://` origin.
+
+### WebSocket: `GET /v1/stream`
+
+A WebSocket endpoint for push notifications from the companion to the extension (e.g. index
+rebuild complete, indexer state changed).  Frame format is TBD and not schematised in this
+task.  Frames are JSON objects with at minimum a `type` string field.  Authentication is
+established by passing the Bearer token as a query parameter `?token=<token>` on the initial
+HTTP upgrade request.
+
+---
+
+## 1. Object types
+
+All named types are in `protocol.schema.json#/$defs`.
+
+| Type | Description |
+|------|-------------|
+| `PingResponse` | Returned by `GET /v1/ping` — companion identity, OS, indexer list |
+| `IndexerInfo` | One indexer entry inside `PingResponse.indexers` |
+| `Capabilities` | Feature flags for an indexer (all booleans) |
+| `PairRequest` / `PairResponse` | Pairing flow |
+| `SearchRequest` | Search query with mode, sort, filters, pagination |
+| `Sort` / `Filters` / `DateRange` | Sub-objects of `SearchRequest` |
+| `SearchResponse` | Paginated results |
+| `FileResult` | A single file match |
+| `FileType` | Enum shared by `FileResult.type` and `Filters.types` |
+| `OpenRequest` / `OpenResponse` | Open-file action |
+| `ErrorResponse` | Error payload for any failed request |
+| `AstNode` | Parsed query AST node (oneOf six shapes) |
+
+### `FileResult.id` — canonical choice
+
+`FileResult.id` is the **absolute path** of the file (identical to `FileResult.path`).
+Using the path as the id keeps it stable across companion restarts and human-readable in
+logs.  Implementations that cannot guarantee a stable absolute path (e.g. removable media)
+may use a deterministic hash of the path and must document the hash function used.
+
+---
+
+## 2. Query mini-syntax and AST
+
+This section is the authoritative specification.  All three implementations (Go, TypeScript,
+Kotlin) must parse the same query string into the same normalised AST.  The fixture file
+[`fixtures/query-parsing.json`](./fixtures/query-parsing.json) encodes the canonical AST for
+every case listed below and is the parity gate.
+
+### Syntax rules
+
+- **Whitespace** separates terms.  Adjacent terms are implicitly **AND**.
+- **`OR`** (case-insensitive, as a standalone token) **or** `|` (pipe) joins adjacent
+  AND-groups with **OR**.  **AND binds tighter than OR**:
+  `a b OR c d` → `(a AND b) OR (c AND d)`.
+- A **leading `-` or `!`** on a term negates it: `a -b` → `a AND NOT b`.
+- **Double quotes** form a **phrase**: `"foo bar"` is one phrase node (spaces are literal).
+- **`path:` prefix** scopes a term to the `path` field instead of the default `name` field:
+  `path:src`, `path:"my docs"`, `path:*util*`.
+- **Wildcards** `*` and `?`:
+  - In **`wildcard` mode**: `*` matches any run of characters; `?` matches one character.
+    A term that contains `*` or `?` produces a `term` node with `wildcard: true`.
+  - In **`simple` mode**: `*` and `?` are **literal characters**; `wildcard` is always `false`.
+- In **`regex` mode**: no tokenisation occurs.  The entire `query` string is treated as a
+  regular expression against the `name` field.  Exception: if the query starts with `path:`,
+  the remainder (after stripping `path:`) is a regex against the `path` field.  No
+  AND/OR/NOT/phrase parsing applies in regex mode.
+
+### AST node shapes
+
+Each node is one of (discriminated by `op`):
+
+| `op`     | Required fields                          | Notes |
+|----------|------------------------------------------|-------|
+| `"and"`  | `nodes` (array, ≥ 2 `AstNode`s)         | Nested ANDs are flattened |
+| `"or"`   | `nodes` (array, ≥ 2 `AstNode`s)         | Children are AND-groups |
+| `"not"`  | `node` (single `AstNode`)               | Wraps exactly one node |
+| `"term"` | `field`, `value`, `wildcard`             | `field`: `"name"` or `"path"` |
+| `"phrase"`| `field`, `value`                        | `field`: `"name"` or `"path"` |
+| `"regex"` | `field`, `value`                        | `field`: `"name"` or `"path"` |
+
+### Normalisation rules
+
+- A single term parses to the bare leaf node — no wrapping `and`.
+- Multiple AND'd terms produce one flat `and` node with N children (nested ANDs are merged).
+- OR produces one `or` node whose children are the AND-groups (each child is a leaf, a
+  `phrase`, or an `and` node).
+- `not` always wraps exactly one node.
+
+### Fixture cases (summary)
+
+See [`fixtures/query-parsing.json`](./fixtures/query-parsing.json) for the full ASTs.
+
+| # | Query | Mode | Top-level op |
+|---|-------|------|--------------|
+| 1 | `report` | simple | `term` |
+| 2 | `annual report` | simple | `and` |
+| 3 | `cat OR dog` | simple | `or` |
+| 4 | `a b \| c d` | wildcard | `or` → two `and` children |
+| 5 | `report -draft` | simple | `and` (with `not` child) |
+| 6 | `report !draft` | wildcard | `and` (with `not` child) |
+| 7 | `"final report"` | simple | `phrase` |
+| 8 | `path:projects` | simple | `term` on `path` field |
+| 9 | `path:"my docs"` | wildcard | `phrase` on `path` field |
+| 10 | `inv*.pdf` | wildcard | `term`, `wildcard:true` |
+| 11 | `inv*.pdf` | simple | `term`, `wildcard:false` |
+| 12 | `path:*reports*` | wildcard | `term` on `path`, `wildcard:true` |
+| 13 | `^budget_\d{4}\.xlsx$` | regex | `regex` on `name` |
+| 14 | `path:.*/invoices/.*` | regex | `regex` on `path` |
+| 15 | `path:src foo OR bar -baz` | wildcard | `or` → two `and` children |
+
+---
+
+## 3. Capabilities matrix
+
+See [`fixtures/capabilities.json`](./fixtures/capabilities.json) for the four documented
+platform scenarios:
+
+| Scenario | `defaultIndexer` | Notes |
+|----------|-----------------|-------|
+| Linux KDE | `baloo` | plocate available for regex routing |
+| Linux (plocate only) | `plocate` | No content search |
+| Windows | `wsearch` | Everything available for regex/wildcard |
+| Android | `mediastore` | Reports `os: "linux"` (Android kernel); no regex, no content |
+
+> **Android OS value:** The companion protocol's `os` field has three values —
+> `"linux"`, `"windows"`, `"macos"`. An Android device reports `"linux"` because Android
+> runs on the Linux kernel.  Client code that needs to distinguish Android from a desktop
+> Linux host should check whether `defaultIndexer` is `"mediastore"`.

--- a/shared/companion-protocol/fixtures/capabilities.json
+++ b/shared/companion-protocol/fixtures/capabilities.json
@@ -113,7 +113,7 @@
         "name": "fast-travel-companion",
         "version": "1.0.0",
         "protocolVersion": 1,
-        "os": "linux",
+        "os": "android",
         "paired": true,
         "pairingOpen": false,
         "defaultIndexer": "mediastore",

--- a/shared/companion-protocol/fixtures/capabilities.json
+++ b/shared/companion-protocol/fixtures/capabilities.json
@@ -1,0 +1,138 @@
+{
+  "cases": [
+    {
+      "name": "linux-kde – baloo default, plocate available (regex routed to plocate)",
+      "ping": {
+        "name": "fast-travel-companion",
+        "version": "1.0.0",
+        "protocolVersion": 1,
+        "os": "linux",
+        "paired": true,
+        "pairingOpen": false,
+        "defaultIndexer": "baloo",
+        "indexers": [
+          {
+            "id": "baloo",
+            "name": "KDE Baloo",
+            "available": true,
+            "capabilities": {
+              "booleanOps": true,
+              "prefixWildcard": true,
+              "infixWildcard": false,
+              "regex": false,
+              "pathScope": true,
+              "content": true
+            }
+          },
+          {
+            "id": "plocate",
+            "name": "plocate",
+            "available": true,
+            "capabilities": {
+              "booleanOps": false,
+              "prefixWildcard": true,
+              "infixWildcard": true,
+              "regex": true,
+              "pathScope": true,
+              "content": false
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "linux – plocate only, awaiting pairing",
+      "ping": {
+        "name": "fast-travel-companion",
+        "version": "1.0.0",
+        "protocolVersion": 1,
+        "os": "linux",
+        "paired": false,
+        "pairingOpen": true,
+        "defaultIndexer": "plocate",
+        "indexers": [
+          {
+            "id": "plocate",
+            "name": "plocate",
+            "available": true,
+            "capabilities": {
+              "booleanOps": false,
+              "prefixWildcard": true,
+              "infixWildcard": true,
+              "regex": true,
+              "pathScope": true,
+              "content": false
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "windows – wsearch default, Everything available",
+      "ping": {
+        "name": "fast-travel-companion",
+        "version": "1.0.0",
+        "protocolVersion": 1,
+        "os": "windows",
+        "paired": true,
+        "pairingOpen": false,
+        "defaultIndexer": "wsearch",
+        "indexers": [
+          {
+            "id": "wsearch",
+            "name": "Windows Search",
+            "available": true,
+            "capabilities": {
+              "booleanOps": true,
+              "prefixWildcard": true,
+              "infixWildcard": false,
+              "regex": false,
+              "pathScope": true,
+              "content": true
+            }
+          },
+          {
+            "id": "everything",
+            "name": "Everything",
+            "available": true,
+            "capabilities": {
+              "booleanOps": true,
+              "prefixWildcard": true,
+              "infixWildcard": true,
+              "regex": true,
+              "pathScope": true,
+              "content": false
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "android – MediaStore only, no regex",
+      "ping": {
+        "name": "fast-travel-companion",
+        "version": "1.0.0",
+        "protocolVersion": 1,
+        "os": "linux",
+        "paired": true,
+        "pairingOpen": false,
+        "defaultIndexer": "mediastore",
+        "indexers": [
+          {
+            "id": "mediastore",
+            "name": "Android MediaStore",
+            "available": true,
+            "capabilities": {
+              "booleanOps": false,
+              "prefixWildcard": true,
+              "infixWildcard": false,
+              "regex": false,
+              "pathScope": false,
+              "content": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/shared/companion-protocol/fixtures/query-parsing.json
+++ b/shared/companion-protocol/fixtures/query-parsing.json
@@ -1,0 +1,204 @@
+{
+  "cases": [
+    {
+      "name": "single term – simple",
+      "query": "report",
+      "queryMode": "simple",
+      "ast": {
+        "op": "term",
+        "field": "name",
+        "value": "report",
+        "wildcard": false
+      }
+    },
+    {
+      "name": "two terms AND – simple",
+      "query": "annual report",
+      "queryMode": "simple",
+      "ast": {
+        "op": "and",
+        "nodes": [
+          { "op": "term", "field": "name", "value": "annual", "wildcard": false },
+          { "op": "term", "field": "name", "value": "report", "wildcard": false }
+        ]
+      }
+    },
+    {
+      "name": "OR with keyword – simple",
+      "query": "cat OR dog",
+      "queryMode": "simple",
+      "ast": {
+        "op": "or",
+        "nodes": [
+          { "op": "term", "field": "name", "value": "cat", "wildcard": false },
+          { "op": "term", "field": "name", "value": "dog", "wildcard": false }
+        ]
+      }
+    },
+    {
+      "name": "OR with pipe + AND precedence – wildcard",
+      "query": "a b | c d",
+      "queryMode": "wildcard",
+      "ast": {
+        "op": "or",
+        "nodes": [
+          {
+            "op": "and",
+            "nodes": [
+              { "op": "term", "field": "name", "value": "a", "wildcard": false },
+              { "op": "term", "field": "name", "value": "b", "wildcard": false }
+            ]
+          },
+          {
+            "op": "and",
+            "nodes": [
+              { "op": "term", "field": "name", "value": "c", "wildcard": false },
+              { "op": "term", "field": "name", "value": "d", "wildcard": false }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "NOT with dash – simple",
+      "query": "report -draft",
+      "queryMode": "simple",
+      "ast": {
+        "op": "and",
+        "nodes": [
+          { "op": "term", "field": "name", "value": "report", "wildcard": false },
+          {
+            "op": "not",
+            "node": { "op": "term", "field": "name", "value": "draft", "wildcard": false }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NOT with bang – wildcard",
+      "query": "report !draft",
+      "queryMode": "wildcard",
+      "ast": {
+        "op": "and",
+        "nodes": [
+          { "op": "term", "field": "name", "value": "report", "wildcard": false },
+          {
+            "op": "not",
+            "node": { "op": "term", "field": "name", "value": "draft", "wildcard": false }
+          }
+        ]
+      }
+    },
+    {
+      "name": "phrase – simple",
+      "query": "\"final report\"",
+      "queryMode": "simple",
+      "ast": {
+        "op": "phrase",
+        "field": "name",
+        "value": "final report"
+      }
+    },
+    {
+      "name": "path scope term – simple",
+      "query": "path:projects",
+      "queryMode": "simple",
+      "ast": {
+        "op": "term",
+        "field": "path",
+        "value": "projects",
+        "wildcard": false
+      }
+    },
+    {
+      "name": "path scope phrase – wildcard",
+      "query": "path:\"my docs\"",
+      "queryMode": "wildcard",
+      "ast": {
+        "op": "phrase",
+        "field": "path",
+        "value": "my docs"
+      }
+    },
+    {
+      "name": "wildcard glob – wildcard mode",
+      "query": "inv*.pdf",
+      "queryMode": "wildcard",
+      "ast": {
+        "op": "term",
+        "field": "name",
+        "value": "inv*.pdf",
+        "wildcard": true
+      }
+    },
+    {
+      "name": "wildcard literal in simple mode",
+      "query": "inv*.pdf",
+      "queryMode": "simple",
+      "ast": {
+        "op": "term",
+        "field": "name",
+        "value": "inv*.pdf",
+        "wildcard": false
+      }
+    },
+    {
+      "name": "path wildcard – wildcard mode",
+      "query": "path:*reports*",
+      "queryMode": "wildcard",
+      "ast": {
+        "op": "term",
+        "field": "path",
+        "value": "*reports*",
+        "wildcard": true
+      }
+    },
+    {
+      "name": "regex mode – name field",
+      "query": "^budget_\\d{4}\\.xlsx$",
+      "queryMode": "regex",
+      "ast": {
+        "op": "regex",
+        "field": "name",
+        "value": "^budget_\\d{4}\\.xlsx$"
+      }
+    },
+    {
+      "name": "regex mode – path field",
+      "query": "path:.*/invoices/.*",
+      "queryMode": "regex",
+      "ast": {
+        "op": "regex",
+        "field": "path",
+        "value": ".*/invoices/.*"
+      }
+    },
+    {
+      "name": "mixed – path scope + AND + OR + NOT – wildcard",
+      "query": "path:src foo OR bar -baz",
+      "queryMode": "wildcard",
+      "ast": {
+        "op": "or",
+        "nodes": [
+          {
+            "op": "and",
+            "nodes": [
+              { "op": "term", "field": "path", "value": "src", "wildcard": false },
+              { "op": "term", "field": "name", "value": "foo", "wildcard": false }
+            ]
+          },
+          {
+            "op": "and",
+            "nodes": [
+              { "op": "term", "field": "name", "value": "bar", "wildcard": false },
+              {
+                "op": "not",
+                "node": { "op": "term", "field": "name", "value": "baz", "wildcard": false }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/shared/companion-protocol/fixtures/search-examples.json
+++ b/shared/companion-protocol/fixtures/search-examples.json
@@ -1,0 +1,143 @@
+{
+  "cases": [
+    {
+      "name": "simple mode – annual report, multiple types",
+      "request": {
+        "query": "annual report",
+        "queryMode": "simple",
+        "sort": { "field": "relevance", "dir": "desc" },
+        "filters": { "types": ["document", "image"] },
+        "page": 0,
+        "pageSize": 10
+      },
+      "response": {
+        "results": [
+          {
+            "id": "/home/alice/Documents/annual-report-2024.pdf",
+            "name": "annual-report-2024.pdf",
+            "path": "/home/alice/Documents/annual-report-2024.pdf",
+            "dir": "/home/alice/Documents",
+            "ext": "pdf",
+            "mime": "application/pdf",
+            "type": "document",
+            "size": 1572864,
+            "createdAt": 1704067200000,
+            "modifiedAt": 1711929600000,
+            "score": 0.95
+          },
+          {
+            "id": "/home/alice/Documents/annual-report-2023.pdf",
+            "name": "annual-report-2023.pdf",
+            "path": "/home/alice/Documents/annual-report-2023.pdf",
+            "dir": "/home/alice/Documents",
+            "ext": "pdf",
+            "mime": "application/pdf",
+            "type": "document",
+            "size": 1441792,
+            "createdAt": 1672531200000,
+            "modifiedAt": 1680307200000,
+            "score": 0.82
+          },
+          {
+            "id": "/home/alice/Pictures/annual-report-cover.png",
+            "name": "annual-report-cover.png",
+            "path": "/home/alice/Pictures/annual-report-cover.png",
+            "dir": "/home/alice/Pictures",
+            "ext": "png",
+            "mime": "image/png",
+            "type": "image",
+            "size": 204800,
+            "createdAt": 1704067200000,
+            "modifiedAt": 1704067200000,
+            "score": 0.61
+          }
+        ],
+        "total": 3,
+        "page": 0,
+        "tookMs": 8,
+        "indexer": "baloo"
+      }
+    },
+    {
+      "name": "regex mode – degraded via plocate fallback",
+      "request": {
+        "query": "^budget_\\d{4}\\.xlsx$",
+        "queryMode": "regex",
+        "sort": { "field": "modified", "dir": "desc" },
+        "filters": {},
+        "page": 0,
+        "pageSize": 20
+      },
+      "response": {
+        "results": [
+          {
+            "id": "/home/bob/Finance/budget_2024.xlsx",
+            "name": "budget_2024.xlsx",
+            "path": "/home/bob/Finance/budget_2024.xlsx",
+            "dir": "/home/bob/Finance",
+            "ext": "xlsx",
+            "mime": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "type": "document",
+            "size": 327680,
+            "createdAt": 1704067200000,
+            "modifiedAt": 1717200000000,
+            "score": 1.0
+          }
+        ],
+        "total": 1,
+        "page": 0,
+        "tookMs": 12,
+        "indexer": "plocate",
+        "degraded": true
+      }
+    },
+    {
+      "name": "wildcard mode – invoice files by path prefix",
+      "request": {
+        "query": "inv*.pdf",
+        "queryMode": "wildcard",
+        "sort": { "field": "modified", "dir": "desc" },
+        "filters": { "pathPrefix": "/home/bob/Invoices" },
+        "page": 0,
+        "pageSize": 50,
+        "history": [
+          "/home/bob/Invoices/invoice_2024_003.pdf"
+        ]
+      },
+      "response": {
+        "results": [
+          {
+            "id": "/home/bob/Invoices/invoice_2024_003.pdf",
+            "name": "invoice_2024_003.pdf",
+            "path": "/home/bob/Invoices/invoice_2024_003.pdf",
+            "dir": "/home/bob/Invoices",
+            "ext": "pdf",
+            "mime": "application/pdf",
+            "type": "document",
+            "size": 98304,
+            "createdAt": 1717200000000,
+            "modifiedAt": 1717200000000,
+            "score": 0.88
+          },
+          {
+            "id": "/home/bob/Invoices/invoice_2024_002.pdf",
+            "name": "invoice_2024_002.pdf",
+            "path": "/home/bob/Invoices/invoice_2024_002.pdf",
+            "dir": "/home/bob/Invoices",
+            "ext": "pdf",
+            "mime": "application/pdf",
+            "type": "document",
+            "size": 94208,
+            "createdAt": 1714521600000,
+            "modifiedAt": 1714521600000,
+            "score": 0.85
+          }
+        ],
+        "total": 2,
+        "page": 0,
+        "tookMs": 5,
+        "indexer": "plocate"
+      }
+    }
+  ]
+}

--- a/shared/companion-protocol/fixtures/search-examples.json
+++ b/shared/companion-protocol/fixtures/search-examples.json
@@ -8,7 +8,8 @@
         "sort": { "field": "relevance", "dir": "desc" },
         "filters": { "types": ["document", "image"] },
         "page": 0,
-        "pageSize": 10
+        "pageSize": 10,
+        "caseSensitive": true
       },
       "response": {
         "results": [
@@ -102,7 +103,8 @@
         "pageSize": 50,
         "history": [
           "/home/bob/Invoices/invoice_2024_003.pdf"
-        ]
+        ],
+        "exactPhrase": false
       },
       "response": {
         "results": [

--- a/shared/companion-protocol/protocol.schema.json
+++ b/shared/companion-protocol/protocol.schema.json
@@ -1,0 +1,491 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fast-travel.kavi.sh/companion-protocol.schema.json",
+  "title": "Fast Travel Companion Protocol",
+  "description": "Cross-platform JSON contract for the fast-travel local-search companion daemon. All HTTP endpoints live under /v1 on 127.0.0.1. Named types in $defs are the authoritative source of truth for the Go companion, browser extension (TypeScript), and Android app (Kotlin).",
+  "$defs": {
+    "Capabilities": {
+      "type": "object",
+      "description": "Feature flags for an indexer. All fields are required booleans.",
+      "required": ["booleanOps", "prefixWildcard", "infixWildcard", "regex", "pathScope", "content"],
+      "properties": {
+        "booleanOps": {
+          "type": "boolean",
+          "description": "Supports OR / NOT natively at the indexer level."
+        },
+        "prefixWildcard": {
+          "type": "boolean",
+          "description": "Supports term* glob patterns."
+        },
+        "infixWildcard": {
+          "type": "boolean",
+          "description": "Supports *term* infix glob patterns."
+        },
+        "regex": {
+          "type": "boolean",
+          "description": "Supports full regular-expression queries natively."
+        },
+        "pathScope": {
+          "type": "boolean",
+          "description": "Can scope a query to a specific path or path prefix."
+        },
+        "content": {
+          "type": "boolean",
+          "description": "Supports full-text content search (not just file name)."
+        }
+      },
+      "additionalProperties": false
+    },
+    "IndexerInfo": {
+      "type": "object",
+      "description": "Describes one search indexer available on the host.",
+      "required": ["id", "name", "available", "capabilities"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable machine id. Well-known values: baloo, tracker, plocate, wsearch, everything, mediastore."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable label, e.g. \"KDE Baloo\"."
+        },
+        "available": {
+          "type": "boolean",
+          "description": "Whether the indexer is installed and its daemon/service is reachable."
+        },
+        "capabilities": {
+          "$ref": "#/$defs/Capabilities"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PingResponse": {
+      "type": "object",
+      "description": "Response from GET /v1/ping. Always returned without authentication.",
+      "required": ["name", "version", "protocolVersion", "os", "paired", "pairingOpen", "defaultIndexer", "indexers"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Companion binary name, e.g. \"fast-travel-companion\"."
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semver version of the companion binary, e.g. \"1.0.0\"."
+        },
+        "protocolVersion": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Protocol schema version. Starts at 1. The extension enforces a minimum and refuses older companions."
+        },
+        "os": {
+          "enum": ["linux", "windows", "macos"],
+          "description": "Operating system of the host running the companion. Android reports \"linux\" (Android runs on Linux kernel)."
+        },
+        "paired": {
+          "type": "boolean",
+          "description": "Whether the calling client has a valid pairing token."
+        },
+        "pairingOpen": {
+          "type": "boolean",
+          "description": "Whether the companion's pairing window is currently open and accepting new pairs."
+        },
+        "defaultIndexer": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Id of the indexer used by default for search requests."
+        },
+        "indexers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IndexerInfo"
+          },
+          "description": "All indexers discovered on this host, available or not."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PairRequest": {
+      "type": "object",
+      "description": "Body of POST /v1/pair. Requires the pairing window to be open.",
+      "required": ["clientName"],
+      "properties": {
+        "clientName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable name for the client, e.g. \"Fast Travel (Chrome)\"."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PairResponse": {
+      "type": "object",
+      "description": "Successful response from POST /v1/pair.",
+      "required": ["token"],
+      "properties": {
+        "token": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Bearer token to include in subsequent authenticated requests."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Sort": {
+      "type": "object",
+      "description": "Sort order for search results.",
+      "required": ["field", "dir"],
+      "properties": {
+        "field": {
+          "enum": ["relevance", "created", "modified"],
+          "description": "Field to sort by."
+        },
+        "dir": {
+          "enum": ["asc", "desc"],
+          "description": "Sort direction."
+        }
+      },
+      "additionalProperties": false
+    },
+    "DateRange": {
+      "type": "object",
+      "description": "Inclusive date range in epoch milliseconds. Omitting a bound leaves that end open.",
+      "properties": {
+        "from": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Start of range (epoch ms, inclusive). Omit for open start."
+        },
+        "to": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "End of range (epoch ms, inclusive). Omit for open end."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Filters": {
+      "type": "object",
+      "description": "Optional filters applied server-side before pagination. All fields are optional.",
+      "properties": {
+        "types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FileType"
+          },
+          "description": "Restrict results to these file-type categories."
+        },
+        "createdRange": {
+          "$ref": "#/$defs/DateRange",
+          "description": "Restrict to files created within this range."
+        },
+        "modifiedRange": {
+          "$ref": "#/$defs/DateRange",
+          "description": "Restrict to files last modified within this range."
+        },
+        "pathPrefix": {
+          "type": "string",
+          "description": "Restrict results to files whose absolute path starts with this prefix."
+        },
+        "titleOnly": {
+          "type": "boolean",
+          "description": "When true, match the file name only; ignore path and content fields."
+        },
+        "content": {
+          "type": "boolean",
+          "description": "When true, include content matches. Only honoured when the active indexer's capabilities.content is true."
+        }
+      },
+      "additionalProperties": false
+    },
+    "SearchRequest": {
+      "type": "object",
+      "description": "Body of POST /v1/search. Requires Bearer token.",
+      "required": ["query", "queryMode", "sort", "filters", "page", "pageSize"],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Raw user query in the mini-syntax (see README §2)."
+        },
+        "queryMode": {
+          "enum": ["simple", "wildcard", "regex"],
+          "description": "Parsing mode. simple: wildcards are literals. wildcard: * and ? are globs. regex: query is a regex; no AND/OR/NOT tokenization."
+        },
+        "sort": {
+          "$ref": "#/$defs/Sort"
+        },
+        "filters": {
+          "$ref": "#/$defs/Filters"
+        },
+        "page": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based page number."
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of results per page."
+        },
+        "history": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional list of recently opened result ids (FileResult.id). The companion may boost these for recency re-ranking."
+        }
+      },
+      "additionalProperties": false
+    },
+    "FileType": {
+      "enum": ["document", "image", "video", "audio", "archive", "code", "folder", "other"],
+      "description": "Broad file-type category used in FileResult.type and Filters.types."
+    },
+    "FileResult": {
+      "type": "object",
+      "description": "A single file match returned by /v1/search. FileResult.id is the absolute path of the file. Implementations that cannot guarantee a stable absolute path may use a deterministic hash of it, but must document the choice.",
+      "required": ["id", "name", "path", "dir", "ext", "mime", "type", "size", "createdAt", "modifiedAt", "score"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable result id. Canonical choice is the absolute path (e.g. /home/alice/docs/report.pdf). If using a hash, document the hash function."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "File name including extension, e.g. \"report.pdf\"."
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to the file, e.g. \"/home/alice/docs/report.pdf\"."
+        },
+        "dir": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to the parent directory, e.g. \"/home/alice/docs\"."
+        },
+        "ext": {
+          "type": "string",
+          "description": "Lowercase file extension without the leading dot, e.g. \"pdf\". Empty string for files with no extension."
+        },
+        "mime": {
+          "type": "string",
+          "description": "Best-effort MIME type, e.g. \"application/pdf\". Empty string when unknown."
+        },
+        "type": {
+          "$ref": "#/$defs/FileType"
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "File size in bytes. 0 for folders."
+        },
+        "createdAt": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Creation timestamp in epoch milliseconds. 0 when the platform does not expose ctime."
+        },
+        "modifiedAt": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Last-modified timestamp in epoch milliseconds. 0 when unknown."
+        },
+        "score": {
+          "type": "number",
+          "description": "Ranking score assigned by the indexer. Higher is better. Not comparable across indexers."
+        },
+        "iconHint": {
+          "type": "string",
+          "description": "Optional extra hint for icon selection, e.g. a MIME type or Android app package id."
+        }
+      },
+      "additionalProperties": false
+    },
+    "SearchResponse": {
+      "type": "object",
+      "description": "Successful response from POST /v1/search.",
+      "required": ["results", "total", "page", "tookMs", "indexer"],
+      "properties": {
+        "results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FileResult"
+          },
+          "description": "Paginated result set."
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of matches before pagination."
+        },
+        "page": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based page number of this response."
+        },
+        "tookMs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Time taken to produce this response, in milliseconds."
+        },
+        "indexer": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Id of the indexer that served this query. May differ from PingResponse.defaultIndexer when the companion routed a regex query to a capable fallback."
+        },
+        "degraded": {
+          "type": "boolean",
+          "description": "Optional. True when the requested query mode could not be served natively; results were filtered over a candidate set rather than the full index."
+        }
+      },
+      "additionalProperties": false
+    },
+    "OpenRequest": {
+      "type": "object",
+      "description": "Body of POST /v1/open. Requires Bearer token.",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path of the file or folder to open."
+        },
+        "reveal": {
+          "type": "boolean",
+          "description": "Optional. When true, reveal the item in the file manager instead of opening it directly."
+        }
+      },
+      "additionalProperties": false
+    },
+    "OpenResponse": {
+      "type": "object",
+      "description": "Successful response from POST /v1/open.",
+      "required": ["ok"],
+      "properties": {
+        "ok": {
+          "const": true,
+          "description": "Always true on success."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "description": "Error response returned by any endpoint on failure. HTTP status codes: unauthorized=401, pairing_closed=403, bad_request=400, indexer_unavailable=503, unsupported_mode=422, internal=500.",
+      "required": ["error", "message"],
+      "properties": {
+        "error": {
+          "enum": ["unauthorized", "pairing_closed", "bad_request", "indexer_unavailable", "unsupported_mode", "internal"],
+          "description": "Machine-readable error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description of the error."
+        }
+      },
+      "additionalProperties": false
+    },
+    "AstNode": {
+      "description": "A node in the parsed query AST. Produced by parsing a SearchRequest.query string under the mini-syntax rules (see README §2). The AST is the normalized, canonical representation used by all three implementations.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Logical AND: all child nodes must match. Children are flattened (no nested ands).",
+          "required": ["op", "nodes"],
+          "properties": {
+            "op": { "const": "and" },
+            "nodes": {
+              "type": "array",
+              "minItems": 2,
+              "items": { "$ref": "#/$defs/AstNode" }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Logical OR: at least one child node must match. AND binds tighter: 'a b OR c d' parses as (a AND b) OR (c AND d).",
+          "required": ["op", "nodes"],
+          "properties": {
+            "op": { "const": "or" },
+            "nodes": {
+              "type": "array",
+              "minItems": 2,
+              "items": { "$ref": "#/$defs/AstNode" }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Logical NOT: the child node must not match. Produced by a leading - or ! on a term.",
+          "required": ["op", "node"],
+          "properties": {
+            "op": { "const": "not" },
+            "node": { "$ref": "#/$defs/AstNode" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "A single term matched against a field. In wildcard mode, wildcard:true if the value contains * or ?. In simple mode, wildcard is always false.",
+          "required": ["op", "field", "value", "wildcard"],
+          "properties": {
+            "op": { "const": "term" },
+            "field": {
+              "enum": ["name", "path"],
+              "description": "Field to match against. path: prefix in the query sets this to \"path\"."
+            },
+            "value": {
+              "type": "string",
+              "description": "The term string (with path: prefix stripped)."
+            },
+            "wildcard": {
+              "type": "boolean",
+              "description": "True only in wildcard mode when the value contains * or ?."
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "A quoted phrase matched as a contiguous sequence of words against a field.",
+          "required": ["op", "field", "value"],
+          "properties": {
+            "op": { "const": "phrase" },
+            "field": {
+              "enum": ["name", "path"]
+            },
+            "value": {
+              "type": "string",
+              "description": "The phrase content (without surrounding quotes)."
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "A regular expression (regex mode only). No AND/OR/NOT tokenization occurs; the entire query string is the regex value.",
+          "required": ["op", "field", "value"],
+          "properties": {
+            "op": { "const": "regex" },
+            "field": {
+              "enum": ["name", "path"],
+              "description": "\"path\" when query starts with path:, otherwise \"name\"."
+            },
+            "value": {
+              "type": "string",
+              "description": "The regex string (with path: prefix stripped if present)."
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/shared/companion-protocol/protocol.schema.json
+++ b/shared/companion-protocol/protocol.schema.json
@@ -82,8 +82,8 @@
           "description": "Protocol schema version. Starts at 1. The extension enforces a minimum and refuses older companions."
         },
         "os": {
-          "enum": ["linux", "windows", "macos"],
-          "description": "Operating system of the host running the companion. Android reports \"linux\" (Android runs on Linux kernel)."
+          "enum": ["linux", "windows", "macos", "android"],
+          "description": "Operating system of the host running the companion."
         },
         "paired": {
           "type": "boolean",

--- a/shared/companion-protocol/protocol.schema.json
+++ b/shared/companion-protocol/protocol.schema.json
@@ -236,6 +236,14 @@
             "type": "string"
           },
           "description": "Optional list of recently opened result ids (FileResult.id). The companion may boost these for recency re-ranking."
+        },
+        "caseSensitive": {
+          "type": "boolean",
+          "description": "Optional. When true, term and phrase matching is case-sensitive. Default false (case-insensitive). Regex nodes are unaffected — the pattern's own flags control case."
+        },
+        "exactPhrase": {
+          "type": "boolean",
+          "description": "Optional. When true, the whole query string is treated as one ordered phrase (ignored in regex mode). Default false (AND of individual terms)."
         }
       },
       "additionalProperties": false

--- a/shared/companion-protocol/validate.mjs
+++ b/shared/companion-protocol/validate.mjs
@@ -18,7 +18,7 @@ const QUERY_MODES = new Set(["simple", "wildcard", "regex"]);
 const SORT_FIELDS = new Set(["relevance", "created", "modified"]);
 const SORT_DIRS = new Set(["asc", "desc"]);
 const FILE_TYPES = new Set(["document", "image", "video", "audio", "archive", "code", "folder", "other"]);
-const OS_VALUES = new Set(["linux", "windows", "macos"]);
+const OS_VALUES = new Set(["linux", "windows", "macos", "android"]);
 const AST_OPS = new Set(["and", "or", "not", "term", "phrase", "regex"]);
 const AST_FIELDS = new Set(["name", "path"]);
 

--- a/shared/companion-protocol/validate.mjs
+++ b/shared/companion-protocol/validate.mjs
@@ -216,7 +216,7 @@ function validateFilters(filters, path, errors) {
 }
 
 // --- SearchRequest validator ---
-const SEARCH_REQUEST_KEYS = new Set(["query", "queryMode", "sort", "filters", "page", "pageSize", "history"]);
+const SEARCH_REQUEST_KEYS = new Set(["query", "queryMode", "sort", "filters", "page", "pageSize", "history", "caseSensitive", "exactPhrase"]);
 
 function validateSearchRequest(req, path, errors) {
   if (!isObject(req)) { errors.push(`${path}: must be an object`); return; }
@@ -245,6 +245,12 @@ function validateSearchRequest(req, path, errors) {
         if (!isString(s)) errors.push(`${path}.history[${i}]: must be a string`);
       });
     }
+  }
+  if (req.caseSensitive !== undefined && !isBool(req.caseSensitive)) {
+    errors.push(`${path}.caseSensitive: must be a boolean if present`);
+  }
+  if (req.exactPhrase !== undefined && !isBool(req.exactPhrase)) {
+    errors.push(`${path}.exactPhrase: must be a boolean if present`);
   }
 }
 

--- a/shared/companion-protocol/validate.mjs
+++ b/shared/companion-protocol/validate.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+// Validates shared/companion-protocol fixtures against the shapes defined in
+// protocol.schema.json (hand-rolled subset — the JSON Schema is the source of
+// truth; this script enforces the same invariants both clients rely on at
+// runtime).
+//
+// Exit 0 = OK, exit 1 = errors. Use as a pre-commit / CI gate:
+//   node shared/companion-protocol/validate.mjs
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// --- constants (mirrors schema enums) ---
+const QUERY_MODES = new Set(["simple", "wildcard", "regex"]);
+const SORT_FIELDS = new Set(["relevance", "created", "modified"]);
+const SORT_DIRS = new Set(["asc", "desc"]);
+const FILE_TYPES = new Set(["document", "image", "video", "audio", "archive", "code", "folder", "other"]);
+const OS_VALUES = new Set(["linux", "windows", "macos"]);
+const AST_OPS = new Set(["and", "or", "not", "term", "phrase", "regex"]);
+const AST_FIELDS = new Set(["name", "path"]);
+
+// --- helpers ---
+function isString(v) { return typeof v === "string"; }
+function isNonEmptyString(v) { return typeof v === "string" && v.length > 0; }
+function isInteger(v) { return Number.isInteger(v); }
+function isNonNegInt(v) { return Number.isInteger(v) && v >= 0; }
+function isPosInt(v) { return Number.isInteger(v) && v >= 1; }
+function isBool(v) { return typeof v === "boolean"; }
+function isArray(v) { return Array.isArray(v); }
+function isObject(v) { return v !== null && typeof v === "object" && !Array.isArray(v); }
+
+function checkKeys(obj, allowed, path, errors) {
+  for (const k of Object.keys(obj)) {
+    if (!allowed.has(k)) errors.push(`${path}: unexpected property "${k}"`);
+  }
+}
+
+// --- AST node validator ---
+const AST_AND_KEYS = new Set(["op", "nodes"]);
+const AST_OR_KEYS = new Set(["op", "nodes"]);
+const AST_NOT_KEYS = new Set(["op", "node"]);
+const AST_TERM_KEYS = new Set(["op", "field", "value", "wildcard"]);
+const AST_PHRASE_KEYS = new Set(["op", "field", "value"]);
+const AST_REGEX_KEYS = new Set(["op", "field", "value"]);
+
+function validateAstNode(node, path, errors) {
+  if (!isObject(node)) {
+    errors.push(`${path}: AST node must be an object`);
+    return;
+  }
+  if (!AST_OPS.has(node.op)) {
+    errors.push(`${path}.op: must be one of ${[...AST_OPS].join(", ")} — got ${JSON.stringify(node.op)}`);
+    return;
+  }
+  switch (node.op) {
+    case "and":
+      checkKeys(node, AST_AND_KEYS, path, errors);
+      if (!isArray(node.nodes) || node.nodes.length < 2) {
+        errors.push(`${path}.nodes: must be an array with at least 2 elements for op "and"`);
+      } else {
+        node.nodes.forEach((n, i) => validateAstNode(n, `${path}.nodes[${i}]`, errors));
+      }
+      break;
+    case "or":
+      checkKeys(node, AST_OR_KEYS, path, errors);
+      if (!isArray(node.nodes) || node.nodes.length < 2) {
+        errors.push(`${path}.nodes: must be an array with at least 2 elements for op "or"`);
+      } else {
+        node.nodes.forEach((n, i) => validateAstNode(n, `${path}.nodes[${i}]`, errors));
+      }
+      break;
+    case "not":
+      checkKeys(node, AST_NOT_KEYS, path, errors);
+      if (!isObject(node.node)) {
+        errors.push(`${path}.node: must be an AST node object`);
+      } else {
+        validateAstNode(node.node, `${path}.node`, errors);
+      }
+      break;
+    case "term":
+      checkKeys(node, AST_TERM_KEYS, path, errors);
+      if (!AST_FIELDS.has(node.field)) {
+        errors.push(`${path}.field: must be "name" or "path" — got ${JSON.stringify(node.field)}`);
+      }
+      if (!isString(node.value)) errors.push(`${path}.value: must be a string`);
+      if (!isBool(node.wildcard)) errors.push(`${path}.wildcard: must be a boolean`);
+      break;
+    case "phrase":
+      checkKeys(node, AST_PHRASE_KEYS, path, errors);
+      if (!AST_FIELDS.has(node.field)) {
+        errors.push(`${path}.field: must be "name" or "path" — got ${JSON.stringify(node.field)}`);
+      }
+      if (!isString(node.value)) errors.push(`${path}.value: must be a string`);
+      break;
+    case "regex":
+      checkKeys(node, AST_REGEX_KEYS, path, errors);
+      if (!AST_FIELDS.has(node.field)) {
+        errors.push(`${path}.field: must be "name" or "path" — got ${JSON.stringify(node.field)}`);
+      }
+      if (!isString(node.value)) errors.push(`${path}.value: must be a string`);
+      break;
+  }
+}
+
+// --- Capabilities validator ---
+const CAPABILITIES_KEYS = new Set(["booleanOps", "prefixWildcard", "infixWildcard", "regex", "pathScope", "content"]);
+const CAPABILITIES_REQUIRED = ["booleanOps", "prefixWildcard", "infixWildcard", "regex", "pathScope", "content"];
+
+function validateCapabilities(cap, path, errors) {
+  if (!isObject(cap)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(cap, CAPABILITIES_KEYS, path, errors);
+  for (const k of CAPABILITIES_REQUIRED) {
+    if (!isBool(cap[k])) errors.push(`${path}.${k}: must be a boolean`);
+  }
+}
+
+// --- IndexerInfo validator ---
+const INDEXER_INFO_KEYS = new Set(["id", "name", "available", "capabilities"]);
+
+function validateIndexerInfo(idx, path, errors) {
+  if (!isObject(idx)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(idx, INDEXER_INFO_KEYS, path, errors);
+  if (!isNonEmptyString(idx.id)) errors.push(`${path}.id: must be a non-empty string`);
+  if (!isNonEmptyString(idx.name)) errors.push(`${path}.name: must be a non-empty string`);
+  if (!isBool(idx.available)) errors.push(`${path}.available: must be a boolean`);
+  if (idx.capabilities === undefined) {
+    errors.push(`${path}.capabilities: required`);
+  } else {
+    validateCapabilities(idx.capabilities, `${path}.capabilities`, errors);
+  }
+}
+
+// --- PingResponse validator ---
+const PING_KEYS = new Set(["name", "version", "protocolVersion", "os", "paired", "pairingOpen", "defaultIndexer", "indexers"]);
+
+function validatePingResponse(ping, path, errors) {
+  if (!isObject(ping)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(ping, PING_KEYS, path, errors);
+  if (!isNonEmptyString(ping.name)) errors.push(`${path}.name: must be a non-empty string`);
+  if (!isNonEmptyString(ping.version)) errors.push(`${path}.version: must be a non-empty string`);
+  if (!isInteger(ping.protocolVersion) || ping.protocolVersion < 1) {
+    errors.push(`${path}.protocolVersion: must be an integer >= 1`);
+  }
+  if (!OS_VALUES.has(ping.os)) {
+    errors.push(`${path}.os: must be one of ${[...OS_VALUES].join(", ")} — got ${JSON.stringify(ping.os)}`);
+  }
+  if (!isBool(ping.paired)) errors.push(`${path}.paired: must be a boolean`);
+  if (!isBool(ping.pairingOpen)) errors.push(`${path}.pairingOpen: must be a boolean`);
+  if (!isNonEmptyString(ping.defaultIndexer)) errors.push(`${path}.defaultIndexer: must be a non-empty string`);
+  if (!isArray(ping.indexers)) {
+    errors.push(`${path}.indexers: must be an array`);
+  } else {
+    ping.indexers.forEach((idx, i) => validateIndexerInfo(idx, `${path}.indexers[${i}]`, errors));
+  }
+}
+
+// --- Sort validator ---
+const SORT_KEYS = new Set(["field", "dir"]);
+
+function validateSort(sort, path, errors) {
+  if (!isObject(sort)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(sort, SORT_KEYS, path, errors);
+  if (!SORT_FIELDS.has(sort.field)) {
+    errors.push(`${path}.field: must be one of ${[...SORT_FIELDS].join(", ")} — got ${JSON.stringify(sort.field)}`);
+  }
+  if (!SORT_DIRS.has(sort.dir)) {
+    errors.push(`${path}.dir: must be one of ${[...SORT_DIRS].join(", ")} — got ${JSON.stringify(sort.dir)}`);
+  }
+}
+
+// --- DateRange validator ---
+const DATE_RANGE_KEYS = new Set(["from", "to"]);
+
+function validateDateRange(dr, path, errors) {
+  if (!isObject(dr)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(dr, DATE_RANGE_KEYS, path, errors);
+  if (dr.from !== undefined && !isNonNegInt(dr.from)) {
+    errors.push(`${path}.from: must be an integer >= 0 (epoch ms)`);
+  }
+  if (dr.to !== undefined && !isNonNegInt(dr.to)) {
+    errors.push(`${path}.to: must be an integer >= 0 (epoch ms)`);
+  }
+}
+
+// --- Filters validator ---
+const FILTERS_KEYS = new Set(["types", "createdRange", "modifiedRange", "pathPrefix", "titleOnly", "content"]);
+
+function validateFilters(filters, path, errors) {
+  if (!isObject(filters)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(filters, FILTERS_KEYS, path, errors);
+  if (filters.types !== undefined) {
+    if (!isArray(filters.types)) {
+      errors.push(`${path}.types: must be an array`);
+    } else {
+      filters.types.forEach((t, i) => {
+        if (!FILE_TYPES.has(t)) {
+          errors.push(`${path}.types[${i}]: must be one of ${[...FILE_TYPES].join(", ")} — got ${JSON.stringify(t)}`);
+        }
+      });
+    }
+  }
+  if (filters.createdRange !== undefined) validateDateRange(filters.createdRange, `${path}.createdRange`, errors);
+  if (filters.modifiedRange !== undefined) validateDateRange(filters.modifiedRange, `${path}.modifiedRange`, errors);
+  if (filters.pathPrefix !== undefined && !isString(filters.pathPrefix)) {
+    errors.push(`${path}.pathPrefix: must be a string`);
+  }
+  if (filters.titleOnly !== undefined && !isBool(filters.titleOnly)) {
+    errors.push(`${path}.titleOnly: must be a boolean`);
+  }
+  if (filters.content !== undefined && !isBool(filters.content)) {
+    errors.push(`${path}.content: must be a boolean`);
+  }
+}
+
+// --- SearchRequest validator ---
+const SEARCH_REQUEST_KEYS = new Set(["query", "queryMode", "sort", "filters", "page", "pageSize", "history"]);
+
+function validateSearchRequest(req, path, errors) {
+  if (!isObject(req)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(req, SEARCH_REQUEST_KEYS, path, errors);
+  if (!isString(req.query)) errors.push(`${path}.query: must be a string`);
+  if (!QUERY_MODES.has(req.queryMode)) {
+    errors.push(`${path}.queryMode: must be one of ${[...QUERY_MODES].join(", ")} — got ${JSON.stringify(req.queryMode)}`);
+  }
+  if (req.sort === undefined) {
+    errors.push(`${path}.sort: required`);
+  } else {
+    validateSort(req.sort, `${path}.sort`, errors);
+  }
+  if (req.filters === undefined) {
+    errors.push(`${path}.filters: required`);
+  } else {
+    validateFilters(req.filters, `${path}.filters`, errors);
+  }
+  if (!isNonNegInt(req.page)) errors.push(`${path}.page: must be an integer >= 0`);
+  if (!isPosInt(req.pageSize)) errors.push(`${path}.pageSize: must be an integer >= 1`);
+  if (req.history !== undefined) {
+    if (!isArray(req.history)) {
+      errors.push(`${path}.history: must be an array if present`);
+    } else {
+      req.history.forEach((s, i) => {
+        if (!isString(s)) errors.push(`${path}.history[${i}]: must be a string`);
+      });
+    }
+  }
+}
+
+// --- FileResult validator ---
+const FILE_RESULT_KEYS = new Set(["id", "name", "path", "dir", "ext", "mime", "type", "size", "createdAt", "modifiedAt", "score", "iconHint"]);
+
+function validateFileResult(result, path, errors) {
+  if (!isObject(result)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(result, FILE_RESULT_KEYS, path, errors);
+  if (!isNonEmptyString(result.id)) errors.push(`${path}.id: must be a non-empty string`);
+  if (!isNonEmptyString(result.name)) errors.push(`${path}.name: must be a non-empty string`);
+  if (!isNonEmptyString(result.path)) errors.push(`${path}.path: must be a non-empty string`);
+  if (!isNonEmptyString(result.dir)) errors.push(`${path}.dir: must be a non-empty string`);
+  if (!isString(result.ext)) errors.push(`${path}.ext: must be a string`);
+  if (!isString(result.mime)) errors.push(`${path}.mime: must be a string`);
+  if (!FILE_TYPES.has(result.type)) {
+    errors.push(`${path}.type: must be one of ${[...FILE_TYPES].join(", ")} — got ${JSON.stringify(result.type)}`);
+  }
+  if (!isNonNegInt(result.size)) errors.push(`${path}.size: must be an integer >= 0 (bytes)`);
+  if (!isNonNegInt(result.createdAt)) errors.push(`${path}.createdAt: must be an integer >= 0 (epoch ms)`);
+  if (!isNonNegInt(result.modifiedAt)) errors.push(`${path}.modifiedAt: must be an integer >= 0 (epoch ms)`);
+  if (typeof result.score !== "number") errors.push(`${path}.score: must be a number`);
+  if (result.iconHint !== undefined && !isString(result.iconHint)) {
+    errors.push(`${path}.iconHint: must be a string if present`);
+  }
+}
+
+// --- SearchResponse validator ---
+const SEARCH_RESPONSE_KEYS = new Set(["results", "total", "page", "tookMs", "indexer", "degraded"]);
+
+function validateSearchResponse(resp, path, errors) {
+  if (!isObject(resp)) { errors.push(`${path}: must be an object`); return; }
+  checkKeys(resp, SEARCH_RESPONSE_KEYS, path, errors);
+  if (!isArray(resp.results)) {
+    errors.push(`${path}.results: must be an array`);
+  } else {
+    resp.results.forEach((r, i) => validateFileResult(r, `${path}.results[${i}]`, errors));
+  }
+  if (!isNonNegInt(resp.total)) errors.push(`${path}.total: must be an integer >= 0`);
+  if (!isNonNegInt(resp.page)) errors.push(`${path}.page: must be an integer >= 0`);
+  if (!isNonNegInt(resp.tookMs)) errors.push(`${path}.tookMs: must be an integer >= 0`);
+  if (!isNonEmptyString(resp.indexer)) errors.push(`${path}.indexer: must be a non-empty string`);
+  if (resp.degraded !== undefined && !isBool(resp.degraded)) {
+    errors.push(`${path}.degraded: must be a boolean if present`);
+  }
+}
+
+// --- file loader ---
+function loadJson(filePath, label) {
+  let raw;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (e) {
+    return { error: `Cannot read ${label}: ${e.message}` };
+  }
+  try {
+    return { data: JSON.parse(raw) };
+  } catch (e) {
+    return { error: `Invalid JSON in ${label}: ${e.message}` };
+  }
+}
+
+// --- fixture validators ---
+function validateQueryParsing(data, errors) {
+  if (!isObject(data) || !isArray(data.cases)) {
+    errors.push("fixtures/query-parsing.json: must be { cases: [...] }");
+    return 0;
+  }
+  data.cases.forEach((c, i) => {
+    const p = `query-parsing.cases[${i}] ("${c.name ?? i}")`;
+    if (!isNonEmptyString(c.name)) errors.push(`${p}.name: must be a non-empty string`);
+    if (!isString(c.query)) errors.push(`${p}.query: must be a string`);
+    if (!QUERY_MODES.has(c.queryMode)) {
+      errors.push(`${p}.queryMode: must be one of ${[...QUERY_MODES].join(", ")} — got ${JSON.stringify(c.queryMode)}`);
+    }
+    validateAstNode(c.ast, `${p}.ast`, errors);
+  });
+  return data.cases.length;
+}
+
+function validateSearchExamples(data, errors) {
+  if (!isObject(data) || !isArray(data.cases)) {
+    errors.push("fixtures/search-examples.json: must be { cases: [...] }");
+    return 0;
+  }
+  data.cases.forEach((c, i) => {
+    const p = `search-examples.cases[${i}] ("${c.name ?? i}")`;
+    if (!isNonEmptyString(c.name)) errors.push(`${p}.name: must be a non-empty string`);
+    if (c.request === undefined) {
+      errors.push(`${p}.request: required`);
+    } else {
+      validateSearchRequest(c.request, `${p}.request`, errors);
+    }
+    if (c.response === undefined) {
+      errors.push(`${p}.response: required`);
+    } else {
+      validateSearchResponse(c.response, `${p}.response`, errors);
+    }
+  });
+  return data.cases.length;
+}
+
+function validateCapabilitiesCases(data, errors) {
+  if (!isObject(data) || !isArray(data.cases)) {
+    errors.push("fixtures/capabilities.json: must be { cases: [...] }");
+    return 0;
+  }
+  data.cases.forEach((c, i) => {
+    const p = `capabilities.cases[${i}] ("${c.name ?? i}")`;
+    if (!isNonEmptyString(c.name)) errors.push(`${p}.name: must be a non-empty string`);
+    if (c.ping === undefined) {
+      errors.push(`${p}.ping: required`);
+    } else {
+      validatePingResponse(c.ping, `${p}.ping`, errors);
+    }
+  });
+  return data.cases.length;
+}
+
+// --- main ---
+function main() {
+  let totalErrors = 0;
+
+  // 1. Verify schema exists and is valid JSON
+  const schemaPath = resolve(HERE, "protocol.schema.json");
+  const schemaResult = loadJson(schemaPath, "protocol.schema.json");
+  if (schemaResult.error) {
+    console.error(schemaResult.error);
+    process.exit(1);
+  }
+  console.log("OK protocol.schema.json");
+
+  // 2. query-parsing.json
+  {
+    const label = "fixtures/query-parsing.json";
+    const result = loadJson(resolve(HERE, label), label);
+    if (result.error) {
+      console.error(result.error);
+      totalErrors++;
+    } else {
+      const errors = [];
+      const count = validateQueryParsing(result.data, errors);
+      if (errors.length === 0) {
+        console.log(`OK ${label} (${count} cases)`);
+      } else {
+        console.error(`FAIL ${label} (${errors.length} error${errors.length === 1 ? "" : "s"}):`);
+        for (const e of errors) console.error(`  - ${e}`);
+        totalErrors += errors.length;
+      }
+    }
+  }
+
+  // 3. search-examples.json
+  {
+    const label = "fixtures/search-examples.json";
+    const result = loadJson(resolve(HERE, label), label);
+    if (result.error) {
+      console.error(result.error);
+      totalErrors++;
+    } else {
+      const errors = [];
+      const count = validateSearchExamples(result.data, errors);
+      if (errors.length === 0) {
+        console.log(`OK ${label} (${count} cases)`);
+      } else {
+        console.error(`FAIL ${label} (${errors.length} error${errors.length === 1 ? "" : "s"}):`);
+        for (const e of errors) console.error(`  - ${e}`);
+        totalErrors += errors.length;
+      }
+    }
+  }
+
+  // 4. capabilities.json
+  {
+    const label = "fixtures/capabilities.json";
+    const result = loadJson(resolve(HERE, label), label);
+    if (result.error) {
+      console.error(result.error);
+      totalErrors++;
+    } else {
+      const errors = [];
+      const count = validateCapabilitiesCases(result.data, errors);
+      if (errors.length === 0) {
+        console.log(`OK ${label} (${count} cases)`);
+      } else {
+        console.error(`FAIL ${label} (${errors.length} error${errors.length === 1 ? "" : "s"}):`);
+        for (const e of errors) console.error(`  - ${e}`);
+        totalErrors += errors.length;
+      }
+    }
+  }
+
+  if (totalErrors === 0) {
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Local file search via the `s` command — closes #25

Adds a local file-search command bound to `s`, spanning all three surfaces with a shared protocol contract:

- **Go companion daemon** (`companion/`) — desktop file search over a token-gated loopback HTTP API.
- **Browser extension** — settings/pairing + a Drive-style results UI for `s <query>`.
- **Android app** — native on-device search (MediaStore) with a Kotlin parity core.

### What's included
- **Shared protocol** (`shared/companion-protocol/`): JSON schema + AST/search/capability fixtures + a hand-rolled validator. The query mini-syntax → AST and the matching semantics are the cross-platform parity contract (epoch-ms throughout).
- **Companion (Go)**: loopback HTTP `/v1` (ping/pair/search/open) with token + Origin-locked pairing; pluggable indexer backends — **Linux** Baloo/Tracker/plocate, **Windows** Windows Search + Everything — with **recall-safe query compilation** and regex routing to a regex-capable backend; OS-aware file opener + autostart (Linux/Windows/macOS); cross-compile build script + an independent GitHub-release workflow.
- **Extension (TS)**: companion client + device-local prefs; **Local Search** settings screen (off by default, OS-detected install guide, 1-click pairing, `s`-keyword collision guard, capability-gated defaults); `s`-command intercept + full **Drive-style results UI** (query-mode/sort/filter toolbar, list/grid views, per-type icons, load-more pagination, keyboard nav, open/reveal).
- **Android (Kotlin)**: a JVM-pure parity core (parser + matcher + pipeline, gated by the **shared fixtures**), MediaStore search source + permissions, Local Search settings + collision guard, the `s` intercept + a Compose results screen with the same toolbar/grid/pagination.
- **Query options** (both platforms): **Exact phrase** (off = all-words-any-order; on = ordered phrase; disabled in Regex) and **Match case** toggles.

### Testing
- `companion` `go test ./...` (7 packages) + cross-builds (`windows/amd64`, `darwin/amd64`, `linux/arm64`); extension **426** Vitest unit tests + Chrome/Firefox builds; Android `./gradlew test` + `assembleDebug`; shared-protocol validator. Built in reviewed slices (per-slice implement → review → fix) with a whole-branch parity/security review.
- The desktop happy path was verified **live** against the real companion (pair → enable → `s <query>` → results → sort/filter/grid/open → graceful disconnect).

### Notes for reviewers
- **Not for merge yet** — opened for review/testing.
- A reporter-observed "crash on search" did **not** reproduce in two independent real-stack runs; a DevTools console error is needed to pin it (suspected to be resolved by the focus/suggestion fixes in this branch). The newest query-option toggles are covered by unit tests + review but not a live click-through this session (headless-Chromium MV3 service-worker limitation).
- The companion versions **independently** of the app and is distributed via GitHub Releases only.
- Deferred non-blocking polish/hardening items are tracked in the branch's progress ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALrYbj1VUehuCEkn4jxpCg
