### PR TITLE
Update Instagram search URL to keyword search format

### DIFF
--- a/android/app/src/main/assets/default-config.json
+++ b/android/app/src/main/assets/default-config.json
@@ -921,7 +921,7 @@
             {
               "devices": "*",
               "defaultUrl": "https://www.instagram.com",
-              "searchUrl": "https://www.instagram.com/explore/tags/{query}"
+              "searchUrl": "https://www.instagram.com/explore/search/keyword/?q={query}"
             }
           ]
         },

--- a/shared/config/default-config.json
+++ b/shared/config/default-config.json
@@ -921,7 +921,7 @@
             {
               "devices": "*",
               "defaultUrl": "https://www.instagram.com",
-              "searchUrl": "https://www.instagram.com/explore/tags/{query}"
+              "searchUrl": "https://www.instagram.com/explore/search/keyword/?q={query}"
             }
           ]
         },


### PR DESCRIPTION
Switch Instagram's tag search page to the keyword search endpoint instead.