### PR TITLE
fix(android): clean relaunch state + make icon follow the app theme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,10 +31,8 @@
             android:launchMode="singleTask"
             android:clearTaskOnLaunch="true"
             android:theme="@style/Theme.FastTravel">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+            <!-- MAIN/LAUNCHER lives on the activity-aliases below so the drawer icon
+                 can flip light/dark with the in-app theme (see LauncherIconManager). -->
 
             <!-- Deep link: fasttravel://search?q={query} -->
             <intent-filter>
@@ -60,6 +58,40 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        <!--
+            Launcher entry points. Exactly one alias is enabled at a time; the app
+            toggles them (LauncherIconManager) so the drawer/launcher icon follows the
+            in-app Light/Dark theme. LauncherLight is enabled by default. Note: the
+            Settings > Apps listing uses the <application> icon and does NOT flip.
+        -->
+        <activity-alias
+            android:name=".ui.LauncherLight"
+            android:targetActivity=".ui.SearchActivity"
+            android:enabled="true"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
+
+        <activity-alias
+            android:name=".ui.LauncherDark"
+            android:targetActivity=".ui.SearchActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher_dark"
+            android:roundIcon="@mipmap/ic_launcher_dark_round"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
 
         <activity
             android:name=".ui.SettingsActivity"

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/LauncherIconManager.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/LauncherIconManager.kt
@@ -1,0 +1,94 @@
+package sh.kavi.fasttravel.ui
+
+import android.app.Activity
+import android.app.ActivityManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.content.ContextCompat
+import sh.kavi.fasttravel.R
+import sh.kavi.fasttravel.ui.appearance.ResolvedAppearance
+
+/**
+ * Drives the two launcher-facing surfaces that should follow the in-app theme:
+ *  - the drawer/launcher icon, via two activity-aliases toggled here, and
+ *  - the recents/overview card, via [Activity.setTaskDescription].
+ *
+ * The Settings > Apps listing uses the `<application>` icon, which is fixed at build
+ * time and can't follow the in-app theme at runtime — an OS limitation, not handled here.
+ */
+object LauncherIconManager {
+    // Fully-qualified names of the launcher activity-aliases declared in AndroidManifest.
+    const val ALIAS_LIGHT = "sh.kavi.fasttravel.ui.LauncherLight"
+    const val ALIAS_DARK = "sh.kavi.fasttravel.ui.LauncherDark"
+
+    /** The launcher alias that should be enabled for the given surface darkness. */
+    fun aliasFor(isDark: Boolean): String = if (isDark) ALIAS_DARK else ALIAS_LIGHT
+
+    /**
+     * Opaque ARGB used to tint the recents card header. `TaskDescription` requires an
+     * opaque primary color, so the alpha byte is forced to 0xFF.
+     */
+    fun recentsPrimaryColor(appearance: ResolvedAppearance): Int =
+        appearance.colorScheme.background.toArgb() or 0xFF000000.toInt()
+
+    /**
+     * Enable the alias matching [isDark] and disable the other, so exactly one launcher
+     * icon is ever live. Idempotent: no-ops when already in the desired state to avoid
+     * redundant PackageManager writes / icon flicker. `DONT_KILL_APP` keeps the running
+     * task alive; callers switch on `onStop()` so flipping the live launcher component
+     * can't drop the task from recents.
+     */
+    fun applyThemeIcon(context: Context, isDark: Boolean) {
+        val pm = context.packageManager
+        val pkg = context.packageName
+        val enable = ComponentName(pkg, aliasFor(isDark))
+        val disable = ComponentName(pkg, aliasFor(!isDark))
+
+        val alreadyApplied =
+            pm.getComponentEnabledSetting(enable) == PackageManager.COMPONENT_ENABLED_STATE_ENABLED &&
+                pm.getComponentEnabledSetting(disable) == PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        if (alreadyApplied) return
+
+        // Enable the target before disabling the other so at least one alias is always on.
+        pm.setComponentEnabledSetting(
+            enable,
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            PackageManager.DONT_KILL_APP,
+        )
+        pm.setComponentEnabledSetting(
+            disable,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP,
+        )
+    }
+
+    /**
+     * Point the recents/overview card at the current theme: an opaque header color and a
+     * themed icon rendered from the matching adaptive launcher icon. The header color is
+     * honored broadly across OEMs; the icon is best-effort (many launchers reuse the
+     * activity-alias icon in recents anyway, which we already theme).
+     */
+    fun applyTaskDescription(activity: Activity, appearance: ResolvedAppearance) {
+        val label = activity.getString(R.string.app_name)
+        val color = recentsPrimaryColor(appearance)
+        val iconRes = if (appearance.isDarkSurface) R.mipmap.ic_launcher_dark else R.mipmap.ic_launcher
+        @Suppress("DEPRECATION")
+        activity.setTaskDescription(
+            ActivityManager.TaskDescription(label, renderIcon(activity, iconRes), color),
+        )
+    }
+
+    /** Rasterize an (adaptive) launcher icon drawable into a square bitmap for recents. */
+    private fun renderIcon(context: Context, resId: Int, sizePx: Int = 192): Bitmap? {
+        val drawable = ContextCompat.getDrawable(context, resId) ?: return null
+        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, sizePx, sizePx)
+        drawable.draw(canvas)
+        return bitmap
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -11,6 +11,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -273,6 +274,12 @@ class SearchActivity : ComponentActivity() {
     // increments replay it on each foreground transition.
     private val resumeTick = kotlinx.coroutines.flow.MutableStateFlow(0)
 
+    // The retained, activity-scoped SearchViewModel — the SAME instance the composable
+    // obtains via viewModel(). Holding a reference here lets onStop() reset its state
+    // before the app is backgrounded, so a relaunch starts clean instead of flashing
+    // the previous query + stale suggestions (see SearchViewModel.resetForFreshStart).
+    private val viewModel: SearchViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -332,6 +339,7 @@ class SearchActivity : ComponentActivity() {
                         )
                 ) {
                     SearchScreen(
+                        viewModel = viewModel,
                         initialQuery = deepLinkQuery,
                         fromWidget = fromWidget,
                         focusTick = tick,
@@ -346,6 +354,26 @@ class SearchActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         resumeTick.value++
+        // Keep the recents/overview card tinted to the (possibly just-changed) theme.
+        LauncherIconManager.applyTaskDescription(
+            this,
+            resolveFromPrefs(applicationContext, ThemePreferences(this)),
+        )
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // Reset transient search state while the app is off-screen (opened another app,
+        // home, recents) so the next resume's first frame is already a clean, empty
+        // search bar — no ~1s flash of the previous query + its stale suggestions.
+        viewModel.resetForFreshStart()
+        // Flip the drawer/launcher icon to match the theme while we're off-screen —
+        // switching the live launcher component while foregrounded can drop the task
+        // from recents on some Android versions.
+        LauncherIconManager.applyThemeIcon(
+            this,
+            resolveFromPrefs(applicationContext, ThemePreferences(this)).isDarkSurface,
+        )
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -216,6 +216,26 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         updateChipCommands()
     }
 
+    /**
+     * Reset transient search state back to a cold-open state, synchronously.
+     *
+     * The query + suggestions live in this retained (activity-scoped) ViewModel and,
+     * with the launcher's `singleTask` mode, survive the app being backgrounded to
+     * open another app. Without this reset, relaunching flashes the previous query +
+     * its stale Google suggestions for ~1s before the post-resume effect clears them.
+     * Called from the Activity's `onStop()` so the state is already clean on the next
+     * resume's first frame (no flash). Suggestions are restored to the "Recent" list
+     * immediately (no debounce) so the resumed empty state matches a cold open.
+     */
+    fun resetForFreshStart() {
+        suggestionJob?.cancel()
+        installedAppsJob?.cancel()
+        _query.value = ""
+        _searchState.value = SearchState.Idle
+        _installedApps.value = emptyList()
+        _suggestions.value = config?.let { getHistorySuggestions(it) } ?: emptyList()
+    }
+
     private fun flattenCommands(groups: List<Group>): List<Command> = groups.flatMap { it.commands }
 
     /**

--- a/android/app/src/main/res/drawable/ic_launcher_foreground_dark.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground_dark.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dark-theme variant of the chevron mark. Same shape as ic_launcher_foreground,
+     with lightened strokes so it stays legible on the dark launcher background. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <path
+        android:strokeColor="#B9BEDC"
+        android:strokeWidth="9"
+        android:strokeLineCap="butt"
+        android:strokeLineJoin="miter"
+        android:pathData="M39,41 L53,54 L39,67" />
+
+    <path
+        android:strokeColor="#6FA0E0"
+        android:strokeWidth="9"
+        android:strokeLineCap="butt"
+        android:strokeLineJoin="miter"
+        android:pathData="M55,41 L69,54 L55,67" />
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_dark.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_dark.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background_dark" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_dark" />
+    <!-- Android 13+ themed icons: the launcher tints this silhouette to match the
+         system theme when "Themed icons" is on. Reuses the chevron shape. -->
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_dark_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_dark_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background_dark" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_dark" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -2,6 +2,9 @@
 <resources>
     <color name="widget_hint_text">#9AA0A6</color>
     <color name="ic_launcher_background">#F5F2EC</color>
+    <!-- Dark launcher-icon background (Night). Used by the LauncherDark activity-alias
+         so the drawer icon flips to match the in-app dark theme. -->
+    <color name="ic_launcher_background_dark">#0E1020</color>
     <!-- Window background (light). Matches LightBackground = Paper. -->
     <color name="ft_window_background">#F5F2EC</color>
 </resources>

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/LauncherIconManagerTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/LauncherIconManagerTest.kt
@@ -1,0 +1,60 @@
+package sh.kavi.fasttravel.ui
+
+import android.app.Application
+import android.content.ComponentName
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The drawer/launcher icon follows the in-app theme by toggling two launcher
+ * activity-aliases. These tests pin the decision (which alias for which surface) and
+ * the enable/disable effect on PackageManager.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class LauncherIconManagerTest {
+
+    private val app: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `aliasFor picks the dark alias for a dark surface and light otherwise`() {
+        assertEquals(LauncherIconManager.ALIAS_DARK, LauncherIconManager.aliasFor(isDark = true))
+        assertEquals(LauncherIconManager.ALIAS_LIGHT, LauncherIconManager.aliasFor(isDark = false))
+    }
+
+    @Test
+    fun `applyThemeIcon enables the dark alias and disables the light one`() {
+        LauncherIconManager.applyThemeIcon(app, isDark = true)
+
+        val pm = app.packageManager
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_DARK)),
+        )
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_LIGHT)),
+        )
+    }
+
+    @Test
+    fun `applyThemeIcon flips back to the light alias for a light surface`() {
+        LauncherIconManager.applyThemeIcon(app, isDark = true)
+        LauncherIconManager.applyThemeIcon(app, isDark = false)
+
+        val pm = app.packageManager
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_LIGHT)),
+        )
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_DARK)),
+        )
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/SearchViewModelResetTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/SearchViewModelResetTest.kt
@@ -1,0 +1,90 @@
+package sh.kavi.fasttravel.ui
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import sh.kavi.fasttravel.data.ConfigRefreshInterval
+import sh.kavi.fasttravel.data.EditableConfigStore
+import sh.kavi.fasttravel.data.SearchHistory
+import sh.kavi.fasttravel.data.ThemePreferences
+
+/**
+ * Regression test for the "previous query flashes on relaunch" bug.
+ *
+ * The query/suggestions live in a retained (activity-scoped) [SearchViewModel] and
+ * survive backgrounding (launcher `singleTask`). [SearchViewModel.resetForFreshStart]
+ * is what the Activity calls on `onStop()` so the next resume starts clean instead of
+ * flashing the previous query + its stale Google suggestions.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class SearchViewModelResetTest {
+
+    private val app: Application = ApplicationProvider.getApplicationContext()
+    private val scheduler = TestCoroutineScheduler()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher(scheduler))
+
+        val themePrefs = ThemePreferences(app)
+        themePrefs.configSourceDirty = false
+        themePrefs.configRefreshInterval = ConfigRefreshInterval.MANUAL // cache never expires
+        themePrefs.configUrl = "no-protocol-url" // never hit the network
+        EditableConfigStore(app).clearLocalConfig()
+
+        val configJson = app.assets.open("default-config.json")
+            .bufferedReader().use { it.readText() }
+        app.getSharedPreferences("fast_travel_config", Context.MODE_PRIVATE)
+            .edit()
+            .putString("cached_config_json", configJson)
+            .putLong("cache_timestamp", 1_000_000L)
+            .apply()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `resetForFreshStart clears the query and restores the Recent list`() {
+        // A prior search sits in history so "Recent" has content to restore to.
+        SearchHistory(app).addEntry("weather", null)
+
+        val vm = SearchViewModel(app)
+        scheduler.advanceUntilIdle() // let init load the cached config
+
+        // User was mid-search before backgrounding.
+        vm.onQueryChanged("doordash")
+        scheduler.advanceUntilIdle()
+        assertEquals("precondition: the query is dirty", "doordash", vm.query.value)
+
+        // Act: the Activity's onStop() calls this.
+        vm.resetForFreshStart()
+
+        assertEquals("query must be cleared", "", vm.query.value)
+        assertTrue("installed-app results must be cleared", vm.installedApps.value.isEmpty())
+        // Suggestions are restored to the Recent list synchronously (no debounce).
+        assertTrue(
+            "suggestions must be the Recent history list",
+            vm.suggestions.value.any { it.text == "weather" && it.isHistory },
+        )
+    }
+}


### PR DESCRIPTION
Fixes two device-reported Android bugs.

## 1. Previous query flashes on relaunch
After opening an app via Fast Travel, relaunching briefly showed the previous query + stale Google suggestions for ~1s before clearing. Query/suggestions live in a retained (`singleTask`) `SearchViewModel` and were only cleared by a post-first-frame effect.

**Fix:** `SearchViewModel.resetForFreshStart()` (clears query/installed-apps, restores the Recent list synchronously), called from `SearchActivity.onStop()` — state is clean *before* backgrounding, so the next resume's first frame is already an empty bar.

## 2. App icon doesn't follow the in-app theme
- **Recents card** now themed via `Activity.setTaskDescription` (opaque header color + themed icon).
- **Drawer/launcher icon** flips light↔dark via two activity-aliases (`LauncherLight`/`LauncherDark`) toggled by `LauncherIconManager` on `onStop` (`DONT_KILL_APP`, idempotent). Dark adaptive icon is XML-only (minSdk 26).
- **Known OS limit:** the Settings → Apps listing icon draws from `<application android:icon>` and can't change at runtime.

## Verification
- New unit tests: `SearchViewModelResetTest`, `LauncherIconManagerTest`; full suite green.
- On the `fast_travel_dev` AVD: drawer alias flips light↔dark deterministically, recents card is themed, and search → open app → relaunch shows a clean empty bar with the app in Recent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDs1UjXsq61hXMQd4AtRiS