### PR TITLE
fix(android): stop launcher icon theme-flips from breaking launcher references (Lawnchair gesture crash)

### DIFF
--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ThemePreferences.kt
@@ -35,6 +35,7 @@ class ThemePreferences(private val prefs: SharedPreferences) {
         private const val KEY_AUTO_IGNORE_THRESHOLD = "auto_ignore_threshold"
         private const val KEY_CONFIG_SOURCE_DIRTY = "config_source_dirty"
         const val KEY_INSTALLED_APPS_ENABLED = "installed_apps_enabled"
+        const val KEY_THEMED_ICON_ENABLED = "themed_icon_enabled"
         const val DEFAULT_AUTO_IGNORE_THRESHOLD = 3
         const val AUTO_IGNORE_THRESHOLD_MIN = 1
         const val AUTO_IGNORE_THRESHOLD_MAX = 20
@@ -96,6 +97,13 @@ class ThemePreferences(private val prefs: SharedPreferences) {
     var installedAppsEnabled: Boolean
         get() = prefs.getBoolean(KEY_INSTALLED_APPS_ENABLED, true)
         set(value) { prefs.edit().putBoolean(KEY_INSTALLED_APPS_ENABLED, value).apply() }
+
+    /** Opt-in: flip the launcher icon (activity-aliases) with the in-app theme.
+     *  Off by default because disabling an alias breaks launcher-stored references
+     *  to it — gestures and pinned shortcuts crash or vanish when the icon flips. */
+    var themedIconEnabled: Boolean
+        get() = prefs.getBoolean(KEY_THEMED_ICON_ENABLED, false)
+        set(value) { prefs.edit().putBoolean(KEY_THEMED_ICON_ENABLED, value).apply() }
 
     var shortcutRows: Int
         get() = prefs.getInt(KEY_SHORTCUT_ROWS, 2)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/LauncherIconManager.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/LauncherIconManager.kt
@@ -36,17 +36,28 @@ object LauncherIconManager {
         appearance.colorScheme.background.toArgb() or 0xFF000000.toInt()
 
     /**
-     * Enable the alias matching [isDark] and disable the other, so exactly one launcher
-     * icon is ever live. Idempotent: no-ops when already in the desired state to avoid
-     * redundant PackageManager writes / icon flicker. `DONT_KILL_APP` keeps the running
-     * task alive; callers switch on `onStop()` so flipping the live launcher component
+     * Converge the launcher aliases so exactly one icon is live. With [followTheme]
+     * the enabled alias matches [isDark] (the original themed-icon behavior); without
+     * it the stable light alias is enforced regardless of theme.
+     *
+     * followTheme is opt-in because disabling an alias breaks every external reference
+     * a launcher stored to it — Lawnchair gestures and pinned shortcuts launch the
+     * ComponentName that was enabled at setup time, and launching a DISABLED component
+     * throws ActivityNotFoundException inside the launcher (Lawnchair crashes). The
+     * followTheme=false pass also serves as the migration path for devices where a
+     * previous version left the dark alias live.
+     *
+     * Idempotent: no-ops when already in the desired state to avoid redundant
+     * PackageManager writes / icon flicker. `DONT_KILL_APP` keeps the running task
+     * alive; callers switch on `onStop()` so flipping the live launcher component
      * can't drop the task from recents.
      */
-    fun applyThemeIcon(context: Context, isDark: Boolean) {
+    fun applyThemeIcon(context: Context, isDark: Boolean, followTheme: Boolean) {
+        val wantDark = followTheme && isDark
         val pm = context.packageManager
         val pkg = context.packageName
-        val enable = ComponentName(pkg, aliasFor(isDark))
-        val disable = ComponentName(pkg, aliasFor(!isDark))
+        val enable = ComponentName(pkg, aliasFor(wantDark))
+        val disable = ComponentName(pkg, aliasFor(!wantDark))
 
         val alreadyApplied =
             pm.getComponentEnabledSetting(enable) == PackageManager.COMPONENT_ENABLED_STATE_ENABLED &&

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -367,12 +367,15 @@ class SearchActivity : ComponentActivity() {
         // home, recents) so the next resume's first frame is already a clean, empty
         // search bar — no ~1s flash of the previous query + its stale suggestions.
         viewModel.resetForFreshStart()
-        // Flip the drawer/launcher icon to match the theme while we're off-screen —
-        // switching the live launcher component while foregrounded can drop the task
-        // from recents on some Android versions.
+        // Converge the drawer/launcher icon while we're off-screen — switching the
+        // live launcher component while foregrounded can drop the task from recents
+        // on some Android versions. Theme-following is opt-in; the default pass
+        // enforces the stable light alias so launcher-stored references stay valid.
+        val themePrefs = ThemePreferences(this)
         LauncherIconManager.applyThemeIcon(
             this,
-            resolveFromPrefs(applicationContext, ThemePreferences(this)).isDarkSurface,
+            resolveFromPrefs(applicationContext, themePrefs).isDarkSurface,
+            followTheme = themePrefs.themedIconEnabled,
         )
     }
 

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -1114,7 +1114,33 @@ fun AppearanceScreen(
                     onSelect = { draft = draft.copy(shape = it) },
                 )
             }
-            // 5 & 6. Widget settings (opacity + rows)
+            // 5. App icon: theme-following is opt-in because flipping the live
+            // launcher alias invalidates launcher-stored references (gestures,
+            // pinned shortcuts) to the disabled one — Lawnchair crashes on launch.
+            SettingsCategoryHeader("App icon")
+            SettingsCard {
+                var themedIcon by remember { mutableStateOf(prefs.themedIconEnabled) }
+                SettingsSwitchItem(
+                    headlineText = "Icon follows theme",
+                    supportingText = "Flips the launcher icon light/dark with the app theme. " +
+                        "Launcher gestures and pinned shortcuts point at one icon and can " +
+                        "break or crash their launcher when it flips.",
+                    checked = themedIcon,
+                    onCheckedChange = {
+                        themedIcon = it
+                        prefs.themedIconEnabled = it
+                        // Apply now rather than waiting for the next SearchActivity
+                        // onStop, so turning it off immediately restores the stable
+                        // alias (and turning it on shows the effect right away).
+                        LauncherIconManager.applyThemeIcon(
+                            context,
+                            appearance.isDarkSurface,
+                            followTheme = it,
+                        )
+                    },
+                )
+            }
+            // 6 & 7. Widget settings (opacity + rows)
             SettingsCategoryHeader("Widget")
             SettingsCard {
                 Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ThemePreferencesTest.kt
@@ -16,6 +16,25 @@ class ThemePreferencesTest {
     }
 
     @Test
+    fun `themedIconEnabled defaults to off`() {
+        // Default must stay OFF: theme-following flips the live launcher alias and
+        // breaks launcher-stored references (gestures, pinned shortcuts) to the
+        // disabled one — Lawnchair crashes launching them. Opt-in only.
+        assertFalse(newPrefs().themedIconEnabled)
+    }
+
+    @Test
+    fun `themedIconEnabled persists when opted in`() {
+        val prefs = newPrefs()
+
+        prefs.themedIconEnabled = true
+        assertTrue(prefs.themedIconEnabled)
+
+        prefs.themedIconEnabled = false
+        assertFalse(prefs.themedIconEnabled)
+    }
+
+    @Test
     fun `installedAppsEnabled persists when toggled off and back on`() {
         val prefs = newPrefs()
 

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/LauncherIconManagerTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/LauncherIconManagerTest.kt
@@ -5,15 +5,24 @@ import android.content.ComponentName
 import android.content.pm.PackageManager
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * The drawer/launcher icon follows the in-app theme by toggling two launcher
- * activity-aliases. These tests pin the decision (which alias for which surface) and
- * the enable/disable effect on PackageManager.
+ * The drawer/launcher icon is served by two activity-aliases. Launchers (gestures,
+ * pinned shortcuts, home-screen databases) store the ComponentName that was enabled
+ * when the user set them up and launch it explicitly; a component in
+ * COMPONENT_ENABLED_STATE_DISABLED makes that launch throw ActivityNotFoundException
+ * inside the launcher (Lawnchair crashes outright). So the contract pinned here is:
+ *
+ *  - By default (themed icon OFF) the light alias is always the enabled one and is
+ *    never disabled by a theme change — stored references stay launchable forever.
+ *  - Theme-following is opt-in (followTheme = true) and keeps the old flip behavior.
+ *  - Turning the opt-in off restores the stable light alias (migration path for
+ *    devices coming from 2.1.6 where the dark alias may be the live one).
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = Application::class)
@@ -21,40 +30,80 @@ class LauncherIconManagerTest {
 
     private val app: Application = ApplicationProvider.getApplicationContext()
 
+    private fun enabledState(alias: String): Int =
+        app.packageManager.getComponentEnabledSetting(ComponentName(app.packageName, alias))
+
     @Test
     fun `aliasFor picks the dark alias for a dark surface and light otherwise`() {
         assertEquals(LauncherIconManager.ALIAS_DARK, LauncherIconManager.aliasFor(isDark = true))
         assertEquals(LauncherIconManager.ALIAS_LIGHT, LauncherIconManager.aliasFor(isDark = false))
     }
 
-    @Test
-    fun `applyThemeIcon enables the dark alias and disables the light one`() {
-        LauncherIconManager.applyThemeIcon(app, isDark = true)
+    // ==== Default (themed icon OFF): stored launcher components must stay launchable ====
 
-        val pm = app.packageManager
-        assertEquals(
-            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_DARK)),
+    @Test
+    fun `by default a dark theme never disables the light alias a launcher may have stored`() {
+        // Lawnchair gesture set up while the light alias was live stores
+        // sh.kavi.fasttravel.ui.LauncherLight. A later dark theme pass must not
+        // disable it, or the gesture launch throws ActivityNotFoundException.
+        LauncherIconManager.applyThemeIcon(app, isDark = true, followTheme = false)
+
+        assertNotEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            enabledState(LauncherIconManager.ALIAS_LIGHT),
         )
         assertEquals(
             PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_LIGHT)),
+            enabledState(LauncherIconManager.ALIAS_DARK),
         )
     }
 
     @Test
-    fun `applyThemeIcon flips back to the light alias for a light surface`() {
-        LauncherIconManager.applyThemeIcon(app, isDark = true)
-        LauncherIconManager.applyThemeIcon(app, isDark = false)
+    fun `disabling theme-following restores the stable light alias after a dark flip`() {
+        // Migration from 2.1.6: the dark alias may be the live launcher component.
+        // With the opt-in off, the next pass must converge back to the light alias
+        // no matter what the current theme is.
+        LauncherIconManager.applyThemeIcon(app, isDark = true, followTheme = true)
+        LauncherIconManager.applyThemeIcon(app, isDark = true, followTheme = false)
 
-        val pm = app.packageManager
         assertEquals(
             PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_LIGHT)),
+            enabledState(LauncherIconManager.ALIAS_LIGHT),
         )
         assertEquals(
             PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-            pm.getComponentEnabledSetting(ComponentName(app.packageName, LauncherIconManager.ALIAS_DARK)),
+            enabledState(LauncherIconManager.ALIAS_DARK),
+        )
+    }
+
+    // ==== Opt-in (themed icon ON): the original flip behavior ====
+
+    @Test
+    fun `opted in, a dark surface enables the dark alias and disables the light one`() {
+        LauncherIconManager.applyThemeIcon(app, isDark = true, followTheme = true)
+
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            enabledState(LauncherIconManager.ALIAS_DARK),
+        )
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            enabledState(LauncherIconManager.ALIAS_LIGHT),
+        )
+    }
+
+    @Test
+    fun `opted in, flips back to the light alias for a light surface`() {
+        LauncherIconManager.applyThemeIcon(app, isDark = true, followTheme = true)
+        LauncherIconManager.applyThemeIcon(app, isDark = false, followTheme = true)
+
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            enabledState(LauncherIconManager.ALIAS_LIGHT),
+        )
+        assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            enabledState(LauncherIconManager.ALIAS_DARK),
         )
     }
 }


### PR DESCRIPTION
## Problem

Reported on 2.1.6: **Lawnchair crashes when launching Fast Travel via a launch gesture** after the app icon has flipped light↔dark since the gesture was configured. Flipping the theme back (light→dark→light) makes the gesture work again.

## Root cause

The themed launcher icon from #71 toggles two activity-aliases (`LauncherLight`/`LauncherDark`) with `PackageManager.setComponentEnabledSetting` on every theme change (in `SearchActivity.onStop`, which is also why the icon lags the in-app theme).

Launchers store the **ComponentName that was enabled at setup time** for gestures, pinned shortcuts, and home-screen entries, and launch it explicitly. After a flip, that component is `COMPONENT_ENABLED_STATE_DISABLED`, so the launch throws `ActivityNotFoundException` inside the launcher — Lawnchair doesn't catch it in its gesture path and crashes. Flipping the theme back re-enables the alias, which is exactly the reported "light>dark>light works again".

Android has no API to change the drawer icon without swapping which component is enabled, and no way to keep a disabled component launchable. **Automatically following the app theme therefore inherently breaks launcher-stored references** — twice a day for auto dark/light users.

## Fix

- **Default: stable icon.** `applyThemeIcon` now takes `followTheme`; when false (default) it enforces the light alias regardless of theme, so the component a launcher stored is never disabled. This pass also migrates devices coming from 2.1.6 with the dark alias live back to the stable alias.
- **Theme-following is opt-in:** new "Icon follows theme" switch under **Settings → Appearance → App icon**, with a warning that launcher gestures/pinned shortcuts can break when the icon flips. Toggling applies immediately.
- Recents-card theming (`setTaskDescription`) is unaffected and stays.

Note for users upgrading from 2.1.6 who set up a gesture/shortcut **while the dark icon was live**: that stored reference points at `LauncherDark` and will need to be re-added once (unavoidable — one component has to own the icon; the stable one is the manifest-default `LauncherLight`).

## Testing

- Robolectric tests pin the contract: the default pass never disables the launcher-stored alias; opt-in keeps the original flip behavior; turning the opt-in off restores the light alias. `ThemePreferences.themedIconEnabled` defaults to off.
- Recreated on the `fast_travel_dev` AVD with the 2.1.6 build: dark theme → background app → `am start -n sh.kavi.fasttravel/.ui.LauncherLight` fails with the same `ActivityNotFoundException` Lawnchair hits. After upgrading in place to this branch's build and one foreground/background cycle, the alias is re-enabled and the same launch succeeds across theme changes.
- `cd android && ./gradlew test assembleDebug` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYowhF4xWuEhp9VcXggPvp
