### PR TITLE
fix(android): shorten App Icon setting copy

### DIFF
--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -1117,14 +1117,12 @@ fun AppearanceScreen(
             // 5. App icon: theme-following is opt-in because flipping the live
             // launcher alias invalidates launcher-stored references (gestures,
             // pinned shortcuts) to the disabled one — Lawnchair crashes on launch.
-            SettingsCategoryHeader("App icon")
+            SettingsCategoryHeader("App Icon")
             SettingsCard {
                 var themedIcon by remember { mutableStateOf(prefs.themedIconEnabled) }
                 SettingsSwitchItem(
                     headlineText = "Icon follows theme",
-                    supportingText = "Flips the launcher icon light/dark with the app theme. " +
-                        "Launcher gestures and pinned shortcuts point at one icon and can " +
-                        "break or crash their launcher when it flips.",
+                    supportingText = "Can be unstable with certain launcher shortcuts",
                     checked = themedIcon,
                     onCheckedChange = {
                         themedIcon = it


### PR DESCRIPTION
Reword the themed-launcher-icon setting added in v2.1.7 (#72):

- Category header: `App icon` → **App Icon**
- Toggle title: **Icon follows theme** (unchanged)
- Supporting text: the long two-sentence warning → **Can be unstable with certain launcher shortcuts**

Copy-only; no behavior change. `./gradlew compileDebugKotlin` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYowhF4xWuEhp9VcXggPvp