### PR TITLE
feat(extension): update notice for sideloaded Chromium installs

### DIFF
--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -1,6 +1,13 @@
 import { parseCommand, buildTriggerMap } from "../core/parser.js";
 import { fetchSuggestions } from "../core/suggestions.js";
 import { lintConfig } from "../core/config-linter.js";
+import {
+  LATEST_RELEASE_KEY,
+  RELEASES_API_URL,
+  isSideloadedChromium,
+  isUpdateCheckDue,
+  parseLatestRelease,
+} from "../core/update-check.js";
 import { detectDevice } from "../core/device.js";
 import type { FastTravelConfig, TypoResult } from "../core/types.js";
 import bundledConfig from "../../../shared/config/default-config.json";
@@ -14,6 +21,8 @@ const CONFIG_URL_KEY = "fast-travel-config-url";
 const REFRESH_INTERVAL_KEY = "fast-travel-refresh-interval";
 const LAST_SYNCED_KEY = "fast-travel-last-synced";
 const REFRESH_ALARM = "config-refresh";
+const UPDATE_ALARM = "update-check";
+const UPDATE_CHECK_PERIOD_MINUTES = 24 * 60;
 const CONFIG_FETCH_TIMEOUT_MS = 5000;
 const APPEARANCE_KEY = "fast-travel-appearance";
 
@@ -310,6 +319,46 @@ if (chrome.webNavigation?.onBeforeNavigate) {
   );
 }
 
+// Sideloaded (GitHub-installed) Chromium builds never auto-update, so poll the
+// latest GitHub Release and cache it; the new tab page turns the cached value
+// into a one-time per-version update hint. Store builds skip all of this.
+// Checks run at most once a day: startup calls are throttled against the last
+// check's timestamp, and only the daily alarm passes force=true.
+async function checkForUpdate(force = false): Promise<void> {
+  if (!isSideloadedChromium()) return;
+  if (!force) {
+    const stored = await chrome.storage.local.get(LATEST_RELEASE_KEY);
+    if (!isUpdateCheckDue(stored[LATEST_RELEASE_KEY], Date.now())) return;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CONFIG_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(RELEASES_API_URL, {
+      signal: controller.signal,
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) return;
+    const latest = parseLatestRelease(await response.json(), Date.now());
+    if (latest) {
+      await chrome.storage.local.set({ [LATEST_RELEASE_KEY]: latest });
+    }
+  } catch (e) {
+    console.warn("[fast-travel] update check failed:", e);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function scheduleUpdateCheck(): Promise<void> {
+  if (!isSideloadedChromium()) return;
+  // Don't reset the countdown on every worker spin-up — only create the alarm
+  // if a prior one isn't already pending (alarms persist across restarts).
+  const existing = await chrome.alarms.get(UPDATE_ALARM);
+  if (!existing) {
+    chrome.alarms.create(UPDATE_ALARM, { periodInMinutes: UPDATE_CHECK_PERIOD_MINUTES });
+  }
+}
+
 // Run on every service-worker startup (not just onInstalled/onStartup, which
 // don't fire on a plain reload): on Chrome this REMOVES any stale redirect rule
 // a prior build left behind (issue #44); on Firefox it (re)installs it.
@@ -329,6 +378,8 @@ chrome.runtime.onInstalled.addListener(async () => {
   scheduleRefresh();
   installSearchRedirectRule();
   initToolbarIcon();
+  scheduleUpdateCheck();
+  checkForUpdate();
 });
 
 // Reinstall the rule on every worker startup — dynamic rules persist across
@@ -341,6 +392,8 @@ chrome.runtime.onStartup.addListener(async () => {
     fetchAndStoreConfig();
   }
   initToolbarIcon();
+  scheduleUpdateCheck();
+  checkForUpdate();
 });
 
 // When the refresh interval changes in settings, reschedule the alarm. When the
@@ -361,6 +414,9 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === REFRESH_ALARM) {
     if (!(await isDirty())) await fetchAndStoreConfig();
+  }
+  if (alarm.name === UPDATE_ALARM) {
+    await checkForUpdate(true);
   }
 });
 

--- a/extension/src/core/update-check.ts
+++ b/extension/src/core/update-check.ts
@@ -1,0 +1,93 @@
+// Update notice for sideloaded (GitHub-installed) Chromium builds. The Chrome
+// build isn't on the Web Store (issue #36), so unpacked installs never
+// auto-update; the service worker polls the latest GitHub Release and the new
+// tab page shows a one-time, per-version hint. Store builds (Firefox/AMO) are
+// excluded — their store handles updates.
+
+export const LATEST_RELEASE_KEY = "fast-travel-latest-release";
+export const UPDATE_DISMISSED_KEY = "fast-travel-update-dismissed-version";
+
+export const RELEASES_API_URL =
+  "https://api.github.com/repos/DoubleGremlin181/fast-travel-app/releases/latest";
+export const RELEASES_PAGE_URL =
+  "https://github.com/DoubleGremlin181/fast-travel-app/releases/latest";
+
+export interface LatestRelease {
+  version: string;
+  url: string;
+  checkedAt: number;
+}
+
+export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Once-a-day throttle for opportunistic checks (worker startup): a check is
+ * due only when none has ever completed or the last one is at least a day
+ * old. The daily alarm bypasses this so clock drift can't stack skips.
+ */
+export function isUpdateCheckDue(latest: LatestRelease | undefined, now: number): boolean {
+  if (!latest?.checkedAt) return true;
+  return now - latest.checkedAt >= UPDATE_CHECK_INTERVAL_MS;
+}
+
+/**
+ * Numeric dotted-version compare (an optional leading "v" is stripped; missing
+ * segments count as 0, so "2.1.8" === "2.1.8.0" and beta builds like
+ * "2.1.8.73" sort above their base release). Returns <0 / 0 / >0.
+ * Non-numeric versions compare as unknown: NaN segments make both sides equal
+ * so callers fail closed (no prompt).
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] =>
+    v.replace(/^v/, "").split(".").map((s) => Number.parseInt(s, 10));
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (Number.isNaN(na) || Number.isNaN(nb)) return 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+/**
+ * Whether the new tab page should show the update hint. Only the single
+ * latest release is ever considered — if several versions were skipped they
+ * collapse into one prompt — and dismissing records that version so the hint
+ * stays gone until something newer ships.
+ */
+export function shouldPromptUpdate(
+  currentVersion: string,
+  latest: LatestRelease | undefined,
+  dismissedVersion: string | undefined,
+): boolean {
+  if (!latest?.version) return false;
+  if (compareVersions(latest.version, currentVersion) <= 0) return false;
+  if (dismissedVersion && compareVersions(latest.version, dismissedVersion) <= 0) return false;
+  return true;
+}
+
+/**
+ * True when this install has no store channel updating it: a Chromium build
+ * (the Firefox build ships through AMO) whose manifest has no update_url (the
+ * Web Store injects one into items it distributes; unpacked installs have
+ * none).
+ */
+export function isSideloadedChromium(): boolean {
+  if (navigator.userAgent.includes("Firefox")) return false;
+  return !("update_url" in chrome.runtime.getManifest());
+}
+
+/** Parse the GitHub "latest release" API response; null if it isn't usable. */
+export function parseLatestRelease(body: unknown, now: number): LatestRelease | null {
+  if (!body || typeof body !== "object") return null;
+  const tag = (body as { tag_name?: unknown }).tag_name;
+  if (typeof tag !== "string" || !/^v?\d+(\.\d+)*$/.test(tag)) return null;
+  const htmlUrl = (body as { html_url?: unknown }).html_url;
+  return {
+    version: tag.replace(/^v/, ""),
+    url: typeof htmlUrl === "string" ? htmlUrl : RELEASES_PAGE_URL,
+    checkedAt: now,
+  };
+}

--- a/extension/src/newtab/newtab.css
+++ b/extension/src/newtab/newtab.css
@@ -562,9 +562,10 @@ body:hover #settings-link {
   font-weight: 700;
 }
 
-/* ---- Onboarding hint ---- */
+/* ---- Onboarding + update hints ---- */
 
-#onboarding-hint {
+#onboarding-hint,
+#update-hint {
   margin-top: 28px;
   padding: 14px 16px 14px 18px;
   background: var(--surface);
@@ -578,7 +579,8 @@ body:hover #settings-link {
   animation: hint-in var(--duration-med) var(--ease);
 }
 
-#onboarding-hint.hidden {
+#onboarding-hint.hidden,
+#update-hint.hidden {
   display: none;
 }
 
@@ -587,14 +589,16 @@ body:hover #settings-link {
   to { opacity: 1; transform: translateY(0); }
 }
 
-#onboarding-hint-body {
+#onboarding-hint-body,
+#update-hint-body {
   flex: 1;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-#onboarding-hint-body p {
+#onboarding-hint-body p,
+#update-hint-body p {
   margin: 0;
   line-height: 1.5;
 }
@@ -608,19 +612,23 @@ body:hover #settings-link {
   color: var(--text);
 }
 
-#onboarding-hint-body a {
+#onboarding-hint-body a,
+#update-hint-body a {
   color: var(--primary);
   text-decoration: none;
   font-weight: 500;
 }
 
 #onboarding-hint-body a:hover,
-#onboarding-hint-body a:focus-visible {
+#onboarding-hint-body a:focus-visible,
+#update-hint-body a:hover,
+#update-hint-body a:focus-visible {
   text-decoration: underline;
   outline: none;
 }
 
-#onboarding-hint-dismiss {
+#onboarding-hint-dismiss,
+#update-hint-dismiss {
   flex-shrink: 0;
   width: 24px;
   height: 24px;
@@ -635,7 +643,9 @@ body:hover #settings-link {
 }
 
 #onboarding-hint-dismiss:hover,
-#onboarding-hint-dismiss:focus-visible {
+#onboarding-hint-dismiss:focus-visible,
+#update-hint-dismiss:hover,
+#update-hint-dismiss:focus-visible {
   background: var(--surface-2);
   color: var(--text);
   outline: none;

--- a/extension/src/newtab/newtab.html
+++ b/extension/src/newtab/newtab.html
@@ -62,6 +62,16 @@
         <div id="chips-content"></div>
       </section>
 
+      <aside id="update-hint" class="hidden" aria-label="Update available">
+        <div id="update-hint-body">
+          <p>
+            Fast Travel <span id="update-hint-version"></span> is available.
+            <a id="update-hint-link" href="https://github.com/DoubleGremlin181/fast-travel-app/releases/latest" target="_blank" rel="noopener">Get it from GitHub Releases →</a>
+          </p>
+        </div>
+        <button id="update-hint-dismiss" type="button" aria-label="Dismiss update notice">×</button>
+      </aside>
+
       <aside id="onboarding-hint" class="hidden" aria-label="Fast Travel tips">
         <div id="onboarding-hint-body">
           <p>

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -9,6 +9,13 @@ import type {
   Group,
 } from "../core/types.js";
 import type { Suggestion } from "../core/suggestions.js";
+import {
+  LATEST_RELEASE_KEY,
+  UPDATE_DISMISSED_KEY,
+  isSideloadedChromium,
+  shouldPromptUpdate,
+  type LatestRelease,
+} from "../core/update-check.js";
 import { resolveGroupTint } from "../ui/group-colors.js";
 import { renderFavicon } from "../ui/favicon.js";
 import { applyAppearance, getAppearance, subscribe as subscribeAppearance } from "../ui/appearance.js";
@@ -127,6 +134,35 @@ const defaultLeadingIcon = leadingIcon.innerHTML;
 const ONBOARDING_HINT_DISMISSED_KEY = "fast-travel-onboarding-hint-dismissed";
 const SEARCH_ENGINE_ACTIVE_KEY = "fast-travel-search-engine-active";
 
+// One-time per-version update hint for sideloaded (GitHub-installed) Chromium
+// builds — the service worker caches the latest GitHub Release daily; this
+// page only decides whether to surface it. Returns true when shown so the
+// onboarding hint can yield for this page load (both at once is clutter).
+async function setupUpdateHint(): Promise<boolean> {
+  const hint = document.getElementById("update-hint");
+  const versionEl = document.getElementById("update-hint-version");
+  const link = document.getElementById("update-hint-link") as HTMLAnchorElement | null;
+  const dismissBtn = document.getElementById("update-hint-dismiss");
+  if (!hint || !versionEl || !link || !dismissBtn) return false;
+  if (!isSideloadedChromium()) return false;
+  const stored = await chrome.storage.local.get([LATEST_RELEASE_KEY, UPDATE_DISMISSED_KEY]);
+  const latest = stored[LATEST_RELEASE_KEY] as LatestRelease | undefined;
+  const dismissed = stored[UPDATE_DISMISSED_KEY] as string | undefined;
+  if (!shouldPromptUpdate(chrome.runtime.getManifest().version, latest, dismissed)) return false;
+  versionEl.textContent = `v${latest!.version}`;
+  link.href = latest!.url;
+  const dismiss = async () => {
+    hint.classList.add("hidden");
+    await chrome.storage.local.set({ [UPDATE_DISMISSED_KEY]: latest!.version });
+  };
+  // Following the download link counts as acting on the prompt — don't show
+  // it again for this version.
+  link.addEventListener("click", () => void dismiss());
+  dismissBtn.addEventListener("click", () => void dismiss());
+  hint.classList.remove("hidden");
+  return true;
+}
+
 // Toggle `.tail-visible` based on whether the element's content overflows.
 // The class flips overflow to the start of the line so the tail (with a
 // leading ellipsis) stays visible. Used by the search input on blur and by
@@ -215,7 +251,9 @@ async function init(): Promise<void> {
     }
 
     if (config) renderQuickChips();
-    void setupOnboardingHint();
+    void setupUpdateHint().then((shown) => {
+      if (!shown) return setupOnboardingHint();
+    });
   } catch (e) {
     console.error("[fast-travel] newtab init failed:", e);
   } finally {

--- a/extension/tests/e2e/update-hint.spec.ts
+++ b/extension/tests/e2e/update-hint.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "./fixtures";
+
+// The update hint for sideloaded installs: the service worker caches the
+// latest GitHub Release in storage; the NTP shows a one-time per-version
+// banner. Tests seed the cache directly (no network) — the loaded dist/ is
+// unpacked, so isSideloadedChromium() is genuinely true here.
+
+// onInstalled fires a real update check against the GitHub API; if it resolved
+// after we seed, it would overwrite the fake release and flake the test. Wait
+// for it to settle (populate the key or fail) before seeding.
+async function settleOrganicUpdateCheck(context: import("@playwright/test").BrowserContext) {
+  const sw = context.serviceWorkers()[0];
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    const stored = await sw.evaluate(() =>
+      chrome.storage.local.get("fast-travel-latest-release").then((v) => v["fast-travel-latest-release"]),
+    );
+    if (stored) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}
+
+async function seedLatestRelease(
+  context: import("@playwright/test").BrowserContext,
+  version: string,
+) {
+  await settleOrganicUpdateCheck(context);
+  const sw = context.serviceWorkers()[0];
+  await sw.evaluate(
+    (v) =>
+      chrome.storage.local.set({
+        "fast-travel-latest-release": {
+          version: v,
+          url: `https://github.com/DoubleGremlin181/fast-travel-app/releases/tag/v${v}`,
+          checkedAt: Date.now(),
+        },
+      }),
+    version,
+  );
+}
+
+async function getDismissedVersion(context: import("@playwright/test").BrowserContext) {
+  const sw = context.serviceWorkers()[0];
+  return sw.evaluate(() =>
+    chrome.storage.local
+      .get("fast-travel-update-dismissed-version")
+      .then((v) => v["fast-travel-update-dismissed-version"]),
+  );
+}
+
+test("update hint: shows for a newer release and dismisses per version", async ({
+  context,
+  extensionId,
+}) => {
+  await seedLatestRelease(context, "99.0.0");
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
+
+  const hint = page.locator("#update-hint");
+  await expect(hint).toBeVisible();
+  await expect(page.locator("#update-hint-version")).toHaveText("v99.0.0");
+  await expect(page.locator("#update-hint-link")).toHaveAttribute(
+    "href",
+    "https://github.com/DoubleGremlin181/fast-travel-app/releases/tag/v99.0.0",
+  );
+
+  await page.locator("#update-hint-dismiss").click();
+  await expect(hint).toBeHidden();
+  await expect.poll(() => getDismissedVersion(context)).toBe("99.0.0");
+
+  // Reload: same version stays dismissed — the prompt is one-time.
+  await page.reload();
+  await expect(hint).toBeHidden();
+
+  // An even newer release prompts again, exactly once.
+  await seedLatestRelease(context, "99.1.0");
+  await page.reload();
+  await expect(hint).toBeVisible();
+  await expect(page.locator("#update-hint-version")).toHaveText("v99.1.0");
+});
+
+test("update hint: absent when the cached release is not newer", async ({
+  context,
+  extensionId,
+}) => {
+  const sw = context.serviceWorkers()[0];
+  const currentVersion = await sw.evaluate(() => chrome.runtime.getManifest().version);
+  await seedLatestRelease(context, currentVersion);
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
+
+  await expect(page.locator("#update-hint")).toBeHidden();
+  // With no update pending, the onboarding hint keeps its slot.
+  await expect(page.locator("#onboarding-hint")).toBeVisible();
+});

--- a/extension/tests/unit/update-check.test.ts
+++ b/extension/tests/unit/update-check.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareVersions,
+  shouldPromptUpdate,
+  parseLatestRelease,
+  isUpdateCheckDue,
+  RELEASES_PAGE_URL,
+  UPDATE_CHECK_INTERVAL_MS,
+  type LatestRelease,
+} from "../../src/core/update-check.js";
+
+const latest = (version: string): LatestRelease => ({
+  version,
+  url: `https://github.com/DoubleGremlin181/fast-travel-app/releases/tag/v${version}`,
+  checkedAt: 1_700_000_000_000,
+});
+
+describe("compareVersions", () => {
+  it("orders plain semver-style versions", () => {
+    expect(compareVersions("2.1.8", "2.1.9")).toBeLessThan(0);
+    expect(compareVersions("2.2.0", "2.1.9")).toBeGreaterThan(0);
+    expect(compareVersions("3.0.0", "2.99.99")).toBeGreaterThan(0);
+    expect(compareVersions("2.1.8", "2.1.8")).toBe(0);
+  });
+
+  it("compares segments numerically, not lexically", () => {
+    expect(compareVersions("2.1.10", "2.1.9")).toBeGreaterThan(0);
+  });
+
+  it("strips a leading v", () => {
+    expect(compareVersions("v2.1.9", "2.1.8")).toBeGreaterThan(0);
+    expect(compareVersions("2.1.8", "v2.1.8")).toBe(0);
+  });
+
+  it("treats missing segments as zero", () => {
+    expect(compareVersions("2.1.8", "2.1.8.0")).toBe(0);
+    // PR beta builds get a 4th segment and sort above their base release
+    expect(compareVersions("2.1.8.73", "2.1.8")).toBeGreaterThan(0);
+  });
+
+  it("treats malformed versions as equal (fail closed)", () => {
+    expect(compareVersions("abc", "2.1.8")).toBe(0);
+    expect(compareVersions("2.1.8", "")).toBe(0);
+  });
+});
+
+describe("shouldPromptUpdate", () => {
+  it("prompts when the latest release is newer and nothing was dismissed", () => {
+    expect(shouldPromptUpdate("2.1.8", latest("2.1.9"), undefined)).toBe(true);
+  });
+
+  it("does not prompt without a stored latest release", () => {
+    expect(shouldPromptUpdate("2.1.8", undefined, undefined)).toBe(false);
+  });
+
+  it("does not prompt when up to date or ahead (dev/beta builds)", () => {
+    expect(shouldPromptUpdate("2.1.9", latest("2.1.9"), undefined)).toBe(false);
+    expect(shouldPromptUpdate("2.2.0", latest("2.1.9"), undefined)).toBe(false);
+    expect(shouldPromptUpdate("2.1.9.12", latest("2.1.9"), undefined)).toBe(false);
+  });
+
+  it("stays dismissed for the dismissed version", () => {
+    expect(shouldPromptUpdate("2.1.8", latest("2.1.9"), "2.1.9")).toBe(false);
+  });
+
+  it("prompts again when a version newer than the dismissed one ships", () => {
+    // user skipped 3.14 and 3.15; only 3.16 (the latest) prompts — once
+    expect(shouldPromptUpdate("3.13.0", latest("3.16.0"), "3.14.0")).toBe(true);
+    expect(shouldPromptUpdate("3.13.0", latest("3.16.0"), "3.16.0")).toBe(false);
+  });
+
+  it("fails closed on a malformed stored version", () => {
+    expect(shouldPromptUpdate("2.1.8", latest("garbage"), undefined)).toBe(false);
+  });
+});
+
+describe("isUpdateCheckDue", () => {
+  const NOW = 1_700_000_000_000;
+  const checked = (ageMs: number): LatestRelease => ({ ...latest("2.1.9"), checkedAt: NOW - ageMs });
+
+  it("is due when no check has ever completed", () => {
+    expect(isUpdateCheckDue(undefined, NOW)).toBe(true);
+  });
+
+  it("is not due within a day of the last check", () => {
+    expect(isUpdateCheckDue(checked(0), NOW)).toBe(false);
+    expect(isUpdateCheckDue(checked(UPDATE_CHECK_INTERVAL_MS - 1), NOW)).toBe(false);
+  });
+
+  it("is due once the last check is a day old", () => {
+    expect(isUpdateCheckDue(checked(UPDATE_CHECK_INTERVAL_MS), NOW)).toBe(true);
+  });
+});
+
+describe("parseLatestRelease", () => {
+  const NOW = 1_700_000_000_000;
+
+  it("extracts version and url from a release payload", () => {
+    const parsed = parseLatestRelease(
+      { tag_name: "v2.1.9", html_url: "https://github.com/DoubleGremlin181/fast-travel-app/releases/tag/v2.1.9" },
+      NOW,
+    );
+    expect(parsed).toEqual({
+      version: "2.1.9",
+      url: "https://github.com/DoubleGremlin181/fast-travel-app/releases/tag/v2.1.9",
+      checkedAt: NOW,
+    });
+  });
+
+  it("falls back to the releases page when html_url is missing", () => {
+    expect(parseLatestRelease({ tag_name: "v2.1.9" }, NOW)?.url).toBe(RELEASES_PAGE_URL);
+  });
+
+  it("rejects payloads without a version-shaped tag", () => {
+    expect(parseLatestRelease({ tag_name: "nightly" }, NOW)).toBeNull();
+    expect(parseLatestRelease({ message: "Not Found" }, NOW)).toBeNull();
+    expect(parseLatestRelease(null, NOW)).toBeNull();
+    expect(parseLatestRelease("v2.1.9", NOW)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

The Chrome build now ships exclusively via GitHub Releases (#36 — CWS rejected the extension under the Single Purpose policy), so unpacked installs never auto-update. This adds a lightweight update notice so those users find out when a new release ships.

## What

- **`src/core/update-check.ts`** — pure, unit-tested logic: numeric dotted-version compare (handles `v` prefixes and 4-segment beta builds), prompt gating, once-a-day check throttle, GitHub release-payload parsing, and sideload detection (`Chromium && no update_url in manifest` — the Web Store injects one, unpacked installs have none; the Firefox/AMO build is excluded via UA).
- **Service worker** — polls `releases/latest` at most once a day: startup checks are throttled against the last check's timestamp; a persistent daily alarm forces a refresh. Result is cached in `chrome.storage.local`. 5s timeout, fails silent.
- **New tab page** — a dismissible banner styled identically to the existing onboarding hint: *"Fast Travel vX.Y.Z is available. Get it from GitHub Releases →"*. One prompt per version: dismissing (or clicking the link) records that version; skipped versions collapse since only the latest release is ever considered (e.g. missing 3.14 → 3.16 prompts once, for 3.16). When the update banner shows, the onboarding hint yields for that page load.

## Testing

- 17 new unit tests (`update-check.test.ts`) — version compare, gating, throttle, payload parsing.
- 2 new e2e tests (`update-hint.spec.ts`) — real unpacked install in Chromium: banner appears for a newer release with correct version/link, dismiss persists across reloads, a newer release re-prompts once, and no banner when up to date (onboarding hint keeps its slot). Includes a guard against the organic install-time API check racing the seeded fixture.
- Full suites pass: 233 unit, 62 e2e. Verified visually in a real browser (light theme screenshot in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hgEnPPZkUFhvGrZoeCi78