### PR TITLE
fix(extension): read popup + options-sidebar version from the manifest

### DIFF
--- a/extension/src/options/options.html
+++ b/extension/src/options/options.html
@@ -16,7 +16,7 @@
         <div id="sidebar-header">
           <svg class="sidebar-chevron" viewBox="0 0 200 200" fill="none" aria-hidden="true"><g stroke-width="22" stroke-linecap="square" stroke-linejoin="miter"><polyline points="52,60 97,100 52,140" stroke="currentColor"/><polyline points="103,60 148,100 103,140" style="stroke: var(--primary)"/></g></svg>
           <div id="sidebar-wordmark">Fast Travel</div>
-          <span class="sidebar-version">v2.0.0</span>
+          <span class="sidebar-version"></span>
         </div>
         <a class="sidebar-link" data-route="#/appearance" href="#/appearance">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -36,6 +36,11 @@ defineRoutes([
 const mainEl = document.getElementById("main");
 if (mainEl) init(mainEl, "#/appearance");
 
+// Version comes from the manifest so it can never drift from the release —
+// this was a hardcoded string once and showed a stale 2.0.0.
+const sidebarVersion = document.querySelector(".sidebar-version");
+if (sidebarVersion) sidebarVersion.textContent = `v${chrome.runtime.getManifest().version}`;
+
 // Theme the whole options surface on load (not just the #/appearance route) and
 // keep it live — mirrors newtab.ts / popup.ts. Reads chrome.storage.sync (the
 // source of truth) and corrects the pre-paint shim's OS fallback.

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -17,7 +17,7 @@
         <div class="popup-title">Fast Travel</div>
         <div class="popup-subtitle">Supercharge your search bar</div>
       </div>
-      <span class="popup-version">2.0.0</span>
+      <span class="popup-version"></span>
     </div>
 
     <div class="popup-footer">

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -15,6 +15,10 @@ function openSettings(): void {
 openSettingsBtn?.addEventListener("click", openSettings);
 
 async function init(): Promise<void> {
+  // Version comes from the manifest so it can never drift from the release —
+  // this was a hardcoded string once and showed a stale 2.0.0.
+  const versionEl = document.querySelector(".popup-version");
+  if (versionEl) versionEl.textContent = chrome.runtime.getManifest().version;
   applyAppearance(await getAppearance());
   subscribeAppearance(applyAppearance);
 }

--- a/extension/tests/e2e/version-display.spec.ts
+++ b/extension/tests/e2e/version-display.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "./fixtures";
+
+// The popup and options-sidebar version labels are populated at runtime from
+// chrome.runtime.getManifest().version. They used to be hardcoded strings the
+// release bump script didn't know about, and shipped showing a stale 2.0.0.
+
+test("options sidebar shows the manifest version", async ({ context, extensionId }) => {
+  const sw = context.serviceWorkers()[0];
+  const version = await sw.evaluate(() => chrome.runtime.getManifest().version);
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await expect(page.locator(".sidebar-version")).toHaveText(`v${version}`);
+});
+
+test("popup shows the manifest version", async ({ context, extensionId }) => {
+  const sw = context.serviceWorkers()[0];
+  const version = await sw.evaluate(() => chrome.runtime.getManifest().version);
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await expect(page.locator(".popup-version")).toHaveText(version);
+});


### PR DESCRIPTION
Fixes the popup and settings sidebar showing a hardcoded **v2.0.0** instead of the installed version.

Root cause: three UI surfaces displayed the version, but the release bump script (`tools/bump-version.mjs`) only knew about one of them (`about.ts`). `popup.html` and the options sidebar had forgotten hardcoded literals frozen at 2.0.0.

Fix: both labels are now populated at runtime from `chrome.runtime.getManifest().version`, so they track every release automatically. Added two e2e tests asserting each surface matches the manifest version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hgEnPPZkUFhvGrZoeCi78