### PR TITLE
feat(newtab): Enter on the typo prompt runs the default search

### DIFF
--- a/extension/src/newtab/newtab.html
+++ b/extension/src/newtab/newtab.html
@@ -50,7 +50,7 @@
             <kbd>Y</kbd> Use suggestion
           </button>
           <button id="typo-search" type="button" class="typo-btn">
-            <kbd>G</kbd> Default search
+            <kbd>Enter</kbd> Default search
           </button>
           <button id="typo-ignore" type="button" class="typo-btn">
             <kbd>I</kbd> Ignore permanently

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -885,14 +885,20 @@ searchInput.addEventListener("blur", () => {
 
 // Typo-prompt shortcuts. The type-anywhere handler defers to these while a typo
 // is showing (see focusSearchInput), so the search box stays blurred and these
-// keys reach here. "g" and "n" both decline the suggestion and fall back to the
-// user's default engine (defaultSearch) — "n" ("no") is the engine-agnostic alias
-// and is intentionally not advertised in the UI.
+// keys reach here. Enter, "g" and "n" all decline the suggestion and fall back
+// to the user's default engine (defaultSearch): Enter is the advertised key
+// (the query was just submitted with Enter, so pressing it again reads as
+// "yes, really search this"); "g" and "n" ("no") are unadvertised aliases.
+// Enter defers to the search box when it's focused so editing the query and
+// resubmitting keeps working.
 document.addEventListener("keydown", (e) => {
   if (!currentTypo) return;
   if (e.key === "y" || e.key === "Y") {
     e.preventDefault();
     void acceptTypo();
+  } else if (e.key === "Enter" && e.target !== searchInput) {
+    e.preventDefault();
+    void defaultSearch();
   } else if (e.key === "g" || e.key === "G" || e.key === "n" || e.key === "N") {
     e.preventDefault();
     void defaultSearch();

--- a/extension/tests/e2e/typo-shortcuts.spec.ts
+++ b/extension/tests/e2e/typo-shortcuts.spec.ts
@@ -78,6 +78,29 @@ test("pressing N declines the typo and searches on the default engine (hidden al
   expect(new URL(request.url()).searchParams.get("q")).toBe("scholor");
 });
 
+test("pressing Enter declines the typo and searches on the default engine", async ({
+  context,
+  extensionId,
+}) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/newtab/newtab.html`);
+  await showTypoPrompt(page);
+
+  // Enter mirrors the "Default search" button: the query was just submitted
+  // with Enter, so pressing it again reads as "yes, really search this".
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (r) =>
+        r.isNavigationRequest() &&
+        r.frame() === page.mainFrame() &&
+        /google\.com\/search\?q=/.test(r.url()),
+      { timeout: 8000 },
+    ),
+    page.keyboard.press("Enter"),
+  ]);
+  expect(new URL(request.url()).searchParams.get("q")).toBe("scholor");
+});
+
 // PS: declining a typo must route to the user's configured default engine, not a
 // hard-coded Google. That fallback is pure parser logic (parseCommand →
 // makeDefaultSearch using config.defaultCommand), verified deterministically in the


### PR DESCRIPTION
On the typo prompt ("Did you mean **scholar**?"), pressing **Enter** now does the same thing as the *Default search* button — search the verbatim query on the configured default engine. Rationale: the user just pressed Enter to submit, so a second Enter naturally reads as "yes, really search this".

- `Enter` is now the advertised key on the button (was `G`); `g` and `n` remain as unadvertised aliases, matching the existing hidden-alias pattern.
- Enter defers to the search box when it's focused, so editing the query and resubmitting is unchanged.
- New e2e test mirrors the existing Y/I/N shortcut tests; all 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hgEnPPZkUFhvGrZoeCi78