### PR TITLE
feat: global defaultLuckyUrl (editable on both platforms) + Android Ctrl+Enter lucky + 🌐 URL suggestion icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Every command is yours to configure — change the triggers, point them anywhere
 
 - **Command-based navigation** — short triggers route to any site or search you set up.
 - **Inline suggestions** — autocomplete as you type, per command, from the search engines you choose.
-- **"I'm feeling lucky"** — Ctrl+Enter jumps straight to the first result via the `defaultLuckyUrl` config field (browser extension, and Android with a hardware keyboard).
+- **"I'm feeling lucky"** — Ctrl/Cmd+Enter jumps straight to the first result via the `defaultLuckyUrl` config field (browser extension, and Android with a hardware keyboard).
 - **Bring your own config** — keep your commands in a JSON file you host yourself and sync the same setup across every device and browser, or use the built-in defaults and edit them in-app.
 - **Device-aware routing** — one command can resolve to the right destination per device (e.g. `apps` opens Steam on desktop, the Play Store on Android).
 - **Groups & themes** — organize and personalize your command set, with light/dark modes and multiple styles.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Every command is yours to configure — change the triggers, point them anywhere
 
 - **Command-based navigation** — short triggers route to any site or search you set up.
 - **Inline suggestions** — autocomplete as you type, per command, from the search engines you choose.
+- **"I'm feeling lucky"** — Ctrl+Enter jumps straight to the first result via the `defaultLuckyUrl` config field (browser extension, and Android with a hardware keyboard).
 - **Bring your own config** — keep your commands in a JSON file you host yourself and sync the same setup across every device and browser, or use the built-in defaults and edit them in-app.
 - **Device-aware routing** — one command can resolve to the right destination per device (e.g. `apps` opens Steam on desktop, the Play Store on Android).
 - **Groups & themes** — organize and personalize your command set, with light/dark modes and multiple styles.

--- a/android/app/src/main/assets/default-config.json
+++ b/android/app/src/main/assets/default-config.json
@@ -3,6 +3,7 @@
   "version": 2,
   "defaultCommand": "g",
   "defaultSuggestionsApi": "https://suggestqueries.google.com/complete/search?client=firefox&q={query}",
+  "defaultLuckyUrl": "https://www.google.com/search?q={query}&btnI",
   "groups": [
     {
       "id": "search-engines",
@@ -18,7 +19,6 @@
           "type": "standard",
           "iconUrl": "https://www.google.com/s2/favicons?domain=google.com&sz=128",
           "suggestionsApi": "https://suggestqueries.google.com/complete/search?client=firefox&q={query}",
-          "luckyUrl": "https://www.google.com/search?q={query}&btnI",
           "routes": [
             {
               "devices": "*",

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/ConfigParser.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/ConfigParser.kt
@@ -28,6 +28,7 @@ object ConfigParser {
             version = obj.getInt("version"),
             defaultCommand = obj.getString("defaultCommand"),
             defaultSuggestionsApi = obj.optStringOrNull("defaultSuggestionsApi"),
+            defaultLuckyUrl = obj.optStringOrNull("defaultLuckyUrl"),
             groups = parseGroups(obj.getJSONArray("groups")),
             ignoreList = if (obj.has("ignoreList")) parseStringList(obj.getJSONArray("ignoreList")) else emptyList(),
         )
@@ -67,7 +68,6 @@ object ConfigParser {
             iconUrl = obj.optStringOrNull("iconUrl"),
             iconOverrides = parseIconOverrides(obj.optJSONArray("iconOverrides")),
             suggestionsApi = obj.optStringOrNull("suggestionsApi"),
-            luckyUrl = obj.optStringOrNull("luckyUrl"),
             normalize = parseNormalize(obj.optJSONArray("normalize")),
             routes = parseRoutes(obj.getJSONArray("routes")),
         )

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/ConfigWriter.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/ConfigWriter.kt
@@ -16,6 +16,9 @@ object ConfigWriter {
         if (!cfg.defaultSuggestionsApi.isNullOrBlank()) {
             obj.put("defaultSuggestionsApi", cfg.defaultSuggestionsApi)
         }
+        if (!cfg.defaultLuckyUrl.isNullOrBlank()) {
+            obj.put("defaultLuckyUrl", cfg.defaultLuckyUrl)
+        }
         obj.put("groups", writeGroups(cfg.groups))
         obj.put("ignoreList", writeStringList(cfg.ignoreList))
         return obj.toString(2)
@@ -64,7 +67,6 @@ object ConfigWriter {
             obj.put("iconOverrides", arr)
         }
         if (!c.suggestionsApi.isNullOrBlank()) obj.put("suggestionsApi", c.suggestionsApi)
-        if (!c.luckyUrl.isNullOrBlank()) obj.put("luckyUrl", c.luckyUrl)
         if (c.normalize.isNotEmpty()) {
             val nArr = JSONArray()
             for (step in c.normalize) nArr.put(step.value)

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/Lucky.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/Lucky.kt
@@ -1,0 +1,31 @@
+package sh.kavi.fasttravel.core
+
+/**
+ * Port of extension/src/core/lucky.ts.
+ * Produces identical results for the same inputs as the TypeScript implementation.
+ */
+data class LuckyResult(val url: String, val commandId: String?)
+
+/**
+ * Build the Ctrl+Enter "lucky" navigation URL: the top-level defaultLuckyUrl
+ * template with {query} substituted. Returns null when the config has no
+ * defaultLuckyUrl (callers fall back to a normal search), the default
+ * command doesn't resolve, or the query is empty.
+ */
+object Lucky {
+    fun buildLuckyUrl(config: FastTravelConfig, query: String): LuckyResult? {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return null
+
+        val luckyUrl = config.defaultLuckyUrl?.trim()
+        if (luckyUrl.isNullOrEmpty()) return null
+
+        val defaultCmd = CommandParser.buildTriggerMap(config)[config.defaultCommand.lowercase()]
+            ?: return null
+
+        return LuckyResult(
+            url = luckyUrl.replace("{query}", UrlEncoding.component(trimmed)),
+            commandId = defaultCmd.id,
+        )
+    }
+}

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/core/Models.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/core/Models.kt
@@ -40,7 +40,6 @@ data class Command(
     val iconUrl: String? = null,
     val iconOverrides: List<IconOverride> = emptyList(),
     val suggestionsApi: String? = null,
-    val luckyUrl: String? = null,
     val normalize: List<NormalizeStep> = emptyList(),
     val routes: List<Route>,
 )
@@ -89,6 +88,7 @@ data class FastTravelConfig(
     val version: Int,
     val defaultCommand: String,
     val defaultSuggestionsApi: String? = null,
+    val defaultLuckyUrl: String? = null,
     val groups: List<Group>,
     val ignoreList: List<String>,
 )

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ConfigValidator.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/data/ConfigValidator.kt
@@ -19,6 +19,7 @@ object ConfigValidator {
     private val SCHEME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:.*")
     private val PLACEHOLDER_REGEX =
         Regex("\\{([a-zA-Z0-9_]+)(?::(\\d+)(?:-(\\d+))?)?\\}")
+    private val QUERY_URL_REGEX = Regex("^https?://.*\\{query\\}.*$")
     private const val MAX_PATTERN_LENGTH = 64
 
     fun validate(cfg: FastTravelConfig): List<String> {
@@ -40,6 +41,10 @@ object ConfigValidator {
             errors += "Default command is required."
         } else if (!triggers.containsKey(cfg.defaultCommand.lowercase())) {
             errors += "Default command '${cfg.defaultCommand}' does not match any command trigger."
+        }
+
+        if (!cfg.defaultLuckyUrl.isNullOrBlank() && !QUERY_URL_REGEX.matches(cfg.defaultLuckyUrl)) {
+            errors += "Default lucky URL must be an http(s) URL containing {query}."
         }
 
         return errors

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
@@ -587,6 +588,7 @@ fun SearchScreen(
                 leadingCommandGroupColor = leadingCommand?.let { groupColorMap[it.id] },
                 typoActive = searchState is SearchState.TypoSuggestion,
                 onDeclineTypo = { viewModel.fallbackSearchAfterTypo() },
+                onLuckySearch = { viewModel.onLuckySearch(query) },
                 modifier = Modifier.fillMaxWidth(),
             )
 
@@ -695,6 +697,7 @@ private fun SearchBarPill(
     leadingCommandGroupColor: String? = null,
     typoActive: Boolean = false,
     onDeclineTypo: () -> Unit = {},
+    onLuckySearch: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val appearance = LocalAppearance.current
@@ -771,7 +774,16 @@ private fun SearchBarPill(
                     // mirroring the browser's hidden decline shortcut. Consumed here so
                     // the letter isn't also typed into the field. Not advertised in the UI.
                     .onPreviewKeyEvent { event ->
-                        if (typoActive &&
+                        if (event.type == KeyEventType.KeyDown &&
+                            (event.key == Key.Enter || event.key == Key.NumPadEnter) &&
+                            event.isCtrlPressed
+                        ) {
+                            // Hardware-keyboard Ctrl+Enter "I'm feeling lucky", mirroring the
+                            // extension's shortcut. Consumed here so the IME action doesn't
+                            // also fire and double-navigate. Not advertised in the UI.
+                            onLuckySearch()
+                            true
+                        } else if (typoActive &&
                             event.type == KeyEventType.KeyDown &&
                             event.key == Key.N
                         ) {

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -1262,6 +1262,8 @@ private fun SuggestionRow(
             .semantics { contentDescription = "Search for ${suggestion.displayText}" },
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        // URL-shaped API suggestions (no commandTrigger/commandIconUrl) intentionally get the
+        // globe on Android; the extension currently monograms these (parity gap accepted).
         if (suggestion.commandIconUrl == null && matchedCommand == null && isUrlShaped) {
             UrlGlobeIcon(size = 24.dp)
         } else {

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchActivity.kt
@@ -129,6 +129,7 @@ import androidx.compose.material.icons.filled.Block
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import sh.kavi.fasttravel.core.Command
+import sh.kavi.fasttravel.core.CommandParser
 import sh.kavi.fasttravel.core.CommandType
 import sh.kavi.fasttravel.core.DeviceType
 import sh.kavi.fasttravel.core.InstalledApp
@@ -177,6 +178,24 @@ internal fun ChevronMark(
             lineTo(102f * scale, 140f * scale)
         }
         drawPath(front, color = accent, style = stroke)
+    }
+}
+
+/** Globe icon for URL-shaped rows — parity with the extension's 🌐 rows. */
+@Composable
+private fun UrlGlobeIcon(size: Dp, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.size(size),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "🌐",
+            fontSize = (size.value * 0.72f).sp,
+            textAlign = TextAlign.Center,
+            style = LocalTextStyle.current.copy(
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
+            ),
+        )
     }
 }
 
@@ -1085,6 +1104,9 @@ private fun HistoryRow(
     val groupColorHex = matchedCommand?.let { groupColorMap[it.id] }
     val triggerForMonogram = suggestion.commandTrigger
         ?: suggestion.displayText.trim().ifEmpty { "?" }
+    val isUrlShaped = remember(suggestion.text) {
+        CommandParser.tryUrlDetection(suggestion.text) != null
+    }
 
     Row(
         modifier = Modifier
@@ -1114,6 +1136,8 @@ private fun HistoryRow(
                 contentDescription = "${launchableApp.label} icon",
                 modifier = Modifier.size(24.dp).clip(RoundedCornerShape(6.dp)),
             )
+        } else if (suggestion.commandIconUrl == null && matchedCommand == null && isUrlShaped) {
+            UrlGlobeIcon(size = 24.dp)
         } else {
             CommandFavicon(
                 iconUrl = favicon,
@@ -1226,6 +1250,9 @@ private fun SuggestionRow(
     val groupColorHex = matchedCommand?.let { groupColorMap[it.id] }
     val triggerForMonogram = suggestion.commandTrigger
         ?: suggestion.displayText.trim().ifEmpty { "?" }
+    val isUrlShaped = remember(suggestion.text) {
+        CommandParser.tryUrlDetection(suggestion.text) != null
+    }
 
     Row(
         modifier = Modifier
@@ -1235,12 +1262,16 @@ private fun SuggestionRow(
             .semantics { contentDescription = "Search for ${suggestion.displayText}" },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        CommandFavicon(
-            iconUrl = favicon,
-            trigger = triggerForMonogram,
-            groupColorHex = groupColorHex,
-            size = 24.dp,
-        )
+        if (suggestion.commandIconUrl == null && matchedCommand == null && isUrlShaped) {
+            UrlGlobeIcon(size = 24.dp)
+        } else {
+            CommandFavicon(
+                iconUrl = favicon,
+                trigger = triggerForMonogram,
+                groupColorHex = groupColorHex,
+                size = 24.dp,
+            )
+        }
         Spacer(modifier = Modifier.width(12.dp))
         TailText(
             text = suggestion.displayText,

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SearchViewModel.kt
@@ -15,6 +15,7 @@ import sh.kavi.fasttravel.core.Frecency
 import sh.kavi.fasttravel.core.Group
 import sh.kavi.fasttravel.core.InstalledApp
 import sh.kavi.fasttravel.core.InstalledAppResolver
+import sh.kavi.fasttravel.core.Lucky
 import sh.kavi.fasttravel.core.ParseInput
 import sh.kavi.fasttravel.core.ParseOutput
 import sh.kavi.fasttravel.core.Suggestion
@@ -37,6 +38,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
+
+// Mirrors the scheme guard in newtab.ts's handleLuckySearch.
+private val LUCKY_URL_SCHEME_RE = Regex("^https?:", RegexOption.IGNORE_CASE)
 
 sealed class SearchState {
     data object Idle : SearchState()
@@ -452,6 +456,31 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
                 _searchState.value = SearchState.TypoSuggestion(result)
             }
         }
+    }
+
+    /**
+     * Ctrl+Enter (hardware keyboard only): "I'm feeling lucky"-style navigation
+     * via the top-level defaultLuckyUrl template. Falls back to a normal search when
+     * the config doesn't define one, the default command doesn't resolve, or the
+     * built URL fails the scheme guard. Mirrors handleLuckySearch in newtab.ts.
+     */
+    fun onLuckySearch(searchQuery: String) {
+        val cfg = config ?: return
+        if (searchQuery.isBlank()) return
+
+        val lucky = Lucky.buildLuckyUrl(effectiveConfig(cfg), searchQuery)
+        // Tighter than the general allowlist: the defaultLuckyUrl contract is
+        // https?:// everywhere it's validated (schema/validator/linter). A refused
+        // scheme falls back to a normal search rather than silently eating the keypress.
+        if (lucky == null || !LUCKY_URL_SCHEME_RE.containsMatchIn(lucky.url)) {
+            onSearch(searchQuery)
+            return
+        }
+
+        _suggestions.value = emptyList()
+        searchHistory.addEntry(searchQuery, lucky.commandId)
+        updateChipCommands()
+        _searchState.value = SearchState.Navigate(lucky.url)
     }
 
     fun acceptTypo() {

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -757,6 +757,32 @@ fun ConfigurationScreen(
                             },
                         )
                     }
+                    var defaultLuckyUrlText by remember(config.defaultLuckyUrl) {
+                        mutableStateOf(config.defaultLuckyUrl ?: "")
+                    }
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                        OutlinedTextFieldS(
+                            value = defaultLuckyUrlText,
+                            onValueChange = { defaultLuckyUrlText = it },
+                            label = { Text("Default lucky URL (optional)") },
+                            placeholder = { Text("https://www.google.com/search?q={query}&btnI") },
+                            supportingText = { Text("Use {query}. Ctrl+Enter (hardware keyboard) opens the first result.") },
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(8.dp),
+                            trailingIcon = {
+                                if (defaultLuckyUrlText.trim() != (config.defaultLuckyUrl ?: "")) {
+                                    IconButton(onClick = {
+                                        val url = defaultLuckyUrlText.trim().ifEmpty { null }
+                                        editableStore.saveLocalConfig(config.copy(defaultLuckyUrl = url))
+                                        markDirtyAndCancelRefresh(context, themePrefs)
+                                        onConfigChanged()
+                                    }) {
+                                        Icon(Icons.Default.Check, contentDescription = "Save")
+                                    }
+                                }
+                            },
+                        )
+                    }
                 }
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
                 NavigableListItem(

--- a/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
+++ b/android/app/src/main/kotlin/sh/kavi/fasttravel/ui/SettingsActivity.kt
@@ -773,9 +773,17 @@ fun ConfigurationScreen(
                                 if (defaultLuckyUrlText.trim() != (config.defaultLuckyUrl ?: "")) {
                                     IconButton(onClick = {
                                         val url = defaultLuckyUrlText.trim().ifEmpty { null }
-                                        editableStore.saveLocalConfig(config.copy(defaultLuckyUrl = url))
-                                        markDirtyAndCancelRefresh(context, themePrefs)
-                                        onConfigChanged()
+                                        val updated = config.copy(defaultLuckyUrl = url)
+                                        val errors = ConfigValidator.validate(updated)
+                                        if (errors.isNotEmpty()) {
+                                            scope.launch {
+                                                snackbarHostState.showSnackbar(errors.first())
+                                            }
+                                        } else {
+                                            editableStore.saveLocalConfig(updated)
+                                            markDirtyAndCancelRefresh(context, themePrefs)
+                                            onConfigChanged()
+                                        }
                                     }) {
                                         Icon(Icons.Default.Check, contentDescription = "Save")
                                     }

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/core/ConfigParserTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/core/ConfigParserTest.kt
@@ -43,11 +43,12 @@ class ConfigParserTest {
     }
 
     @Test
-    fun `luckyUrl survives a parse-write-parse round trip`() {
+    fun `defaultLuckyUrl survives a parse-write-parse round trip`() {
         val json = """
             {
               "version": 2,
               "defaultCommand": "g",
+              "defaultLuckyUrl": "https://www.google.com/search?q={query}&btnI",
               "groups": [
                 {
                   "id": "grp",
@@ -58,7 +59,6 @@ class ConfigParserTest {
                       "triggers": ["g"],
                       "name": "Google",
                       "type": "standard",
-                      "luckyUrl": "https://www.google.com/search?q={query}&btnI",
                       "routes": [{ "devices": "*", "defaultUrl": "https://www.google.com" }]
                     }
                   ]
@@ -71,13 +71,13 @@ class ConfigParserTest {
         val parsed = ConfigParser.parseConfig(json)
         assertEquals(
             "https://www.google.com/search?q={query}&btnI",
-            parsed.groups[0].commands[0].luckyUrl,
+            parsed.defaultLuckyUrl,
         )
 
         val rewritten = ConfigParser.parseConfig(ConfigWriter.writeConfig(parsed))
         assertEquals(
             "https://www.google.com/search?q={query}&btnI",
-            rewritten.groups[0].commands[0].luckyUrl,
+            rewritten.defaultLuckyUrl,
         )
     }
 }

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/core/LuckyTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/core/LuckyTest.kt
@@ -1,15 +1,23 @@
 package sh.kavi.fasttravel.core
 
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+import java.util.stream.Stream
 
 /**
- * Minimal hand-written coverage for [Lucky.buildLuckyUrl]. A later task adds a
- * fixture-driven @ParameterizedTest block here (shared/test-fixtures) that exercises
- * the extension and Android ports against the same cases — kept as plain @Test
- * functions for now so that block can be added alongside without restructuring.
+ * Coverage for [Lucky.buildLuckyUrl]: hand-written cases plus a fixture-driven
+ * block (shared/test-fixtures/lucky.fixtures.json) that exercises the extension
+ * and Android ports against the same cases to pin cross-platform parity.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LuckyTest {
 
     private fun command(id: String, trigger: String) = Command(
@@ -66,5 +74,75 @@ class LuckyTest {
     @Test
     fun `returns null when the default command does not resolve`() {
         assertNull(Lucky.buildLuckyUrl(config(defaultCommand = "missing"), "cat pics"))
+    }
+
+    /** Get an optional string field, returning null if absent (not the empty string). */
+    private fun JSONObject.optStringOrNull(key: String): String? =
+        if (has(key) && !isNull(key)) getString(key) else null
+
+    private fun resolveSharedFile(relativePath: String): File {
+        // Try multiple base paths - Gradle may run from android/ or android/app/
+        val candidates = listOf(
+            File("../shared/$relativePath"),
+            File("../../shared/$relativePath"),
+            File("shared/$relativePath"),
+        )
+        return candidates.firstOrNull { it.exists() }
+            ?: throw IllegalStateException(
+                "Cannot find shared/$relativePath. Tried: ${candidates.map { it.absolutePath }}"
+            )
+    }
+
+    data class LuckyFixture(
+        val description: String,
+        val defaultLuckyUrl: String?,
+        val defaultCommand: String,
+        val query: String,
+        val expectedUrl: String?,
+        val expectedCommandId: String?,
+    )
+
+    private fun loadLuckyFixtures(): Stream<LuckyFixture> {
+        val json = resolveSharedFile("test-fixtures/lucky.fixtures.json").readText()
+        val arr = JSONArray(json)
+        val fixtures = mutableListOf<LuckyFixture>()
+
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            val input = obj.getJSONObject("input")
+            val expected = obj.optJSONObject("expected")
+            fixtures.add(
+                LuckyFixture(
+                    description = obj.getString("description"),
+                    defaultLuckyUrl = input.optStringOrNull("defaultLuckyUrl"),
+                    defaultCommand = input.getString("defaultCommand"),
+                    query = input.getString("query"),
+                    expectedUrl = expected?.optStringOrNull("url"),
+                    expectedCommandId = expected?.optStringOrNull("commandId"),
+                )
+            )
+        }
+
+        return fixtures.stream()
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("loadLuckyFixtures")
+    @DisplayName("Lucky URL fixtures")
+    fun `lucky url fixtures`(fixture: LuckyFixture) {
+        val result = Lucky.buildLuckyUrl(
+            config(defaultCommand = fixture.defaultCommand, defaultLuckyUrl = fixture.defaultLuckyUrl),
+            fixture.query,
+        )
+
+        if (fixture.expectedUrl == null) {
+            assertNull(result, "${fixture.description}: expected null")
+        } else {
+            assertEquals(
+                LuckyResult(url = fixture.expectedUrl, commandId = fixture.expectedCommandId),
+                result,
+                fixture.description,
+            )
+        }
     }
 }

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/core/LuckyTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/core/LuckyTest.kt
@@ -1,0 +1,70 @@
+package sh.kavi.fasttravel.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Minimal hand-written coverage for [Lucky.buildLuckyUrl]. A later task adds a
+ * fixture-driven @ParameterizedTest block here (shared/test-fixtures) that exercises
+ * the extension and Android ports against the same cases — kept as plain @Test
+ * functions for now so that block can be added alongside without restructuring.
+ */
+class LuckyTest {
+
+    private fun command(id: String, trigger: String) = Command(
+        id = id,
+        triggers = listOf(trigger),
+        name = id,
+        type = CommandType.Standard,
+        routes = listOf(
+            Route(devices = RouteDevices.Wildcard, defaultUrl = "https://example.com"),
+        ),
+    )
+
+    private fun config(
+        defaultCommand: String = "g",
+        defaultLuckyUrl: String? = "https://www.google.com/search?q={query}&btnI",
+    ) = FastTravelConfig(
+        version = 1,
+        defaultCommand = defaultCommand,
+        defaultLuckyUrl = defaultLuckyUrl,
+        groups = listOf(
+            Group(id = "g1", name = "Group", commands = listOf(command("google", "g"))),
+        ),
+        ignoreList = emptyList(),
+    )
+
+    @Test
+    fun `substitutes query and attributes the default command`() {
+        val result = Lucky.buildLuckyUrl(config(), "cat pics")
+
+        assertEquals(
+            LuckyResult(
+                url = "https://www.google.com/search?q=cat%20pics&btnI",
+                commandId = "google",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `returns null when defaultLuckyUrl is absent`() {
+        assertNull(Lucky.buildLuckyUrl(config(defaultLuckyUrl = null), "cat pics"))
+    }
+
+    @Test
+    fun `returns null when defaultLuckyUrl is blank`() {
+        assertNull(Lucky.buildLuckyUrl(config(defaultLuckyUrl = "   "), "cat pics"))
+    }
+
+    @Test
+    fun `returns null when query is blank`() {
+        assertNull(Lucky.buildLuckyUrl(config(), "   "))
+    }
+
+    @Test
+    fun `returns null when the default command does not resolve`() {
+        assertNull(Lucky.buildLuckyUrl(config(defaultCommand = "missing"), "cat pics"))
+    }
+}

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ConfigValidatorTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/data/ConfigValidatorTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test
 import sh.kavi.fasttravel.core.Command
 import sh.kavi.fasttravel.core.CommandType
 import sh.kavi.fasttravel.core.DeviceType
+import sh.kavi.fasttravel.core.FastTravelConfig
+import sh.kavi.fasttravel.core.Group
 import sh.kavi.fasttravel.core.IconOverride
 import sh.kavi.fasttravel.core.Route
 import sh.kavi.fasttravel.core.RouteDevices
@@ -22,6 +24,51 @@ class ConfigValidatorTest {
             Route(devices = RouteDevices.Wildcard, defaultUrl = "https://example.com"),
         ),
     )
+
+    /** Minimal valid whole-config fixture; each test overrides just what it needs. */
+    private fun baseConfig(defaultLuckyUrl: String? = null) = FastTravelConfig(
+        version = 1,
+        defaultCommand = "t",
+        defaultLuckyUrl = defaultLuckyUrl,
+        groups = listOf(Group(id = "g", name = "G", commands = listOf(baseCommand()))),
+        ignoreList = emptyList(),
+    )
+
+    @Test
+    fun `defaultLuckyUrl null is valid`() {
+        val errors = ConfigValidator.validate(baseConfig(defaultLuckyUrl = null))
+        assertEquals(emptyList<String>(), errors)
+    }
+
+    @Test
+    fun `defaultLuckyUrl with query placeholder is valid`() {
+        val errors = ConfigValidator.validate(
+            baseConfig(defaultLuckyUrl = "https://www.google.com/search?q={query}&btnI"),
+        )
+        assertEquals(emptyList<String>(), errors)
+    }
+
+    @Test
+    fun `defaultLuckyUrl missing query placeholder is rejected`() {
+        val errors = ConfigValidator.validate(
+            baseConfig(defaultLuckyUrl = "https://www.google.com/search?q=foo"),
+        )
+        assertTrue(
+            errors.any { it.contains("Default lucky URL") },
+            "expected a Default lucky URL error, got: $errors",
+        )
+    }
+
+    @Test
+    fun `defaultLuckyUrl with non-http scheme is rejected`() {
+        val errors = ConfigValidator.validate(
+            baseConfig(defaultLuckyUrl = "ftp://example.com/{query}"),
+        )
+        assertTrue(
+            errors.any { it.contains("Default lucky URL") },
+            "expected a Default lucky URL error, got: $errors",
+        )
+    }
 
     @Test
     fun `valid iconOverrides pass validation`() {

--- a/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/SearchViewModelLuckyTest.kt
+++ b/android/app/src/test/kotlin/sh/kavi/fasttravel/ui/SearchViewModelLuckyTest.kt
@@ -1,0 +1,107 @@
+package sh.kavi.fasttravel.ui
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import sh.kavi.fasttravel.data.ConfigRefreshInterval
+import sh.kavi.fasttravel.data.EditableConfigStore
+import sh.kavi.fasttravel.data.ThemePreferences
+
+/**
+ * Regression tests for [SearchViewModel.onLuckySearch] (Ctrl+Enter "I'm feeling lucky"
+ * on a hardware keyboard). Mirrors handleLuckySearch in the extension's newtab.ts:
+ * substitutes {query} into the top-level defaultLuckyUrl and navigates directly,
+ * falling back to a normal search when the config has no defaultLuckyUrl.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class SearchViewModelLuckyTest {
+
+    private val app: Application = ApplicationProvider.getApplicationContext()
+    private val scheduler = TestCoroutineScheduler()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher(scheduler))
+
+        val themePrefs = ThemePreferences(app)
+        themePrefs.configSourceDirty = false
+        themePrefs.configRefreshInterval = ConfigRefreshInterval.MANUAL // cache never expires
+        themePrefs.configUrl = "no-protocol-url" // never hit the network
+        EditableConfigStore(app).clearLocalConfig()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /** Caches [configJson] as the config the ViewModel loads on init. */
+    private fun cacheConfig(configJson: String) {
+        app.getSharedPreferences("fast_travel_config", Context.MODE_PRIVATE)
+            .edit()
+            .putString("cached_config_json", configJson)
+            .putLong("cache_timestamp", 1_000_000L)
+            .apply()
+    }
+
+    private fun defaultConfigJson(): JSONObject =
+        JSONObject(
+            app.assets.open("default-config.json").bufferedReader().use { it.readText() },
+        )
+
+    @Test
+    fun `navigates to the substituted lucky URL when defaultLuckyUrl is present`() {
+        // default-config.json ships defaultLuckyUrl = "https://www.google.com/search?q={query}&btnI".
+        cacheConfig(defaultConfigJson().toString())
+
+        val vm = SearchViewModel(app)
+        scheduler.advanceUntilIdle() // let init load the cached config
+
+        vm.onLuckySearch("cat pics")
+
+        val state = vm.searchState.value
+        assertTrue("expected a Navigate state, got $state", state is SearchState.Navigate)
+        assertEquals(
+            "https://www.google.com/search?q=cat%20pics&btnI",
+            (state as SearchState.Navigate).url,
+        )
+    }
+
+    @Test
+    fun `falls back to a normal search when defaultLuckyUrl is absent`() {
+        val configJson = defaultConfigJson().apply { remove("defaultLuckyUrl") }
+        cacheConfig(configJson.toString())
+
+        val vm = SearchViewModel(app)
+        scheduler.advanceUntilIdle() // let init load the cached config
+
+        // "scholr" is a detectable typo of the "scholar" trigger (per
+        // SearchViewModelTypoIgnoreTest). buildLuckyUrl never produces a typo
+        // suggestion — only onSearch's parseCommand does — so landing in
+        // TypoSuggestion proves onLuckySearch fell through to a normal search
+        // rather than coincidentally producing the same Navigate state.
+        vm.onLuckySearch("scholr")
+
+        assertTrue(
+            "expected a fallback typo suggestion, got ${vm.searchState.value}",
+            vm.searchState.value is SearchState.TypoSuggestion,
+        )
+    }
+}

--- a/extension/src/core/config-linter.ts
+++ b/extension/src/core/config-linter.ts
@@ -51,22 +51,23 @@ export function lintConfig(config: FastTravelConfig): LintError[] {
   checkNormalize(commands, errors);
   checkEmptyStrings(commands, errors);
   checkUrlSchemes(commands, errors);
-  checkLuckyUrls(commands, errors);
+  checkDefaultLuckyUrl(config, errors);
 
   return errors;
 }
 
 const HTTPS_QUERY_RE = /^https?:\/\/.*\{query\}.*$/;
 
-function checkLuckyUrls(commands: Command[], errors: LintError[]): void {
-  for (const cmd of commands) {
-    if (cmd.luckyUrl === undefined) continue;
-    if (!HTTPS_QUERY_RE.test(cmd.luckyUrl)) {
-      errors.push({
-        path: `commands.${cmd.id}.luckyUrl`,
-        message: `luckyUrl must be an http(s) URL containing {query} — got "${cmd.luckyUrl}"`,
-      });
-    }
+function checkDefaultLuckyUrl(
+  config: FastTravelConfig,
+  errors: LintError[],
+): void {
+  if (config.defaultLuckyUrl === undefined) return;
+  if (!HTTPS_QUERY_RE.test(config.defaultLuckyUrl)) {
+    errors.push({
+      path: "defaultLuckyUrl",
+      message: `defaultLuckyUrl must be an http(s) URL containing {query} — got "${config.defaultLuckyUrl}"`,
+    });
   }
 }
 

--- a/extension/src/core/lucky.ts
+++ b/extension/src/core/lucky.ts
@@ -7,10 +7,10 @@ export interface LuckyResult {
 }
 
 /**
- * Build the Ctrl+Enter "lucky" navigation URL: the default command's
- * luckyUrl template with {query} substituted. Returns null when the default
- * command has no luckyUrl (callers fall back to a normal search) or the
- * query is empty.
+ * Build the Ctrl+Enter "lucky" navigation URL: the top-level defaultLuckyUrl
+ * template with {query} substituted. Returns null when the config has no
+ * defaultLuckyUrl (callers fall back to a normal search), the default
+ * command doesn't resolve, or the query is empty.
  */
 export function buildLuckyUrl(
   config: FastTravelConfig,
@@ -19,13 +19,16 @@ export function buildLuckyUrl(
   const trimmed = query.trim();
   if (trimmed === "") return null;
 
+  const luckyUrl = config.defaultLuckyUrl?.trim();
+  if (!luckyUrl) return null;
+
   const defaultCmd = buildTriggerMap(config).get(
     config.defaultCommand.toLowerCase(),
   );
-  if (!defaultCmd?.luckyUrl) return null;
+  if (!defaultCmd) return null;
 
   return {
-    url: defaultCmd.luckyUrl.replaceAll("{query}", encodeURIComponent(trimmed)),
+    url: luckyUrl.replaceAll("{query}", encodeURIComponent(trimmed)),
     commandId: defaultCmd.id,
   };
 }

--- a/extension/src/core/types.ts
+++ b/extension/src/core/types.ts
@@ -14,6 +14,7 @@ export interface FastTravelConfig {
   version: 2;
   defaultCommand: string;
   defaultSuggestionsApi?: string;
+  defaultLuckyUrl?: string;
   groups: Group[];
   ignoreList: string[];
 }
@@ -47,7 +48,6 @@ export interface Command {
   iconUrl?: string;
   iconOverrides?: IconOverride[];
   suggestionsApi?: string;
-  luckyUrl?: string;
   normalize?: NormalizeStep[];
   routes: Route[];
 }

--- a/extension/src/newtab/newtab.css
+++ b/extension/src/newtab/newtab.css
@@ -287,6 +287,11 @@ body:hover #settings-link {
   font-weight: 700;
 }
 
+.suggestion-favicon.globe {
+  font-size: 15px;
+  line-height: 1;
+}
+
 .suggestion-trailing-arrow {
   color: var(--text-placeholder);
   flex-shrink: 0;

--- a/extension/src/newtab/newtab.html
+++ b/extension/src/newtab/newtab.html
@@ -40,7 +40,7 @@
           />
           <div id="suggestions-dropdown" class="hidden" role="listbox"></div>
         </div>
-        <div id="search-hint">Press <kbd>Enter</kbd> to search · Try <kbd>g</kbd>, <kbd>yt</kbd>, <kbd>gh</kbd>, <kbd>$AAPL</kbd> · <kbd>Ctrl</kbd>+<kbd>Enter</kbd> lucky</div>
+        <div id="search-hint">Press <kbd>Enter</kbd> to search · Try <kbd>g</kbd>, <kbd>yt</kbd>, <kbd>gh</kbd>, <kbd>$AAPL</kbd> · <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Enter</kbd> lucky</div>
       </section>
 
       <div id="typo-container" class="hidden" role="alert">

--- a/extension/src/newtab/newtab.html
+++ b/extension/src/newtab/newtab.html
@@ -40,7 +40,7 @@
           />
           <div id="suggestions-dropdown" class="hidden" role="listbox"></div>
         </div>
-        <div id="search-hint">Press <kbd>Enter</kbd> to search · Try <kbd>g</kbd>, <kbd>yt</kbd>, <kbd>gh</kbd>, <kbd>$AAPL</kbd></div>
+        <div id="search-hint">Press <kbd>Enter</kbd> to search · Try <kbd>g</kbd>, <kbd>yt</kbd>, <kbd>gh</kbd>, <kbd>$AAPL</kbd> · <kbd>Ctrl</kbd>+<kbd>Enter</kbd> lucky</div>
       </section>
 
       <div id="typo-container" class="hidden" role="alert">

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -408,9 +408,9 @@ function handleSearch(): void {
   }
 }
 
-// Ctrl/Cmd+Enter: "I'm feeling lucky"-style navigation via the default
-// command's luckyUrl template. Falls back to a normal search when the
-// config doesn't define one.
+// Ctrl/Cmd+Enter: "I'm feeling lucky"-style navigation via the top-level
+// defaultLuckyUrl template. Falls back to a normal search when the config
+// doesn't define one.
 function handleLuckySearch(): void {
   if (!config) return;
   const query = searchInput.value.trim();
@@ -421,8 +421,8 @@ function handleLuckySearch(): void {
     handleSearch();
     return;
   }
-  // Tighter than the general allowlist: the luckyUrl contract is https?://
-  // everywhere it's validated (schema/validator/linter). A refused scheme
+  // Tighter than the general allowlist: the defaultLuckyUrl contract is
+  // https?:// everywhere it's validated (schema/validator/linter). A refused scheme
   // falls back to a normal search rather than silently eating the keypress.
   if (!/^https?:/i.test(lucky.url)) {
     handleSearch();

--- a/extension/src/newtab/newtab.ts
+++ b/extension/src/newtab/newtab.ts
@@ -1,4 +1,4 @@
-import { parseCommand, buildTriggerMap } from "../core/parser.js";
+import { parseCommand, buildTriggerMap, tryUrlDetection } from "../core/parser.js";
 import { buildLuckyUrl } from "../core/lucky.js";
 import { fetchSuggestions } from "../core/suggestions.js";
 import { detectDevice } from "../core/device.js";
@@ -60,6 +60,8 @@ interface SuggestionItem {
   topHit?: boolean;
   /** Navigation target for browser-history rows. */
   url?: string;
+  /** True when the row's underlying text/URL is URL-shaped; shows a 🌐 icon instead of a monogram. */
+  isUrl?: boolean;
 }
 
 interface ResolvedCommand {
@@ -578,6 +580,7 @@ async function showHistory(): Promise<void> {
         iconUrl: rc ? resolveIconUrl(rc.cmd, device) : undefined,
         groupColor: rc?.groupColor,
         command: rc?.cmd,
+        isUrl: h.commandId === null ? tryUrlDetection(h.query) !== null : undefined,
       };
     });
 
@@ -699,6 +702,7 @@ function showSuggestions(query: string): void {
             groupColor: rc?.groupColor,
             command: rc?.cmd,
             topHit: b.topHit,
+            isUrl: b.entry.commandId === null ? tryUrlDetection(b.entry.query) !== null : undefined,
           };
         }
         return {
@@ -708,6 +712,7 @@ function showSuggestions(query: string): void {
           url: b.entry.url,
           timestamp: b.entry.lastVisitTime || undefined,
           topHit: b.topHit,
+          isUrl: true,
         };
       });
       renderSuggestions([...commandItems, ...blendedItems]);
@@ -799,12 +804,17 @@ function renderSuggestions(items: SuggestionItem[], showClearHistory = false): v
 
     const favicon = document.createElement("div");
     favicon.className = "suggestion-favicon";
-    renderFavicon(favicon, {
-      iconUrl: item.iconUrl,
-      trigger: item.matchedTrigger ?? item.command?.triggers[0] ?? item.display.charAt(0),
-      groupColor: item.groupColor,
-      size: 20,
-    });
+    if (item.isUrl && !item.iconUrl) {
+      favicon.classList.add("globe");
+      favicon.textContent = "🌐";
+    } else {
+      renderFavicon(favicon, {
+        iconUrl: item.iconUrl,
+        trigger: item.matchedTrigger ?? item.command?.triggers[0] ?? item.display.charAt(0),
+        groupColor: item.groupColor,
+        size: 20,
+      });
+    }
     el.appendChild(favicon);
 
     if (item.kind === "history") {

--- a/extension/src/options/screens/configuration.ts
+++ b/extension/src/options/screens/configuration.ts
@@ -38,6 +38,14 @@ export async function renderConfiguration(main: HTMLElement): Promise<void> {
     });
     card.appendChild(apiRow);
     card.appendChild(el("div", { class: "card-divider" }));
+
+    const luckyRow = defaultLuckyUrlRow(config, async (url) => {
+      const current = await getConfig();
+      if (!current) return;
+      await setConfig({ ...current, defaultLuckyUrl: url || undefined });
+    });
+    card.appendChild(luckyRow);
+    card.appendChild(el("div", { class: "card-divider" }));
   }
 
   // Import / Export row — its subtitle surfaces sync state (mirrors Android):
@@ -90,6 +98,24 @@ function defaultSuggestionsApiRow(
   input.addEventListener("change", () => void onSave(input.value.trim()));
   row.appendChild(input);
   row.appendChild(el("div", { class: "form-hint" }, "Fallback when a command has no suggestions URL. Include {query}."));
+  return row;
+}
+
+function defaultLuckyUrlRow(
+  config: FastTravelConfig,
+  onSave: (url: string) => Promise<void>,
+): HTMLElement {
+  const row = el("div", { class: "form-row", style: "padding:12px 16px;" });
+  row.appendChild(el("label", { for: "default-lucky-url" }, "Default lucky URL (optional)"));
+  const input = el("input", {
+    id: "default-lucky-url",
+    type: "text",
+    placeholder: "https://www.google.com/search?q={query}&btnI",
+    value: config.defaultLuckyUrl ?? "",
+  }) as HTMLInputElement;
+  input.addEventListener("change", () => void onSave(input.value.trim()));
+  row.appendChild(input);
+  row.appendChild(el("div", { class: "form-hint" }, "Must include {query}. Ctrl+Enter opens the first result via this URL."));
   return row;
 }
 

--- a/extension/tests/e2e/config-editing.spec.ts
+++ b/extension/tests/e2e/config-editing.spec.ts
@@ -90,6 +90,58 @@ test("config: export produces valid JSON matching stored config", async ({ conte
   expect(exported).toEqual(stored);
 });
 
+// onInstalled kicks off a non-blocking fetch of the remote default config
+// (unless dirty) that can race with — and silently overwrite — the freshly
+// seeded bundled config the assertions below depend on (see
+// project_config_dirty_pause.md / fetchAndStoreConfig in service-worker.ts).
+// Block that request so the bundled shipped values load deterministically.
+async function blockRemoteConfigFetch(context: import("@playwright/test").BrowserContext) {
+  await context.route("https://raw.githubusercontent.com/**", (route) => route.abort());
+}
+
+const SHIPPED_LUCKY_URL = "https://www.google.com/search?q={query}&btnI";
+
+test("config: default lucky URL field is pre-filled, editable, and persists", async ({ context, extensionId }) => {
+  await blockRemoteConfigFetch(context);
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/options/options.html#/configuration`);
+
+  const luckyInput = inputByLabel(page, "Default lucky URL (optional)");
+  await expect(luckyInput).toHaveValue(SHIPPED_LUCKY_URL);
+
+  const customUrl = "https://www.bing.com/search?q={query}&btnI";
+  await luckyInput.fill(customUrl);
+  await luckyInput.blur();
+
+  await expect
+    .poll(async () => (await getStoredConfig(context, extensionId)).defaultLuckyUrl)
+    .toBe(customUrl);
+
+  await page.reload();
+  await expect(inputByLabel(page, "Default lucky URL (optional)")).toHaveValue(customUrl);
+});
+
+test("config: invalid default lucky URL is rejected and not persisted", async ({ context, extensionId }) => {
+  await blockRemoteConfigFetch(context);
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/options/options.html#/configuration`);
+
+  const before = await waitForSeededConfig(context, extensionId);
+  const luckyInput = inputByLabel(page, "Default lucky URL (optional)");
+  await expect(luckyInput).toHaveValue(before.defaultLuckyUrl);
+
+  await luckyInput.fill("ftp://x");
+  await luckyInput.blur();
+
+  // The background rejects the lint failure and never persists it — the
+  // stored config should remain exactly what it was before the edit.
+  await page.waitForTimeout(300);
+  const after = await getStoredConfig(context, extensionId);
+  expect(after.defaultLuckyUrl).toBe(before.defaultLuckyUrl);
+});
+
 test("config: importing a valid file replaces config", async ({ context, extensionId }) => {
   const page = await context.newPage();
   await page.goto(`chrome-extension://${extensionId}/options/options.html#/import-export`);

--- a/extension/tests/e2e/suggestions-blend.spec.ts
+++ b/extension/tests/e2e/suggestions-blend.spec.ts
@@ -160,6 +160,30 @@ test("blend: Ctrl+ArrowDown jumps to the next section start", async ({
   await expect(page.locator(".suggestion-item.active")).toHaveClass(/suggestion-history/);
 });
 
+test("URL-shaped history rows show the globe icon", async ({ context, extensionId }) => {
+  await stubSuggestApi(context);
+  const page = await openNewtab(context, extensionId);
+  await seedHistory(page, [
+    { query: "github.com/foo", commandId: null, timestamp: Date.now() },
+    { query: "gitlab pipelines", commandId: null, timestamp: Date.now() - 86_400_000 },
+  ]);
+  await page.reload();
+  await page.locator("html[data-ft-ready]").waitFor();
+
+  await page.locator("#search-input").fill("gi");
+
+  const globeIcons = page.locator(".suggestion-item .suggestion-favicon.globe");
+  await expect(globeIcons).toHaveCount(1, { timeout: 5000 });
+  await expect(globeIcons).toHaveText("🌐");
+
+  const plainRow = page.locator(".suggestion-item.suggestion-history", {
+    hasText: "gitlab pipelines",
+  });
+  const plainFavicon = plainRow.locator(".suggestion-favicon");
+  await expect(plainFavicon).toHaveClass(/monogram/);
+  await expect(plainFavicon).not.toHaveClass(/globe/);
+});
+
 test("settings: Suggestions screen defaults — FT on, browser history off", async ({
   context,
   extensionId,

--- a/extension/tests/e2e/url-navigation.spec.ts
+++ b/extension/tests/e2e/url-navigation.spec.ts
@@ -5,7 +5,7 @@
  *   1. Typing a bare domain navigates directly (no search engine round-trip)
  *   2. A multi-token query containing a domain-like word still searches
  *   3. javascript: input never navigates (complements xss-javascript-url.spec.ts)
- *   4. Ctrl+Enter routes through the default command's luckyUrl template
+ *   4. Ctrl+Enter routes through the top-level defaultLuckyUrl template
  *
  * Navigation assertions use waitForRequest so tests resolve when the request
  * is issued, without depending on external sites actually loading.
@@ -94,25 +94,22 @@ test("javascript: input searches instead of navigating", async ({ context, exten
   expect(dialogFired).toBe(false);
 });
 
-test("Ctrl+Enter routes through the default command's luckyUrl", async ({
+test("Ctrl+Enter routes through the top-level defaultLuckyUrl", async ({
   context,
   extensionId,
 }) => {
   const page = await readyNewtab(context, extensionId);
 
   // Seed the config directly: the service worker refreshes config from the
-  // repo's main branch on install, which may not carry luckyUrl yet. Direct
-  // storage write keeps this test hermetic (same pattern as the xss spec).
+  // repo's main branch on install, which may not carry defaultLuckyUrl yet.
+  // Direct storage write keeps this test hermetic (same pattern as the xss spec).
   const sw = context.serviceWorkers()[0];
   await sw.evaluate(() =>
     chrome.storage.local
       .get("fast-travel-config")
       .then((v: Record<string, any>) => {
         const cfg = v["fast-travel-config"];
-        const google = cfg.groups
-          .flatMap((g: any) => g.commands)
-          .find((c: any) => c.id === "google");
-        google.luckyUrl = "https://www.google.com/search?q={query}&btnI";
+        cfg.defaultLuckyUrl = "https://www.google.com/search?q={query}&btnI";
         return chrome.storage.local.set({ "fast-travel-config": cfg });
       }),
   );

--- a/extension/tests/unit/config-linter.test.ts
+++ b/extension/tests/unit/config-linter.test.ts
@@ -188,33 +188,30 @@ describe("config-linter: existing checks still work", () => {
 });
 
 // ---------------------------------------------------------------------------
-// luckyUrl validation
+// defaultLuckyUrl validation
 // ---------------------------------------------------------------------------
 
-describe("config-linter: luckyUrl", () => {
-  it("accepts an http(s) luckyUrl containing {query}", () => {
-    const cfg = makeConfig();
-    cfg.groups[0].commands[0].luckyUrl = "https://www.google.com/search?q={query}&btnI";
+describe("config-linter: defaultLuckyUrl", () => {
+  it("accepts an http(s) defaultLuckyUrl containing {query}", () => {
+    const cfg = makeConfig({ defaultLuckyUrl: "https://www.google.com/search?q={query}&btnI" });
     const errors = lintConfig(cfg);
-    expect(errors.filter((e) => e.path.includes("luckyUrl"))).toHaveLength(0);
+    expect(errors.filter((e) => e.path.includes("defaultLuckyUrl"))).toHaveLength(0);
   });
 
-  it("rejects a luckyUrl without {query}", () => {
-    const cfg = makeConfig();
-    cfg.groups[0].commands[0].luckyUrl = "https://www.google.com/search?btnI";
+  it("rejects a defaultLuckyUrl without {query}", () => {
+    const cfg = makeConfig({ defaultLuckyUrl: "https://www.google.com/search?btnI" });
     const errors = lintConfig(cfg);
-    expect(errors.filter((e) => e.path.includes("luckyUrl"))).toHaveLength(1);
+    expect(errors.filter((e) => e.path.includes("defaultLuckyUrl"))).toHaveLength(1);
   });
 
-  it("rejects a non-http luckyUrl", () => {
-    const cfg = makeConfig();
-    cfg.groups[0].commands[0].luckyUrl = "javascript:alert('{query}')";
+  it("rejects a non-http defaultLuckyUrl", () => {
+    const cfg = makeConfig({ defaultLuckyUrl: "javascript:alert('{query}')" });
     const errors = lintConfig(cfg);
-    expect(errors.filter((e) => e.path.includes("luckyUrl"))).toHaveLength(1);
+    expect(errors.filter((e) => e.path.includes("defaultLuckyUrl"))).toHaveLength(1);
   });
 
-  it("ignores commands without a luckyUrl", () => {
+  it("ignores an absent defaultLuckyUrl", () => {
     const errors = lintConfig(makeConfig());
-    expect(errors.filter((e) => e.path.includes("luckyUrl"))).toHaveLength(0);
+    expect(errors.filter((e) => e.path.includes("defaultLuckyUrl"))).toHaveLength(0);
   });
 });

--- a/extension/tests/unit/config.test.ts
+++ b/extension/tests/unit/config.test.ts
@@ -174,13 +174,13 @@ describe("config schema validation", () => {
   });
 });
 
-describe("mergeConfig - luckyUrl preservation", () => {
-  it("keeps the default command's luckyUrl through an unrelated override", () => {
+describe("mergeConfig - defaultLuckyUrl preservation", () => {
+  it("keeps the top-level defaultLuckyUrl through an unrelated override", () => {
     const merged = mergeConfig(config, {
       overrideCommands: [{ id: "google", name: "Google Renamed" }],
     });
     const google = flattenCommands(merged).find((c) => c.id === "google");
     expect(google?.name).toBe("Google Renamed");
-    expect(google?.luckyUrl).toBe("https://www.google.com/search?q={query}&btnI");
+    expect(merged.defaultLuckyUrl).toBe("https://www.google.com/search?q={query}&btnI");
   });
 });

--- a/extension/tests/unit/configuration-screen-callbacks.test.ts
+++ b/extension/tests/unit/configuration-screen-callbacks.test.ts
@@ -61,7 +61,13 @@ function makeCallbacks(
     await setConfig({ ...current, defaultSuggestionsApi: url || undefined });
   }
 
-  return { onDefaultCommandChange, onDefaultSuggestionsApiChange };
+  async function onDefaultLuckyUrlChange(url: string): Promise<void> {
+    const current = await getConfig();
+    if (!current) return;
+    await setConfig({ ...current, defaultLuckyUrl: url || undefined });
+  }
+
+  return { onDefaultCommandChange, onDefaultSuggestionsApiChange, onDefaultLuckyUrlChange };
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +131,19 @@ describe("configuration screen callbacks — fixed (fetch-at-call-time)", () => 
 
     await callbacks.onDefaultSuggestionsApiChange("");
     expect(store.snapshot().defaultSuggestionsApi).toBeUndefined();
+  });
+
+  it("onDefaultLuckyUrlChange saves the new lucky URL", async () => {
+    await callbacks.onDefaultLuckyUrlChange("https://www.bing.com/search?q={query}&btnI");
+    expect(store.snapshot().defaultLuckyUrl).toBe("https://www.bing.com/search?q={query}&btnI");
+  });
+
+  it("onDefaultLuckyUrlChange with empty string clears the field (stores undefined)", async () => {
+    store = makeConfigStore({ ...baseConfig, defaultLuckyUrl: "https://old.example.com?q={query}" });
+    callbacks = makeCallbacks(store.getConfig, store.setConfig);
+
+    await callbacks.onDefaultLuckyUrlChange("");
+    expect(store.snapshot().defaultLuckyUrl).toBeUndefined();
   });
 
   it("sequential changes both persist — the core regression test", async () => {

--- a/extension/tests/unit/lucky.test.ts
+++ b/extension/tests/unit/lucky.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect } from "vitest";
 import { buildLuckyUrl } from "../../src/core/lucky.js";
 import type { FastTravelConfig } from "../../src/core/types.js";
 
-function makeConfig(luckyUrl?: string, defaultCommand = "g"): FastTravelConfig {
+function makeConfig(defaultLuckyUrl?: string, defaultCommand = "g"): FastTravelConfig {
   return {
     version: 2,
     defaultCommand,
+    ...(defaultLuckyUrl !== undefined ? { defaultLuckyUrl } : {}),
     groups: [
       {
         id: "grp",
@@ -16,7 +17,6 @@ function makeConfig(luckyUrl?: string, defaultCommand = "g"): FastTravelConfig {
             triggers: ["g"],
             name: "Google",
             type: "standard",
-            ...(luckyUrl !== undefined ? { luckyUrl } : {}),
             routes: [{ devices: "*", defaultUrl: "https://www.google.com" }],
           },
         ],
@@ -27,7 +27,7 @@ function makeConfig(luckyUrl?: string, defaultCommand = "g"): FastTravelConfig {
 }
 
 describe("buildLuckyUrl", () => {
-  it("substitutes the encoded query into the default command's luckyUrl", () => {
+  it("substitutes the encoded query into the top-level defaultLuckyUrl", () => {
     const cfg = makeConfig("https://www.google.com/search?q={query}&btnI");
     expect(buildLuckyUrl(cfg, "hello world")).toEqual({
       url: "https://www.google.com/search?q=hello%20world&btnI",
@@ -35,7 +35,7 @@ describe("buildLuckyUrl", () => {
     });
   });
 
-  it("returns null when the default command has no luckyUrl", () => {
+  it("returns null when the config has no defaultLuckyUrl", () => {
     expect(buildLuckyUrl(makeConfig(), "hello")).toBeNull();
   });
 

--- a/extension/tests/unit/lucky.test.ts
+++ b/extension/tests/unit/lucky.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import { buildLuckyUrl } from "../../src/core/lucky.js";
 import type { FastTravelConfig } from "../../src/core/types.js";
 
-function makeConfig(defaultLuckyUrl?: string, defaultCommand = "g"): FastTravelConfig {
+function makeConfig(defaultLuckyUrl?: string | null, defaultCommand = "g"): FastTravelConfig {
   return {
     version: 2,
     defaultCommand,
-    ...(defaultLuckyUrl !== undefined ? { defaultLuckyUrl } : {}),
+    ...(defaultLuckyUrl != null ? { defaultLuckyUrl } : {}),
     groups: [
       {
         id: "grp",
@@ -49,4 +51,27 @@ describe("buildLuckyUrl", () => {
     expect(buildLuckyUrl(cfg, "")).toBeNull();
     expect(buildLuckyUrl(cfg, "   ")).toBeNull();
   });
+});
+
+interface LuckyFixture {
+  description: string;
+  input: { defaultLuckyUrl: string | null; defaultCommand: string; query: string };
+  expected: { url: string; commandId: string } | null;
+}
+
+const luckyFixtures: LuckyFixture[] = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "../../../shared/test-fixtures/lucky.fixtures.json"),
+    "utf-8",
+  ),
+);
+
+describe("buildLuckyUrl — shared fixtures", () => {
+  for (const fixture of luckyFixtures) {
+    it(fixture.description, () => {
+      const cfg = makeConfig(fixture.input.defaultLuckyUrl, fixture.input.defaultCommand);
+      const result = buildLuckyUrl(cfg, fixture.input.query);
+      expect(result).toEqual(fixture.expected);
+    });
+  }
 });

--- a/shared/config/config.schema.json
+++ b/shared/config/config.schema.json
@@ -23,6 +23,11 @@
       "pattern": "^https?://.*\\{query\\}.*$",
       "description": "URL template for default autocomplete suggestions. Must be https? and contain {query}."
     },
+    "defaultLuckyUrl": {
+      "type": "string",
+      "pattern": "^https?://.*\\{query\\}.*$",
+      "description": "Ctrl+Enter 'I'm Feeling Lucky'-style URL template used by the default search (e.g. Google's &btnI). Must be https? and contain {query}."
+    },
     "groups": {
       "type": "array",
       "minItems": 1,
@@ -139,11 +144,6 @@
           "type": "string",
           "pattern": "^https?://.*\\{query\\}.*$",
           "description": "URL template for command-specific autocomplete. Must be https? and contain {query}."
-        },
-        "luckyUrl": {
-          "type": "string",
-          "pattern": "^https?://.*\\{query\\}.*$",
-          "description": "Optional 'I'm Feeling Lucky'-style URL template used by Ctrl+Enter on the default command (e.g. Google's &btnI). Must be https? and contain {query}."
         },
         "normalize": {
           "type": "array",

--- a/shared/config/default-config.json
+++ b/shared/config/default-config.json
@@ -3,6 +3,7 @@
   "version": 2,
   "defaultCommand": "g",
   "defaultSuggestionsApi": "https://suggestqueries.google.com/complete/search?client=firefox&q={query}",
+  "defaultLuckyUrl": "https://www.google.com/search?q={query}&btnI",
   "groups": [
     {
       "id": "search-engines",
@@ -18,7 +19,6 @@
           "type": "standard",
           "iconUrl": "https://www.google.com/s2/favicons?domain=google.com&sz=128",
           "suggestionsApi": "https://suggestqueries.google.com/complete/search?client=firefox&q={query}",
-          "luckyUrl": "https://www.google.com/search?q={query}&btnI",
           "routes": [
             {
               "devices": "*",

--- a/shared/test-fixtures/lucky.fixtures.json
+++ b/shared/test-fixtures/lucky.fixtures.json
@@ -1,0 +1,95 @@
+[
+  {
+    "description": "Basic substitution - encoded query dropped into the template",
+    "input": {
+      "defaultLuckyUrl": "https://www.google.com/search?q={query}&btnI",
+      "defaultCommand": "g",
+      "query": "hello world"
+    },
+    "expected": {
+      "url": "https://www.google.com/search?q=hello%20world&btnI",
+      "commandId": "google"
+    }
+  },
+  {
+    "description": "Every {query} occurrence in the template is replaced",
+    "input": {
+      "defaultLuckyUrl": "https://x.example/{query}?q={query}",
+      "defaultCommand": "g",
+      "query": "a"
+    },
+    "expected": {
+      "url": "https://x.example/a?q=a",
+      "commandId": "google"
+    }
+  },
+  {
+    "description": "Encoding parity - percent-encoding matches JS encodeURIComponent exactly",
+    "input": {
+      "defaultLuckyUrl": "https://example.com/?q={query}",
+      "defaultCommand": "g",
+      "query": "c++ & äöü (~'!)"
+    },
+    "expected": {
+      "url": "https://example.com/?q=c%2B%2B%20%26%20%C3%A4%C3%B6%C3%BC%20(~'!)",
+      "commandId": "google"
+    }
+  },
+  {
+    "description": "Null when defaultLuckyUrl is absent (null)",
+    "input": {
+      "defaultLuckyUrl": null,
+      "defaultCommand": "g",
+      "query": "hello"
+    },
+    "expected": null
+  },
+  {
+    "description": "Null when defaultLuckyUrl is blank/whitespace",
+    "input": {
+      "defaultLuckyUrl": "   ",
+      "defaultCommand": "g",
+      "query": "hello"
+    },
+    "expected": null
+  },
+  {
+    "description": "Null for an empty query",
+    "input": {
+      "defaultLuckyUrl": "https://example.com/?q={query}",
+      "defaultCommand": "g",
+      "query": ""
+    },
+    "expected": null
+  },
+  {
+    "description": "Null for a whitespace-only query",
+    "input": {
+      "defaultLuckyUrl": "https://example.com/?q={query}",
+      "defaultCommand": "g",
+      "query": "   "
+    },
+    "expected": null
+  },
+  {
+    "description": "Query is trimmed before substitution",
+    "input": {
+      "defaultLuckyUrl": "https://example.com/?q={query}",
+      "defaultCommand": "g",
+      "query": "  hi  "
+    },
+    "expected": {
+      "url": "https://example.com/?q=hi",
+      "commandId": "google"
+    }
+  },
+  {
+    "description": "Null when defaultCommand matches no trigger",
+    "input": {
+      "defaultLuckyUrl": "https://example.com/?q={query}",
+      "defaultCommand": "missing",
+      "query": "hello"
+    },
+    "expected": null
+  }
+]

--- a/tools/validate-config.mjs
+++ b/tools/validate-config.mjs
@@ -33,9 +33,9 @@ const PLACEHOLDER_RE = /\{(\w+)(?::\d+(?:-\d+)?)?\}/g;
 const URL_LENGTH_MODIFIER_RE = /\{\w+:\d+(?:-\d+)?\}/g;
 
 const ALLOWED_KEYS = {
-  root: new Set(["$schema", "version", "defaultCommand", "defaultSuggestionsApi", "groups", "ignoreList"]),
+  root: new Set(["$schema", "version", "defaultCommand", "defaultSuggestionsApi", "defaultLuckyUrl", "groups", "ignoreList"]),
   group: new Set(["id", "name", "color", "description", "commands", "groups"]),
-  command: new Set(["id", "triggers", "name", "type", "description", "color", "iconUrl", "iconOverrides", "suggestionsApi", "luckyUrl", "normalize", "routes"]),
+  command: new Set(["id", "triggers", "name", "type", "description", "color", "iconUrl", "iconOverrides", "suggestionsApi", "normalize", "routes"]),
   iconOverride: new Set(["devices", "iconUrl"]),
   route: new Set(["devices", "browsers", "defaultUrl", "searchUrl", "patterns"]),
   pattern: new Set(["match", "url"]),
@@ -225,9 +225,6 @@ function validateCommand(c, path, errors, seenIds, seenTriggers) {
   if (c.suggestionsApi !== undefined && (!isPlainString(c.suggestionsApi) || !HTTPS_QUERY_RE.test(c.suggestionsApi))) {
     errors.push(`${path}.suggestionsApi: must be http(s) URL containing {query} — got "${c.suggestionsApi}"`);
   }
-  if (c.luckyUrl !== undefined && (!isPlainString(c.luckyUrl) || !HTTPS_QUERY_RE.test(c.luckyUrl))) {
-    errors.push(`${path}.luckyUrl: must be http(s) URL containing {query} — got "${c.luckyUrl}"`);
-  }
 
   if (c.normalize !== undefined) {
     if (!Array.isArray(c.normalize) || c.normalize.length === 0) {
@@ -295,6 +292,10 @@ export function validateConfig(cfg) {
   if (cfg.defaultSuggestionsApi !== undefined &&
       (!isPlainString(cfg.defaultSuggestionsApi) || !HTTPS_QUERY_RE.test(cfg.defaultSuggestionsApi))) {
     errors.push(`config.defaultSuggestionsApi: must be http(s) URL containing {query}`);
+  }
+  if (cfg.defaultLuckyUrl !== undefined &&
+      (!isPlainString(cfg.defaultLuckyUrl) || !HTTPS_QUERY_RE.test(cfg.defaultLuckyUrl))) {
+    errors.push(`config.defaultLuckyUrl: must be http(s) URL containing {query}`);
   }
   if (cfg.ignoreList !== undefined) {
     if (!Array.isArray(cfg.ignoreList)) {


### PR DESCRIPTION
## Summary

Follow-up to #78: restructures the Ctrl+Enter "I'm feeling lucky" config and closes its platform gaps.

- **Config**: per-command `luckyUrl` → single top-level `defaultLuckyUrl`, stored exactly like `defaultSuggestionsApi` (schema, default configs, CI validator, extension, Android — all layers; shared and Android-asset configs byte-identical). No schema version bump: additive and gracefully degrading in both directions.
- **Editable in the UI**: new "Default lucky URL (optional)" field in Settings → Configuration on the extension and Android, mirroring the suggestions-API field, with e2e coverage (invalid values are rejected on both platforms — Android now pre-validates before `saveLocalConfig`, fixing a path where an invalid save caused the entire local config to be silently discarded on next load).
- **Android Ctrl+Enter**: hardware-keyboard lucky action (`core/Lucky.kt` port of `lucky.ts`, `SearchViewModel.onLuckySearch`, key handling in `SearchActivity`), falling back to a normal search when the field is absent/invalid.
- **🌐 suggestion icons**: URL-shaped rows (browser-history rows and URL-typed history entries) show a globe instead of a first-letter monogram, on both platforms. Android intentionally extends this to URL-shaped API suggestions (documented divergence).
- **Parity pinned**: new `shared/test-fixtures/lucky.fixtures.json` consumed by both Vitest and JUnit, including an `encodeURIComponent`/`UrlEncoding.component` encoding-parity case.
- **Docs**: newtab hint (`Ctrl/Cmd+Enter lucky`) + README Features bullet.

Trade-off (deliberate): switching `defaultCommand` to another engine now requires updating `defaultLuckyUrl` too; a stale/absent value degrades to a normal search, never a broken keypress.

## Test plan

- [x] `node tools/validate-config.mjs` + `node tools/test-version-consistency.mjs`
- [x] `diff shared/config/default-config.json android/app/src/main/assets/default-config.json` — identical
- [x] Extension: 337/337 unit tests, build, e2e (config-editing, suggestions-blend, url-navigation)
- [x] Android: `./gradlew test` (incl. new LuckyTest fixture suite, SearchViewModelLuckyTest, ConfigValidatorTest) + `assembleDebug`
- [ ] Manual: 🌐 emoji rendering in the 24dp slot on a physical device (OEM emoji fonts vary) — before next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZB7JQoSbXsFfAs3GNPUs8